### PR TITLE
Fix build by updating the VS Code engine's version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "version": "0.10.0-beta",
     "publisher": "julialang",
     "engines": {
-        "vscode": "^1.17.2"
+        "vscode": "^1.20.0"
     },
     "license": "SEE LICENSE IN LICENSE",
     "bugs": {


### PR DESCRIPTION
VS Code's ColorProvider APIs are no longer in a "proposed" state so the `engine` in the `package.json` file needs to be updated. Otherwise, what the extension downloads won't match what the `vscode-languageclient` npm module is expecting.