### PR TITLE
upgrade to event-stream v4.0.1, fix missing flatmap-stream dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -438,22 +438,6 @@
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
             "dev": true
         },
-        "event-stream": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
-            "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
-            "dev": true,
-            "requires": {
-                "duplexer": "^0.1.1",
-                "flatmap-stream": "^0.1.0",
-                "from": "^0.1.7",
-                "map-stream": "0.0.7",
-                "pause-stream": "^0.0.11",
-                "split": "^1.0.1",
-                "stream-combiner": "^0.2.2",
-                "through": "^2.3.8"
-            }
-        },
         "expand-brackets": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
@@ -554,12 +538,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
             "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
-            "dev": true
-        },
-        "flatmap-stream": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.1.tgz",
-            "integrity": "sha512-lAq4tLbm3sidmdCN8G3ExaxH7cUCtP5mgDvrYowsx84dcYkJJ4I28N7gkxA6+YlSXzaGLJYIDEi9WGfXzMiXdw==",
             "dev": true
         },
         "for-in": {
@@ -866,6 +844,21 @@
                     "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
                     "dev": true
                 },
+                "event-stream": {
+                    "version": "3.3.5",
+                    "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.5.tgz",
+                    "integrity": "sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==",
+                    "dev": true,
+                    "requires": {
+                        "duplexer": "^0.1.1",
+                        "from": "^0.1.7",
+                        "map-stream": "0.0.7",
+                        "pause-stream": "^0.0.11",
+                        "split": "^1.0.1",
+                        "stream-combiner": "^0.2.2",
+                        "through": "^2.3.8"
+                    }
+                },
                 "vinyl": {
                     "version": "2.2.0",
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
@@ -930,6 +923,23 @@
                 "mkdirp": "^0.5.1",
                 "queue": "^3.1.0",
                 "vinyl-fs": "^2.4.3"
+            },
+            "dependencies": {
+                "event-stream": {
+                    "version": "3.3.5",
+                    "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.5.tgz",
+                    "integrity": "sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==",
+                    "dev": true,
+                    "requires": {
+                        "duplexer": "^0.1.1",
+                        "from": "^0.1.7",
+                        "map-stream": "0.0.7",
+                        "pause-stream": "^0.0.11",
+                        "split": "^1.0.1",
+                        "stream-combiner": "^0.2.2",
+                        "through": "^2.3.8"
+                    }
+                }
             }
         },
         "gulp-untar": {
@@ -950,6 +960,21 @@
                     "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
                     "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
                     "dev": true
+                },
+                "event-stream": {
+                    "version": "3.3.5",
+                    "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.5.tgz",
+                    "integrity": "sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==",
+                    "dev": true,
+                    "requires": {
+                        "duplexer": "^0.1.1",
+                        "from": "^0.1.7",
+                        "map-stream": "0.0.7",
+                        "pause-stream": "^0.0.11",
+                        "split": "^1.0.1",
+                        "stream-combiner": "^0.2.2",
+                        "through": "^2.3.8"
+                    }
                 },
                 "replace-ext": {
                     "version": "0.0.1",
@@ -996,6 +1021,21 @@
                     "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
                     "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
                     "dev": true
+                },
+                "event-stream": {
+                    "version": "3.3.5",
+                    "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.5.tgz",
+                    "integrity": "sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==",
+                    "dev": true,
+                    "requires": {
+                        "duplexer": "^0.1.1",
+                        "from": "^0.1.7",
+                        "map-stream": "0.0.7",
+                        "pause-stream": "^0.0.11",
+                        "split": "^1.0.1",
+                        "stream-combiner": "^0.2.2",
+                        "through": "^2.3.8"
+                    }
                 },
                 "queue": {
                     "version": "4.5.0",


### PR DESCRIPTION
Disclaimer: I know very little about NodeJS, and only did some light testing to check if eventstream v4.0.1 is compatible with this project. The maintainers should double check that this doesn't break anything.

One of the dependencies of this project, flatmap-stream v0.1.1, was recently compromised and removed from the NodeJS registry (https://blog.npmjs.org/post/180565383195/details-about-the-event-stream-incident). This results in a "flatmap-stream@0.1.1 cannot be found" error message upon running `npm run update2latest`.

The maintainers of event-stream (which I think is where the flatmap-stream dep came from) have switched to map-stream in v4.0.1. That version appears to work for compiling this project.

This PR updates package-lock.json to event-stream v4.0.1 and removes the flatmap-stream dependency. 

