### PR TITLE
Support for custom sysimg

### DIFF
--- a/package.json
+++ b/package.json
@@ -357,6 +357,12 @@
                     "default": null,
                     "description": "Path to a julia environment.",
                     "scope": "window"
+                },
+                "julia.useCustomSysimage": {
+                    "type": "boolean",
+                    "default": "false",
+                    "description": "Use an existing custom sysimage when starting the REPL",
+                    "scope": "application"
                 }
             }
         },

--- a/scripts/tasks/task_compileenv.jl
+++ b/scripts/tasks/task_compileenv.jl
@@ -1,0 +1,52 @@
+using Pkg, Libdl
+import PackageCompiler
+
+pkg_ctx = Pkg.Types.Context()
+
+mktempdir() do temp_dir
+    precompile_temp_file_name = joinpath(temp_dir, "temp_file_for_compile.jl")
+
+    used_packages = Set(keys(pkg_ctx.env.project.deps))
+
+    usings = """
+        using $(join(used_packages, ','))
+        for Mod in [$used_packages]
+            isdefined(Mod, :__init__) && Mod.__init__()
+        end
+        """
+
+    open(precompile_temp_file_name, "w") do out_file
+        println(out_file, """
+            # We need to use all used packages in the precompile file for maximum
+            # usage of the precompile statements.
+            # Since this can be any recursive dependency of the package we AOT compile,
+            # we decided to just use them without installing them. An added
+            # benefit is, that we can call __init__ this way more easily, since
+            # incremental sysimage compilation won't call __init__ on `using`
+            # https://github.com/JuliaLang/julia/issues/22910
+            $usings
+            # bring recursive dependencies of used packages and standard libraries into namespace
+            for Mod in Base.loaded_modules_array()
+                if !Core.isdefined(@__MODULE__, nameof(Mod))
+                    Core.eval(@__MODULE__, Expr(:const, Expr(:(=), nameof(Mod), Mod)))
+                end
+            end
+            """)
+    end
+
+    systemp = joinpath(temp_dir, "sys.a")
+
+    sysout = joinpath(dirname(pkg_ctx.env.project_file), "JuliaSysimage.$(Libdl.dlext)")
+    
+    code = PackageCompiler.PrecompileCommand(precompile_temp_file_name)
+
+    @info "Running Julia to create sysimage..."
+
+    PackageCompiler.run_julia(code, O = 3, output_o = systemp, g = 1,
+            track_allocation = "none", startup_file = "no", code_coverage = "none",
+            project = replace(dirname(pkg_ctx.env.project_file), '\\' => '/'))
+
+    @info "Building shared library..."
+
+    PackageCompiler.build_shared(sysout, systemp, false, PackageCompiler.sysimg_folder(), true, "3", false, PackageCompiler.system_compiler, nothing)
+end

--- a/src/jlpkgenv.ts
+++ b/src/jlpkgenv.ts
@@ -53,7 +53,8 @@ async function switchEnvToPath(envpath: string) {
 
     if (vscode.workspace.workspaceFolders!==undefined &&
         vscode.workspace.workspaceFolders.length==1 &&
-        vscode.workspace.workspaceFolders[0].uri.fsPath != g_path_of_current_environment) {
+        vscode.workspace.workspaceFolders[0].uri.fsPath != g_path_of_current_environment &&
+        (await fs.exists(path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, 'Project.toml')) || await fs.exists(path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, 'JuliaProject.toml')))) {
 
         let case_adjusted = process.platform == "win32" ?
             vscode.workspace.workspaceFolders[0].uri.fsPath.charAt(0).toUpperCase() + vscode.workspace.workspaceFolders[0].uri.fsPath.slice(1) :

--- a/src/jlpkgenv.ts
+++ b/src/jlpkgenv.ts
@@ -18,6 +18,19 @@ let g_current_environment: vscode.StatusBarItem = null;
 let g_path_of_current_environment: string = null;
 let g_path_of_default_environment: string = null;
 
+export async function getProjectFilePaths(envpath: string) {
+    let dlext = process.platform == 'darwin' ? 'dylib' : process.platform == 'win32' ? 'dll': 'so';
+    return {
+        project_toml_path: (await fs.exists(path.join(envpath, 'JuliaProject.toml'))) ?
+            path.join(envpath, 'JuliaProject.toml') :
+            (await fs.exists(path.join(envpath, 'Project.toml'))) ? path.join(envpath, 'Project.toml') : undefined,
+        manifest_toml_path: (await fs.exists(path.join(envpath, 'JuliaManifest.toml'))) ?
+            path.join(envpath, 'JuliaManifest.toml') :
+            (await fs.exists(path.join(envpath, 'Manifest.toml'))) ? path.join(envpath, 'Manifest.toml') : undefined,
+        sysimage_path: (await fs.exists(path.join(envpath, `JuliaSysimage.${dlext}`))) ? path.join(envpath, `JuliaSysimage.${dlext}`) : undefined
+    }
+}
+
 async function switchEnvToPath(envpath: string) {
     g_path_of_current_environment = envpath;
 

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -177,7 +177,7 @@ async function startREPL(preserveFocus: boolean) {
             let env_file_paths = await jlpkgenv.getProjectFilePaths(pkgenvpath);
 
             let sysImageArgs = [];
-            if (env_file_paths.sysimage_path && env_file_paths.project_toml_path && env_file_paths.manifest_toml_path) {
+            if (vscode.workspace.getConfiguration("julia").get("useCustomSysimage") && env_file_paths.sysimage_path && env_file_paths.project_toml_path && env_file_paths.manifest_toml_path) {
                 let date_sysimage = await fs.stat(env_file_paths.sysimage_path);
                 let date_manifest = await fs.stat(env_file_paths.manifest_toml_path);
 

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -59,6 +59,11 @@ async function provideJuliaTasksForFolder(folder: vscode.WorkspaceFolder): Promi
             result.push(testTaskWithCoverage);
         }
 
+        let buildJuliaSysimage = new vscode.Task({ type: 'julia', command: 'juliasysimagebuild' }, folder, `Build custom sysimage for current environment (experimental)`, 'julia', new vscode.ProcessExecution(jlexepath, ['--color=yes', `--project=${pkgenvpath}`, '--startup-file=no', '--history-file=no', path.join(g_context.extensionPath, 'scripts', 'tasks', 'task_compileenv.jl')]), "");
+        buildJuliaSysimage.group = vscode.TaskGroup.Build;
+        buildJuliaSysimage.presentationOptions = { echo: false, focus: false, panel: vscode.TaskPanelKind.Dedicated, clear: true };
+        result.push(buildJuliaSysimage);
+
         if (await fs.exists(path.join(rootPath, 'deps', 'build.jl'))) {
             let buildTask = new vscode.Task({ type: 'julia', command: 'build' }, folder, `Run build`, 'julia', new vscode.ProcessExecution(jlexepath, ['--color=yes', `--project=${pkgenvpath}`, '-e', `using Pkg; Pkg.build("${folder.name}")`]), "");
             buildTask.group = vscode.TaskGroup.Build;


### PR DESCRIPTION
This adds experimental support for custom sysimages. There are two parts to this:
- A task that builds a custom sysimage for the current environment and stores that as `JuliaSysimage.dll` alongside the `Project.toml`.
- A configuration setting (off by default) that enables a logic where we start new REPLs with a custom sysimage if there is a file `JuliaSysimage.dll` in the same folder as the `Project.toml`.

This all only works if PackageCompiler.jl is installed. I might look into ways to cut that dependency at some point in the future, but I think for now this is ok, given that all of this is labeled experimental.

@KristofferC if you have thoughts on this, I'd be really interested to hear them!