### PR TITLE
Adds automatic transformation of atom-language-julia grammar.

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,11 +70,11 @@
                 "scopeName": "source.julia",
                 "path": "./syntaxes/julia.json",
                 "embeddedLanguages": {
-                    "meta.embedded.block.cpp": "cpp",
-                    "meta.embedded.block.javascript": "javascript",
-                    "meta.embedded.block.markdown": "juliamarkdown",
-                    "meta.embedded.block.python": "python",
-                    "meta.embedded.block.r": "r"
+                    "meta.embedded.inline.cpp": "cpp",
+                    "meta.embedded.inline.javascript": "javascript",
+                    "meta.embedded.inline.markdown": "juliamarkdown",
+                    "meta.embedded.inline.python": "python",
+                    "meta.embedded.inline.r": "r"
                 }
             },
             {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
                 "path": "./syntaxes/julia.json",
                 "embeddedLanguages": {
                     "meta.embedded.block.cpp": "cpp",
-                    "meta.embedded.block.js": "javascript",
+                    "meta.embedded.block.javascript": "javascript",
                     "meta.embedded.block.markdown": "markdown",
                     "meta.embedded.block.python": "python",
                     "meta.embedded.block.r": "r"
@@ -81,6 +81,16 @@
                 "language": "juliamarkdown",
                 "scopeName": "source.juliamarkdown",
                 "path": "./syntaxes/juliamarkdown.json"
+            },
+            {
+                "scopeName": "markdown.julia.codeblock",
+                "path": "./syntaxes/juliacodeblock.json",
+                "injectTo": [
+                    "text.html.markdown"
+                ],
+                "embeddedLanguages": {
+                    "meta.embedded.block.julia": "julia"
+                }
             }
         ],
         "commands": [

--- a/package.json
+++ b/package.json
@@ -72,14 +72,14 @@
                 "embeddedLanguages": {
                     "meta.embedded.block.cpp": "cpp",
                     "meta.embedded.block.javascript": "javascript",
-                    "meta.embedded.block.markdown": "markdown",
+                    "meta.embedded.block.markdown": "juliamarkdown",
                     "meta.embedded.block.python": "python",
                     "meta.embedded.block.r": "r"
                 }
             },
             {
                 "language": "juliamarkdown",
-                "scopeName": "source.juliamarkdown",
+                "scopeName": "text.html.markdown.julia",
                 "path": "./syntaxes/juliamarkdown.json"
             },
             {

--- a/syntaxes/julia.json
+++ b/syntaxes/julia.json
@@ -516,7 +516,7 @@
             }
           },
           "name": "embed.js.julia",
-          "contentName": "meta.embedded.block.js",
+          "contentName": "meta.embedded.block.javascript",
           "patterns": [
             {
               "include": "source.js"
@@ -543,7 +543,7 @@
               "name": "punctuation.definition.string.end.julia"
             }
           },
-          "contentName": "meta.embedded.block.js",
+          "contentName": "meta.embedded.block.javascript",
           "patterns": [
             {
               "include": "source.js"
@@ -753,6 +753,30 @@
             },
             {
               "include": "#string_dollar_sign_interpolate"
+            }
+          ]
+        },
+        {
+          "begin": "r\"\"\"",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.regexp.begin.julia"
+            }
+          },
+          "end": "(\"\"\")([imsx]{0,4})?",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.regexp.end.julia"
+            },
+            "2": {
+              "comment": "I took this scope name from python regex grammar",
+              "name": "keyword.other.option-toggle.regexp.julia"
+            }
+          },
+          "name": "string.regexp.julia",
+          "patterns": [
+            {
+              "include": "#string_escaped_char"
             }
           ]
         },

--- a/syntaxes/julia.json
+++ b/syntaxes/julia.json
@@ -408,10 +408,10 @@
             }
           },
           "name": "embed.cxx.julia",
-          "contentName": "source.cpp",
+          "contentName": "meta.embedded.block.cpp",
           "patterns": [
             {
-              "include": "source.cpp"
+              "include": "source.cpp#root_context"
             },
             {
               "include": "#string_dollar_sign_interpolate"
@@ -435,10 +435,10 @@
               "name": "punctuation.definition.string.end.julia"
             }
           },
-          "contentName": "source.cpp",
+          "contentName": "meta.embedded.block.cpp",
           "patterns": [
             {
-              "include": "source.cpp"
+              "include": "source.cpp#root_context"
             },
             {
               "include": "#string_dollar_sign_interpolate"
@@ -462,7 +462,7 @@
             }
           },
           "name": "embed.python.julia",
-          "contentName": "source.python",
+          "contentName": "meta.embedded.block.python",
           "patterns": [
             {
               "include": "source.python"
@@ -489,7 +489,7 @@
               "name": "punctuation.definition.string.end.julia"
             }
           },
-          "contentName": "source.python",
+          "contentName": "meta.embedded.block.python",
           "patterns": [
             {
               "include": "source.python"
@@ -516,7 +516,7 @@
             }
           },
           "name": "embed.js.julia",
-          "contentName": "source.js",
+          "contentName": "meta.embedded.block.js",
           "patterns": [
             {
               "include": "source.js"
@@ -543,7 +543,7 @@
               "name": "punctuation.definition.string.end.julia"
             }
           },
-          "contentName": "source.js",
+          "contentName": "meta.embedded.block.js",
           "patterns": [
             {
               "include": "source.js"
@@ -570,7 +570,7 @@
             }
           },
           "name": "embed.R.julia",
-          "contentName": "source.r",
+          "contentName": "meta.embedded.block.r",
           "patterns": [
             {
               "include": "source.r"
@@ -597,7 +597,7 @@
               "name": "punctuation.definition.string.end.julia"
             }
           },
-          "contentName": "source.r",
+          "contentName": "meta.embedded.block.r",
           "patterns": [
             {
               "include": "source.r"
@@ -624,10 +624,10 @@
             }
           },
           "name": "embed.markdown.julia",
-          "contentName": "source.gfm",
+          "contentName": "meta.embedded.block.markdown",
           "patterns": [
             {
-              "include": "source.gfm"
+              "include": "text.html.markdown"
             },
             {
               "include": "#string_dollar_sign_interpolate"
@@ -651,10 +651,10 @@
               "name": "punctuation.definition.string.end.julia"
             }
           },
-          "contentName": "source.gfm",
+          "contentName": "meta.embedded.block.markdown",
           "patterns": [
             {
-              "include": "source.gfm"
+              "include": "text.html.markdown"
             },
             {
               "include": "#string_dollar_sign_interpolate"

--- a/syntaxes/julia.json
+++ b/syntaxes/julia.json
@@ -408,7 +408,7 @@
             }
           },
           "name": "embed.cxx.julia",
-          "contentName": "meta.embedded.block.cpp",
+          "contentName": "meta.embedded.inline.cpp",
           "patterns": [
             {
               "include": "source.cpp#root_context"
@@ -435,7 +435,7 @@
               "name": "punctuation.definition.string.end.julia"
             }
           },
-          "contentName": "meta.embedded.block.cpp",
+          "contentName": "meta.embedded.inline.cpp",
           "patterns": [
             {
               "include": "source.cpp#root_context"
@@ -462,7 +462,7 @@
             }
           },
           "name": "embed.python.julia",
-          "contentName": "meta.embedded.block.python",
+          "contentName": "meta.embedded.inline.python",
           "patterns": [
             {
               "include": "source.python"
@@ -489,7 +489,7 @@
               "name": "punctuation.definition.string.end.julia"
             }
           },
-          "contentName": "meta.embedded.block.python",
+          "contentName": "meta.embedded.inline.python",
           "patterns": [
             {
               "include": "source.python"
@@ -516,7 +516,7 @@
             }
           },
           "name": "embed.js.julia",
-          "contentName": "meta.embedded.block.javascript",
+          "contentName": "meta.embedded.inline.javascript",
           "patterns": [
             {
               "include": "source.js"
@@ -543,7 +543,7 @@
               "name": "punctuation.definition.string.end.julia"
             }
           },
-          "contentName": "meta.embedded.block.javascript",
+          "contentName": "meta.embedded.inline.javascript",
           "patterns": [
             {
               "include": "source.js"
@@ -570,7 +570,7 @@
             }
           },
           "name": "embed.R.julia",
-          "contentName": "meta.embedded.block.r",
+          "contentName": "meta.embedded.inline.r",
           "patterns": [
             {
               "include": "source.r"
@@ -597,7 +597,7 @@
               "name": "punctuation.definition.string.end.julia"
             }
           },
-          "contentName": "meta.embedded.block.r",
+          "contentName": "meta.embedded.inline.r",
           "patterns": [
             {
               "include": "source.r"
@@ -624,7 +624,7 @@
             }
           },
           "name": "embed.markdown.julia",
-          "contentName": "meta.embedded.block.markdown",
+          "contentName": "meta.embedded.inline.markdown",
           "patterns": [
             {
               "include": "text.html.markdown.julia"
@@ -651,7 +651,7 @@
               "name": "punctuation.definition.string.end.julia"
             }
           },
-          "contentName": "meta.embedded.block.markdown",
+          "contentName": "meta.embedded.inline.markdown",
           "patterns": [
             {
               "include": "text.html.markdown.julia"

--- a/syntaxes/julia.json
+++ b/syntaxes/julia.json
@@ -627,7 +627,7 @@
           "contentName": "meta.embedded.block.markdown",
           "patterns": [
             {
-              "include": "text.html.markdown"
+              "include": "text.html.markdown.julia"
             },
             {
               "include": "#string_dollar_sign_interpolate"
@@ -654,7 +654,7 @@
           "contentName": "meta.embedded.block.markdown",
           "patterns": [
             {
-              "include": "text.html.markdown"
+              "include": "text.html.markdown.julia"
             },
             {
               "include": "#string_dollar_sign_interpolate"

--- a/syntaxes/juliacodeblock.json
+++ b/syntaxes/juliacodeblock.json
@@ -8,17 +8,20 @@
 	],
 	"repository": {
 		"julia-code-block": {
-			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(julia|jl(?:doctest)?)(\\s+[^`~]*)?$)",
+			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(julia|jl(doctest)?))((;|\\s)([^`~]*))?$",
 			"name": "markup.fenced_code.block.markdown",
 			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
 			"beginCaptures": {
 				"3": {
 					"name": "punctuation.definition.markdown"
 				},
-				"5": {
+				"4": {
 					"name": "fenced_code.block.language"
 				},
-				"6": {
+				"7": {
+					"name": "punctuation.definition.markdown"
+				},
+				"8": {
 					"name": "fenced_code.block.language.attributes"
 				}
 			},

--- a/syntaxes/juliacodeblock.json
+++ b/syntaxes/juliacodeblock.json
@@ -1,0 +1,45 @@
+{
+	"fileTypes": [],
+	"injectionSelector": "L:text.html.markdown",
+	"patterns": [
+		{
+			"include": "#julia-code-block"
+		}
+	],
+	"repository": {
+		"julia-code-block": {
+			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(julia|jl(?:doctest)?)(\\s+[^`~]*)?$)",
+			"name": "markup.fenced_code.block.markdown",
+			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+			"beginCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				},
+				"5": {
+					"name": "fenced_code.block.language"
+				},
+				"6": {
+					"name": "fenced_code.block.language.attributes"
+				}
+			},
+			"endCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.julia",
+					"patterns": [
+						{
+							"include": "source.julia"
+						}
+					]
+				}
+			]
+		}
+	},
+	"scopeName": "markdown.julia.codeblock"
+}

--- a/syntaxes/juliamarkdown.json
+++ b/syntaxes/juliamarkdown.json
@@ -1,40 +1,12 @@
 {
     "name": "julia Markdown",
-    "scopeName": "source.juliamarkdown",
+    "scopeName": "text.html.markdown.julia",
     "fileTypes": [
         "jmd"
     ],
     "patterns": [
         {
-            "begin": "^(```)(\\{|\\{\\.|)(julia|jldoctest)(;|)\\s*(.*?)(\\}|)\\s*$",
-            "beginCaptures": {
-                "1": {
-                    "name": "markup.heading.juliamarkdown"
-                },
-                "3": {
-                    "name": "markup.bold.juliamarkdown"
-                },
-                "5": {
-                    "contentName": "source.julia",
-                    "patterns": [
-                        {
-                            "include": "source.julia"
-                        }
-                    ]
-                }
-            },
-            "end": "^```\\s*$",
-            "endCaptures": {
-                "0": {
-                    "name": "markup.heading.juliamarkdown"
-                }
-            },
-            "contentName": "source.julia",
-            "patterns": [
-                {
-                    "include": "source.julia"
-                }
-            ]
+            "include": "markdown.julia.codeblock"
         },
         {
             "include": "text.html.markdown"

--- a/syntaxes/update_syntax.jl
+++ b/syntaxes/update_syntax.jl
@@ -1,0 +1,32 @@
+# Converts the latest grammar from atom-language-julia to one compatible with vscode
+# Requires:
+#  - HTTP.jl to be installed;
+#  - `cson2json` to be on your path. (Install via npm.)
+
+import HTTP
+
+const url = "https://raw.githubusercontent.com/JuliaEditorSupport/atom-language-julia/master/grammars/julia.cson"
+
+HTTP.open("GET", url) do cson
+  open(pipeline(`cson2json`, stdin=IOBuffer(read(cson))), "r") do c2j
+    # get the raw json
+    json = read(c2j, String)
+
+    # apply substitutions
+    sub!(pr) = json = replace(json, pr; count=typemax(Int))
+
+    # when the juliamarkdown grammar is converted into an injection, this will also highlight embedded julia
+    sub!(r"(\"include\"\s*:\s*\")source\.gfm(\")" => s"\1text.html.markdown\2")
+    sub!(r"(\"include\"\s*:\s*\"source\.cpp)(\")" => s"\1#root_context\2")
+    sub!(r"(\"contentName\"\s*:\s*\")source\.cpp(\")" => s"\1meta.embedded.block.cpp\2")
+    sub!(r"(\"contentName\"\s*:\s*\")source\.gfm(\")" => s"\1meta.embedded.block.markdown\2")
+    sub!(r"(\"contentName\"\s*:\s*\")source\.js(\")" => s"\1meta.embedded.block.js\2")
+    sub!(r"(\"contentName\"\s*:\s*\")source\.r(\")" => s"\1meta.embedded.block.r\2")
+    sub!(r"(\"contentName\"\s*:\s*\")source\.python(\")" => s"\1meta.embedded.block.python\2")
+
+    # print out the transformed syntax
+    println(json)
+  end
+end
+
+##

--- a/syntaxes/update_syntax.jl
+++ b/syntaxes/update_syntax.jl
@@ -16,7 +16,7 @@ json = Ref(read(open(pipeline(`cson2json`, stdin=IOBuffer(cson))), String))
 # apply substitutions
 sub!(pr) = json.x = replace(json.x, pr; count=typemax(Int))
 
-sub!(r"(\"include\"\s*:\s*\")source\.gfm(\")" => s"\1text.html.markdown\2")
+sub!(r"(\"include\"\s*:\s*\")source\.gfm(\")" => s"\1text.html.markdown.julia\2")
 
 # Skip over-zealous top-level production in `source.cpp`. See offending pattern here:
 # https://github.com/microsoft/vscode/blob/c3fe2d8acde04e579880413ae4622a1f551efdcc/extensions/cpp/syntaxes/cpp.tmLanguage.json#L745

--- a/syntaxes/update_syntax.jl
+++ b/syntaxes/update_syntax.jl
@@ -1,32 +1,34 @@
-# Converts the latest grammar from atom-language-julia to one compatible with vscode
+#! julia
+# Converts an atom-language-julia grammar into one compatible with vscode
 # Requires:
 #  - HTTP.jl to be installed;
 #  - `cson2json` to be on your path. (Install via npm.)
-
 import HTTP
 
-const url = "https://raw.githubusercontent.com/JuliaEditorSupport/atom-language-julia/master/grammars/julia.cson"
+url = "https://raw.githubusercontent.com/JuliaEditorSupport/atom-language-julia/master/grammars/julia.cson"
 
-HTTP.open("GET", url) do cson
-  open(pipeline(`cson2json`, stdin=IOBuffer(read(cson))), "r") do c2j
-    # get the raw json
-    json = read(c2j, String)
+# get cson - download if filename not given
+cson = isempty(ARGS) ? String(HTTP.get(url).body) : read(ARGS[1], String)
 
-    # apply substitutions
-    sub!(pr) = json = replace(json, pr; count=typemax(Int))
+# convert cson to json
+json = Ref(read(open(pipeline(`cson2json`, stdin=IOBuffer(cson))), String))
 
-    # when the juliamarkdown grammar is converted into an injection, this will also highlight embedded julia
-    sub!(r"(\"include\"\s*:\s*\")source\.gfm(\")" => s"\1text.html.markdown\2")
-    sub!(r"(\"include\"\s*:\s*\"source\.cpp)(\")" => s"\1#root_context\2")
-    sub!(r"(\"contentName\"\s*:\s*\")source\.cpp(\")" => s"\1meta.embedded.block.cpp\2")
-    sub!(r"(\"contentName\"\s*:\s*\")source\.gfm(\")" => s"\1meta.embedded.block.markdown\2")
-    sub!(r"(\"contentName\"\s*:\s*\")source\.js(\")" => s"\1meta.embedded.block.js\2")
-    sub!(r"(\"contentName\"\s*:\s*\")source\.r(\")" => s"\1meta.embedded.block.r\2")
-    sub!(r"(\"contentName\"\s*:\s*\")source\.python(\")" => s"\1meta.embedded.block.python\2")
+# apply substitutions
+sub!(pr) = json.x = replace(json.x, pr; count=typemax(Int))
 
-    # print out the transformed syntax
-    println(json)
-  end
-end
+sub!(r"(\"include\"\s*:\s*\")source\.gfm(\")" => s"\1text.html.markdown\2")
 
-##
+# Skip over-zealous top-level production in `source.cpp`. See offending pattern here:
+# https://github.com/microsoft/vscode/blob/c3fe2d8acde04e579880413ae4622a1f551efdcc/extensions/cpp/syntaxes/cpp.tmLanguage.json#L745
+sub!(r"(\"include\"\s*:\s*\"source\.cpp)(\")" => s"\1#root_context\2")
+
+# Choose content names consistent with the vscode conventions for embedded code. Cf.:
+# https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide#embedded-languages
+sub!(r"(\"contentName\"\s*:\s*\")source\.cpp(\")" => s"\1meta.embedded.block.cpp\2")
+sub!(r"(\"contentName\"\s*:\s*\")source\.gfm(\")" => s"\1meta.embedded.block.markdown\2")
+sub!(r"(\"contentName\"\s*:\s*\")source\.js(\")" => s"\1meta.embedded.block.javascript\2")
+sub!(r"(\"contentName\"\s*:\s*\")source\.r(\")" => s"\1meta.embedded.block.r\2")
+sub!(r"(\"contentName\"\s*:\s*\")source\.python(\")" => s"\1meta.embedded.block.python\2")
+
+# print out the transformed syntax
+println(json.x)

--- a/syntaxes/update_syntax.jl
+++ b/syntaxes/update_syntax.jl
@@ -24,11 +24,11 @@ sub!(r"(\"include\"\s*:\s*\"source\.cpp)(\")" => s"\1#root_context\2")
 
 # Choose content names consistent with the vscode conventions for embedded code. Cf.:
 # https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide#embedded-languages
-sub!(r"(\"contentName\"\s*:\s*\")source\.cpp(\")" => s"\1meta.embedded.block.cpp\2")
-sub!(r"(\"contentName\"\s*:\s*\")source\.gfm(\")" => s"\1meta.embedded.block.markdown\2")
-sub!(r"(\"contentName\"\s*:\s*\")source\.js(\")" => s"\1meta.embedded.block.javascript\2")
-sub!(r"(\"contentName\"\s*:\s*\")source\.r(\")" => s"\1meta.embedded.block.r\2")
-sub!(r"(\"contentName\"\s*:\s*\")source\.python(\")" => s"\1meta.embedded.block.python\2")
+sub!(r"(\"contentName\"\s*:\s*\")source\.cpp(\")" => s"\1meta.embedded.inline.cpp\2")
+sub!(r"(\"contentName\"\s*:\s*\")source\.gfm(\")" => s"\1meta.embedded.inline.markdown\2")
+sub!(r"(\"contentName\"\s*:\s*\")source\.js(\")" => s"\1meta.embedded.inline.javascript\2")
+sub!(r"(\"contentName\"\s*:\s*\")source\.r(\")" => s"\1meta.embedded.inline.r\2")
+sub!(r"(\"contentName\"\s*:\s*\")source\.python(\")" => s"\1meta.embedded.inline.python\2")
 
 # print out the transformed syntax
 println(json.x)


### PR DESCRIPTION
 - Updates the syntax using the new script.
 - Fixes #765.
 - Fixes #770.
 - Adds an injection grammar for highlighting julia code blocks in markdown.