### PR TITLE
Fix error reporting for multi line error messages

### DIFF
--- a/scripts/languageserver/main.jl
+++ b/scripts/languageserver/main.jl
@@ -31,9 +31,13 @@ catch e
         # Send error type as one line
         println(pipe_to_vscode, typeof(e))
 
-        # Send error message as one line
-        showerror(pipe_to_vscode, e)        
-        println(pipe_to_vscode)
+        # Send error message
+        temp_io = IOBuffer()
+        showerror(temp_io, e)
+        error_message_str = chomp(String(take!(temp_io)))
+        n = count(i->i=='\n', error_message_str) + 1
+        println(pipe_to_vscode, n)
+        println(pipe_to_vscode, error_message_str)
 
         # Send stack trace, one frame per line
         # Note that stack frames need to be formatted in Node.js style

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -100,11 +100,12 @@ export function startLsCrashServer() {
         });
 
         connection.on('close', async function (had_err) {
-            let bufferResult = accumulatingBuffer.toString()
             let replResponse = accumulatingBuffer.toString().split("\n")
-            let stacktrace = replResponse.slice(2,replResponse.length-1).join('\n');
+            let errorMessageLines = parseInt(replResponse[1])
+            let errorMessage = replResponse.slice(2, 2 + errorMessageLines).join('\n');
+            let stacktrace = replResponse.slice(2 + errorMessageLines,replResponse.length-1).join('\n');
 
-            crashReporterQueue.push({exception: {name: replResponse[0], message: replResponse[1], stack: stacktrace}});
+            crashReporterQueue.push({exception: {name: replResponse[0], message: errorMessage, stack: stacktrace}});
 
             traceEvent('lserror');
 


### PR DESCRIPTION
We have a couple of error messages that are not comprehensible right now, and I think this should help.