### PR TITLE
Enable bracket paste on Windows

### DIFF
--- a/src/repl.ts
+++ b/src/repl.ts
@@ -539,7 +539,7 @@ async function executeCode(text, individualLine) {
     var lines = text.split(/\r?\n/);
     lines = lines.filter(line => line != '');
     text = lines.join('\n');
-    if (individualLine || process.platform == "win32") {
+    if (individualLine) {
         g_terminal.sendText(text + '\n', false);
     }
     else {


### PR DESCRIPTION
I now believe that I removed this on Windows for the wrong reason, and that a different fix that I added later fixes the problem that originally triggered me reverting things on Windows.

Fixes https://github.com/julia-vscode/julia-vscode/issues/826.

CC @KristofferC 