### PR TITLE
Change code execution keybindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -258,6 +258,11 @@
                 "when": "editorTextFocus && editorLangId == julia"
             },
             {
+                "command": "language-julia.executeJuliaCodeInREPL",
+                "key": "alt+Enter",
+                "when": "editorTextFocus && editorLangId == julia"
+            },
+            {
                 "command": "language-julia.executeJuliaCellInREPL",
                 "key": "shift+Enter",
                 "when": "editorTextFocus && editorLangId == julia"


### PR DESCRIPTION
When a range of text is selected Alt-Enter now executes that selection.