### PR TITLE
Support Alt+enter with selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
             {
                 "command": "language-julia.executeJuliaBlockInREPL",
                 "key": "alt+Enter",
-                "when": "editorTextFocus && editorLangId == julia && !editorHasSelection"
+                "when": "editorTextFocus && editorLangId == julia"
             },
             {
                 "command": "language-julia.executeJuliaCodeInREPL",

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -648,8 +648,20 @@ async function executeJuliaCellInRepl() {
 async function executeJuliaBlockInRepl() {
     telemetry.traceEvent('command-executejuliablockinrepl');
 
-    if (g_languageClient == null) {
+    var editor = vscode.window.activeTextEditor;
+    if (!editor) {
+        return;
+    }
+
+    var selection = editor.selection;
+
+    if (selection.isEmpty && g_languageClient == null) {
         vscode.window.showErrorMessage('Error: Language server is not running.');
+    }
+    else if (!selection.isEmpty) {
+        let code_to_run = editor.document.getText(selection);
+
+        executeInRepl(code_to_run, editor.document.fileName, selection.start);
     }
     else {
         var editor = vscode.window.activeTextEditor;


### PR DESCRIPTION
Fixes #837. Replaces #841.

@ZacLN I think this is a cleaner approach. This way Alt+Enter never sends text to the terminal, but instead uses the (more robust) code execution story we have now, where things like `@__DIR__` etc should in theory work.