### PR TITLE
Support shebang

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
                 "extensions": [
                     ".jl"
                 ],
+                "firstLine": "^#!\\s*/.*\\bjulia[0-9.-]*\\b",
                 "configuration": "./julia.configuration.json"
             },
             {


### PR DESCRIPTION
Copied a line from python extension https://github.com/Microsoft/vscode/blob/master/extensions/python/package.json#L17 so that we recognize [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) executable files without `.jl` extension.

Note: edited from github, didn't test it locally.