### PR TITLE
Adding NUM_THREADS to test environment

### DIFF
--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -53,13 +53,13 @@ async function provideJuliaTasksForFolder(folder: vscode.WorkspaceFolder): Promi
             testTask.presentationOptions = { echo: false, focus: false, panel: vscode.TaskPanelKind.Dedicated, clear: true };
             result.push(testTask);
 
-            let testTaskWithCoverage = new vscode.Task({ type: 'julia', command: 'testcoverage' }, folder, `Run tests with coverage`, 'julia', new vscode.ProcessExecution(jlexepath, ['--color=yes', `--project=${pkgenvpath}`, path.join(g_context.extensionPath, 'scripts', 'tasks', 'task_test.jl'), folder.name]), "");
+            let testTaskWithCoverage = new vscode.Task({ type: 'julia', command: 'testcoverage' }, folder, `Run tests with coverage`, 'julia', new vscode.ProcessExecution(jlexepath, ['--color=yes', `--project=${pkgenvpath}`, path.join(g_context.extensionPath, 'scripts', 'tasks', 'task_test.jl'), folder.name], { env: { JULIA_NUM_THREADS: vscode.workspace.getConfiguration("julia").get("NumThreads").toString()}}), "");
             testTaskWithCoverage.group = vscode.TaskGroup.Test;
             testTaskWithCoverage.presentationOptions = { echo: false, focus: false, panel: vscode.TaskPanelKind.Dedicated, clear: true };
             result.push(testTaskWithCoverage);
         }
 
-        let buildJuliaSysimage = new vscode.Task({ type: 'julia', command: 'juliasysimagebuild' }, folder, `Build custom sysimage for current environment (experimental)`, 'julia', new vscode.ProcessExecution(jlexepath, ['--color=yes', `--project=${pkgenvpath}`, '--startup-file=no', '--history-file=no', path.join(g_context.extensionPath, 'scripts', 'tasks', 'task_compileenv.jl')]), "");
+        let buildJuliaSysimage = new vscode.Task({ type: 'julia', command: 'juliasysimagebuild' }, folder, `Build custom sysimage for current environment (experimental)`, 'julia', new vscode.ProcessExecution(jlexepath, ['--color=yes', `--project=${pkgenvpath}`, '--startup-file=no', '--history-file=no', path.join(g_context.extensionPath, 'scripts', 'tasks', 'task_compileenv.jl')], { env: { JULIA_NUM_THREADS: vscode.workspace.getConfiguration("julia").get("NumThreads").toString()}}), "");
         buildJuliaSysimage.group = vscode.TaskGroup.Build;
         buildJuliaSysimage.presentationOptions = { echo: false, focus: false, panel: vscode.TaskPanelKind.Dedicated, clear: true };
         result.push(buildJuliaSysimage);


### PR DESCRIPTION
I am unable to run the test suite in my environment, so I may have a TS syntax error here.  (I'll see if I can figure out how to fire it up.)  But the concept of adding the `env` option works - I tested by hacking my local js files in the extension.

Let me know if you'd rather have this packaged in an alternate branch, or what other contribution guidlines you'd like me to follow.