### PR TITLE
Switch to PackageCompilerX for sysimage

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "scripts/languageserver/packages/FilePathsBase"]
 	path = scripts/languageserver/packages/FilePathsBase
 	url = https://github.com/rofinn/FilePathsBase.jl.git
+[submodule "scripts/tasks/sysimageenv/PackageCompilerX"]
+	path = scripts/tasks/sysimageenv/PackageCompilerX
+	url = https://github.com/KristofferC/PackageCompilerX.jl.git

--- a/scripts/tasks/sysimageenv/Manifest.toml
+++ b/scripts/tasks/sysimageenv/Manifest.toml
@@ -1,0 +1,71 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[PackageCompilerX]]
+deps = ["Libdl", "Pkg", "UUIDs"]
+path = "PackageCompilerX"
+uuid = "dffaa6cc-da53-48e5-b007-4292dfcc27f1"
+version = "0.1.0"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Test", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/scripts/tasks/sysimageenv/Project.toml
+++ b/scripts/tasks/sysimageenv/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+PackageCompilerX = "dffaa6cc-da53-48e5-b007-4292dfcc27f1"

--- a/scripts/tasks/task_compileenv.jl
+++ b/scripts/tasks/task_compileenv.jl
@@ -1,52 +1,15 @@
-using Pkg, Libdl
-import PackageCompiler
+import Pkg, Libdl, PackageCompilerX
 
-pkg_ctx = Pkg.Types.Context()
+env_to_precompile = ARGS[1]
 
-mktempdir() do temp_dir
-    precompile_temp_file_name = joinpath(temp_dir, "temp_file_for_compile.jl")
+sysimage_path = joinpath(env_to_precompile, "JuliaSysimage.$(Libdl.dlext)")
 
-    used_packages = Set(keys(pkg_ctx.env.project.deps))
+project_filename = isfile(joinpath(env_to_precompile, "JuliaProject.toml")) ? joinpath(env_to_precompile, "JuliaProject.toml") : joinpath(env_to_precompile, "Project.toml")
 
-    usings = """
-        using $(join(used_packages, ','))
-        for Mod in [$used_packages]
-            isdefined(Mod, :__init__) && Mod.__init__()
-        end
-        """
+project = Pkg.API.read_project(project_filename)
 
-    open(precompile_temp_file_name, "w") do out_file
-        println(out_file, """
-            # We need to use all used packages in the precompile file for maximum
-            # usage of the precompile statements.
-            # Since this can be any recursive dependency of the package we AOT compile,
-            # we decided to just use them without installing them. An added
-            # benefit is, that we can call __init__ this way more easily, since
-            # incremental sysimage compilation won't call __init__ on `using`
-            # https://github.com/JuliaLang/julia/issues/22910
-            $usings
-            # bring recursive dependencies of used packages and standard libraries into namespace
-            for Mod in Base.loaded_modules_array()
-                if !Core.isdefined(@__MODULE__, nameof(Mod))
-                    Core.eval(@__MODULE__, Expr(:const, Expr(:(=), nameof(Mod), Mod)))
-                end
-            end
-            """)
-    end
+used_packages = Symbol.(collect(keys(project.deps)))
 
-    systemp = joinpath(temp_dir, "sys.a")
+@info "Now building a custom sysimage for the environment '$env_to_precompile'."
 
-    sysout = joinpath(dirname(pkg_ctx.env.project_file), "JuliaSysimage.$(Libdl.dlext)")
-    
-    code = PackageCompiler.PrecompileCommand(precompile_temp_file_name)
-
-    @info "Running Julia to create sysimage..."
-
-    PackageCompiler.run_julia(code, O = 3, output_o = systemp, g = 1,
-            track_allocation = "none", startup_file = "no", code_coverage = "none",
-            project = replace(dirname(pkg_ctx.env.project_file), '\\' => '/'))
-
-    @info "Building shared library..."
-
-    PackageCompiler.build_shared(sysout, systemp, false, PackageCompiler.sysimg_folder(), true, "3", false, PackageCompiler.system_compiler, nothing)
-end
+PackageCompilerX.create_sysimage(used_packages, sysimage_path=sysimage_path, project=env_to_precompile)

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -59,7 +59,7 @@ async function provideJuliaTasksForFolder(folder: vscode.WorkspaceFolder): Promi
             result.push(testTaskWithCoverage);
         }
 
-        let buildJuliaSysimage = new vscode.Task({ type: 'julia', command: 'juliasysimagebuild' }, folder, `Build custom sysimage for current environment (experimental)`, 'julia', new vscode.ProcessExecution(jlexepath, ['--color=yes', `--project=${pkgenvpath}`, '--startup-file=no', '--history-file=no', path.join(g_context.extensionPath, 'scripts', 'tasks', 'task_compileenv.jl')]), "");
+        let buildJuliaSysimage = new vscode.Task({ type: 'julia', command: 'juliasysimagebuild' }, folder, `Build custom sysimage for current environment (experimental)`, 'julia', new vscode.ProcessExecution(jlexepath, ['--color=yes', `--project=${path.join(g_context.extensionPath, 'scripts', 'tasks', 'sysimageenv')}`, '--startup-file=no', '--history-file=no', path.join(g_context.extensionPath, 'scripts', 'tasks', 'task_compileenv.jl'), pkgenvpath]), "");
         buildJuliaSysimage.group = vscode.TaskGroup.Build;
         buildJuliaSysimage.presentationOptions = { echo: false, focus: false, panel: vscode.TaskPanelKind.Dedicated, clear: true };
         result.push(buildJuliaSysimage);


### PR DESCRIPTION
Seems much more robust in general. With this PR we also ship PackageCompilerX with the extension.

Only thing that isn't perfect yet is the question where does the compiler come from. I would still say we merge this now, as this is certainly an improvement over the status quo.

CC @KristofferC.