### PR TITLE
Add execute file to explorer context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,11 +201,18 @@
             "explorer/context": [
                 {
                     "when": "resourceLangId == julia",
-                    "command": "language-julia.toggle-file-lint"
+                    "command": "language-julia.executeJuliaFileInREPL",
+                    "group": "julia"
+                },
+                {
+                    "when": "resourceLangId == julia",
+                    "command": "language-julia.toggle-file-lint",
+                    "group": "julia"
                 },
                 {
                     "when": "explorerResourceIsFolder",
-                    "command": "language-julia.toggle-file-lint"
+                    "command": "language-julia.toggle-file-lint",
+                    "group": "julia"
                 }
             ],
             "editor/title": [

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -614,15 +614,24 @@ async function executeInRepl(code: string, filename: string, start: vscode.Posit
     sendMessage('repl/runcode', msg)
 }
 
-async function executeFile() {
+async function executeFile(uri?: vscode.Uri) {
     telemetry.traceEvent('command-executejuliafileinrepl');
 
-    var editor = vscode.window.activeTextEditor;
-    if (!editor) {
-        return;
+    let path = ""
+    let code = ""
+    if (uri) {
+        path = uri.fsPath
+        code = await fs.readTextFile(path)
     }
-    let document = editor.document;
-    executeInRepl(document.getText(), document.fileName, new vscode.Position(0, 0))
+    else {
+        let editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            return;
+        }
+        path = editor.document.fileName;
+        code = editor.document.getText()
+    }
+    executeInRepl(code, path, new vscode.Position(0, 0))
 }
 
 async function selectJuliaBlock() {
@@ -759,7 +768,7 @@ export function activate(context: vscode.ExtensionContext, settings: settings.IS
 
     context.subscriptions.push(vscode.commands.registerCommand('language-julia.executeJuliaCodeInREPL', executeSelection));
 
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.executeJuliaFileInREPL', executeFile));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.executeJuliaFileInREPL', (uri?: vscode.Uri) => { executeFile(uri) }));
 
     context.subscriptions.push(vscode.commands.registerCommand('language-julia.executeJuliaCellInREPL', executeJuliaCellInRepl));
 

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -769,7 +769,7 @@ export function activate(context: vscode.ExtensionContext, settings: settings.IS
 
     context.subscriptions.push(vscode.commands.registerCommand('language-julia.executeJuliaCodeInREPL', executeSelection));
 
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.executeJuliaFileInREPL', (uri?: vscode.Uri) => { executeFile(uri) }));
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.executeJuliaFileInREPL', executeFile));
 
     context.subscriptions.push(vscode.commands.registerCommand('language-julia.executeJuliaCellInREPL', executeJuliaCellInRepl));
 

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -617,11 +617,12 @@ async function executeInRepl(code: string, filename: string, start: vscode.Posit
 async function executeFile(uri?: vscode.Uri) {
     telemetry.traceEvent('command-executejuliafileinrepl');
 
-    let path = ""
-    let code = ""
+    let path = "";
+    let code = "";
     if (uri) {
-        path = uri.fsPath
-        code = await fs.readTextFile(path)
+        path = uri.fsPath;
+        const readBytes = await vscode.workspace.fs.readFile(uri);
+        code = Buffer.from(readBytes).toString('utf8');
     }
     else {
         let editor = vscode.window.activeTextEditor;
@@ -629,9 +630,9 @@ async function executeFile(uri?: vscode.Uri) {
             return;
         }
         path = editor.document.fileName;
-        code = editor.document.getText()
+        code = editor.document.getText();
     }
-    executeInRepl(code, path, new vscode.Position(0, 0))
+    executeInRepl(code, path, new vscode.Position(0, 0));
 }
 
 async function selectJuliaBlock() {


### PR DESCRIPTION
Individual files can be selected with the explorer context menu and sent to the REPL.