### PR TITLE
Change Julia 1.4.0 Windows path to new default

### DIFF
--- a/src/juliaexepath.ts
+++ b/src/juliaexepath.ts
@@ -38,7 +38,7 @@ export async function getJuliaExePath() {
             let pathsToSearch = [];
             if (process.platform == "win32") {
                 pathsToSearch = ["julia.exe",
-                    path.join(homedir, "AppData", "Local", "Julia-1.4.0", "bin", "julia.exe"),
+                    path.join(homedir, "AppData", "Local", "Programs", "Julia", "Julia-1.4.0", "bin", "julia.exe"),
                     path.join(homedir, "AppData", "Local", "Julia-1.3.2", "bin", "julia.exe"),
                     path.join(homedir, "AppData", "Local", "Julia-1.3.1", "bin", "julia.exe"),
                     path.join(homedir, "AppData", "Local", "Julia-1.3.0", "bin", "julia.exe"),


### PR DESCRIPTION
1.4.0 has a new Windows installer with a different default path.