### PR TITLE
Shield LS from custom JULIA_LOAD_PATH

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -144,6 +144,7 @@ async function startLanguageServer() {
         cwd: path.join(g_context.extensionPath, 'scripts', 'languageserver'),
         env: {
             JULIA_DEPOT_PATH: path.join(g_context.extensionPath, 'scripts', 'languageserver', 'julia_pkgdir'),
+            JULIA_LOAD_PATH: process.platform == "win32" ? ';' : ':',
             HOME: process.env.HOME ? process.env.HOME : os.homedir()
         }
     };


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/848.

We should never run the LS process with a custom `JULIA_LOAD_PATH` setting. This makes sure that `Base.LOAD_PATH` in the LS process is always the default.