### PR TITLE
Show stack trace for LS errors

### DIFF
--- a/scripts/languageserver/error_handler.jl
+++ b/scripts/languageserver/error_handler.jl
@@ -57,5 +57,6 @@ function global_err_handler(e, bt)
     finally
         close(pipe_to_vscode)
     end
+    Base.display_error(e, bt)
     exit(1)
 end


### PR DESCRIPTION
A previous PR accidentally removed display of this.