### PR TITLE
Invoke revise in repl/runcode

### DIFF
--- a/scripts/terminalserver/terminalserver.jl
+++ b/scripts/terminalserver/terminalserver.jl
@@ -150,7 +150,7 @@ end
             source_code = payload_as_string[end_second_line_pos+1:end]
 
             hideprompt() do
-                if isdefined(Main, :Revise)
+                if isdefined(Main, :Revise) && isdefined(Main.Revise, :revise) && Main.Revise.revise isa Function
                     let mode = get(ENV, "JULIA_REVISE", "auto")
                         mode == "auto" && Main.Revise.revise()
                     end

--- a/scripts/terminalserver/terminalserver.jl
+++ b/scripts/terminalserver/terminalserver.jl
@@ -150,6 +150,11 @@ end
             source_code = payload_as_string[end_second_line_pos+1:end]
 
             hideprompt() do
+                if isdefined(Main, :Revise)
+                    let mode = get(ENV, "JULIA_REVISE", "auto")
+                        mode == "auto" && Main.Revise.revise()
+                    end
+                end
                 # println(' '^code_column * source_code)
 
                 try


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/1028.

We need to run Revise.jl before we execute code if it is loaded.

@timholy, does this look sane to you? This is essentially just the place that executes if someone selects some text in VS Code and then sends that for execution in the REPL. With this PR we call `Revise.revise()` before we execute the user code. One question: Was that API always around for Revise.jl, i.e. will this code work with any version of Revise.jl that has ever shipped?