### PR TITLE
Properly load base files in debugger

### DIFF
--- a/scripts/debugger/debugger_requests.jl
+++ b/scripts/debugger/debugger_requests.jl
@@ -235,6 +235,11 @@ function getstacktrace_request(conn, state, msg_body, msg_id)
         lineno = curr_whereis[2]
         meth_or_mod_name = Base.nameof(curr_fr)
 
+        # Is this a file from base?
+        if !isabspath(file_name)
+            file_name = basepath(file_name)
+        end
+
         if isfile(file_name)
             push!(frames_as_string, string(id, ";", meth_or_mod_name, ";path;", file_name, ";", lineno))
         elseif curr_scopeof isa Method

--- a/scripts/debugger/debugger_utils.jl
+++ b/scripts/debugger/debugger_utils.jl
@@ -9,3 +9,8 @@ function lowercase_drive(a)
         return a
     end
 end
+
+const SRC_DIR = joinpath(Sys.BINDIR,"..","..","base")
+const RELEASE_DIR = joinpath(Sys.BINDIR,"..","share","julia","base")
+basepath(file) =
+  normpath(joinpath((@static isdir(SRC_DIR) ? SRC_DIR : RELEASE_DIR), file))


### PR DESCRIPTION
Fixes #1089. Sort of, at least we no longer crash. There is still a problem that the breakpoint is misplaced somehow, but I'll track that in a new issue.