### PR TITLE
Echo Julia code in REPL before executing it

### DIFF
--- a/scripts/terminalserver/terminalserver.jl
+++ b/scripts/terminalserver/terminalserver.jl
@@ -156,7 +156,17 @@ end
                         mode == "auto" && Main.Revise.revise()
                     end
                 end
-                # println(' '^code_column * source_code)
+                for (i,line) in enumerate(eachline(IOBuffer(source_code)))
+                    if i==1
+                        printstyled("julia> ", color=:green)
+                        print(' '^code_column)
+                    else
+                        # Indent by 7 so that it aligns with the julia> prompt
+                        print(' '^7)
+                    end
+                
+                    println(line)
+                end
 
                 try
                     withpath(source_filename) do


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/1007.

For now it just looks exactly the same as if it was typed in the REPL, I think that is probably the least surprising way to do this.

We could add an option later on to turn this off, but I think as a default this makes most sense.