### PR TITLE
Adjust debug mode for LS

### DIFF
--- a/scripts/languageserver/main.jl
+++ b/scripts/languageserver/main.jl
@@ -24,10 +24,10 @@ try
     conn = stdout
     (outRead, outWrite) = redirect_stdout()
 
-    if Base.ARGS[2] == "--debug=no"
-        const global ls_debug_mode = false
-    elseif Base.ARGS[2] == "--debug=yes"
-        const global ls_debug_mode = true
+    if Base.ARGS[2] == "--debug=yes"
+        ENV["JULIA_DEBUG"] = "all"
+    elseif Base.ARGS[2] != "--debug=no"
+        error("Invalid argument passed.")
     end
 
     try
@@ -48,7 +48,7 @@ try
 
     @info "Symbol server store is at '$symserver_store_path'."
 
-    server = LanguageServerInstance(stdin, conn, ls_debug_mode, Base.ARGS[1], Base.ARGS[4], global_err_handler, symserver_store_path)
+    server = LanguageServerInstance(stdin, conn, Base.ARGS[1], Base.ARGS[4], global_err_handler, symserver_store_path)
     run(server)
 catch e
     global_err_handler(e, catch_backtrace())


### PR DESCRIPTION
This is needed to make `master` work with the latest LS version.

Also, the `ENV["JULIA_DEBUG"] = "all"` should lead to a situation that `@debug` statements show up in output.