### PR TITLE
Fix a bug in REPLTree

### DIFF
--- a/src/repl.ts
+++ b/src/repl.ts
@@ -123,7 +123,7 @@ export class REPLTreeDataProvider implements vscode.TreeDataProvider<string> {
     readonly onDidChangeTreeData: vscode.Event<string | undefined> = this._onDidChangeTreeData.event;
 
     refresh(): void {
-        this._onDidChangeTreeData.fire();
+        this._onDidChangeTreeData.fire(undefined);
     }
 
     getChildren(node?: string) {


### PR DESCRIPTION
Without this the CI compile doesn't finish. Not sure why this is showing up now, probably I updated some TypeScript defs to the latest version. In any case, should be harmless, this isn't used right now in any case :)