### PR TITLE
Use a version of findfirst that exists on all Julia versions

### DIFF
--- a/scripts/debugger/debugger_rcp.jl
+++ b/scripts/debugger/debugger_rcp.jl
@@ -1,6 +1,6 @@
 function decode_msg(line::AbstractString)
-    pos = findfirst(':', line)
-    pos2 = findnext(':', line, pos+1)
+    pos = findfirst(":", line)
+    pos2 = findnext(":", line, pos+1)
 
     msg_id = line[1:pos-1]        
     msg_cmd = line[pos+1:pos2-1]

--- a/scripts/debugger/debugger_requests.jl
+++ b/scripts/debugger/debugger_requests.jl
@@ -20,7 +20,7 @@ function debug_request(conn, state, msg_body, msg_id)
     @debug "debug_request"
 
     state.debug_mode = :launch
-    index_of_sep = findfirst(';', msg_body)
+    index_of_sep = findfirst(";", msg_body)
 
     stop_on_entry_as_string = msg_body[1:index_of_sep-1]
 
@@ -62,7 +62,7 @@ function exec_request(conn, state, msg_body, msg_id)
 
     state.debug_mode = :attach
 
-    index_of_sep = findfirst(';', msg_body)
+    index_of_sep = findfirst(";", msg_body)
 
     stop_on_entry_as_string = msg_body[1:index_of_sep-1]
 
@@ -605,7 +605,7 @@ end
 function evaluate_request(conn, state, msg_body, msg_id)
     @debug "evaluate_request"
 
-    index_of_sep = findfirst(':', msg_body)
+    index_of_sep = findfirst(":", msg_body)
 
     stack_id = parse(Int, msg_body[1:index_of_sep-1])
 


### PR DESCRIPTION
Fixes a bug from crash reporting (yeah, we have crash reports for the debugger!).

The version of `findfirst` that uses a `Char` as the first arg doesn't exist pre Julia 1.3, so instead I'm now using a version that exists everywhere.