### PR TITLE
Remove dead code from REPL

### DIFF
--- a/scripts/terminalserver/terminalserver.jl
+++ b/scripts/terminalserver/terminalserver.jl
@@ -3,95 +3,13 @@ module _vscodeserver
 include("repl.jl")
 include("../debugger/debugger.jl")
 
-function remlineinfo!(x)
-    if isa(x, Expr)
-        if x.head == :macrocall && x.args[2] != nothing
-            id = findall(map(x -> (isa(x, Expr) && x.head == :line) || (isdefined(:LineNumberNode) && x isa LineNumberNode), x.args))
-            deleteat!(x.args, id)
-            for j in x.args
-                remlineinfo!(j)
-            end
-            insert!(x.args, 2, nothing)
-        else
-            id = findall(map(x -> (isa(x, Expr) && x.head == :line) || (isdefined(:LineNumberNode) && x isa LineNumberNode), x.args))
-            deleteat!(x.args, id)
-            for j in x.args
-                remlineinfo!(j)
-            end
-        end
-    end
-    x
-end
-
 using REPL, Sockets, Base64, Pkg, UUIDs
 import Base: display, redisplay
 import Dates
-global active_module = :Main
 
 struct InlineDisplay <: AbstractDisplay end
 
 pid = Base.ARGS[1]
-
-function change_module(newmodule::String, print_change = true)
-    global active_module
-    smods = Symbol.(split(newmodule, "."))
-
-    val = Main
-    for i = 1:length(smods)
-        if isdefined(val, smods[i])
-            val = getfield(val, smods[i])
-        else
-            println("Could not find module $newmodule")
-            return
-        end
-    end
-    expr = Meta.parse(newmodule)
-    active_module = expr
-    repl = Base.active_repl
-    main_mode = repl.interface.modes[1]
-    main_mode.prompt = string(newmodule,"> ")
-    main_mode.on_done = REPL.respond(repl,main_mode; pass_empty = false) do line
-        if !isempty(line)
-            ex = Meta.parse(line)
-            if ex isa Expr && ex.head == :module
-                ret = :( Base.eval($expr, Expr(:(=), :ans, Expr(:toplevel, Meta.parse($line)))) )
-            else
-                ret = :( Core.eval($expr, Expr(:(=), :ans, Meta.parse($line))) )
-            end
-        else
-            ret = :(  )
-        end
-        sendMsgToVscode("repl/variables", getVariables())
-        return ret
-    end
-    print(" \r ")
-    print_change && println("Changed root module to $expr")
-    printstyled(string(newmodule,"> "), bold = true, color = :green)
-end
-
-function get_available_modules(m=Main, out = Module[])
-    for n in names(m, all = true, imported = true)
-        if isdefined(m, n) && getfield(m, n) isa Module  && !(getfield(m, n) in out)
-            M = getfield(m, n)
-            push!(out, M)
-            get_available_modules(M, out)
-        end
-    end
-    out
-end
-
-function getVariables()
-    M = @__MODULE__
-    variables = []
-    msg = ""
-    for n in names(M)
-        !isdefined(M, n) && continue
-        x = getfield(M, n)
-        t = typeof(x)
-        msg = string(msg, ";", n, "::", t)
-    end
-    return msg
-end
 
 function generate_pipe_name(name)
     if Sys.iswindows()
@@ -109,8 +27,6 @@ pipename_torepl = generate_pipe_name("torepl")
 if issocket(pipename_torepl)
     rm(pipename_torepl)
 end
-
-
 
 function sendMsgToVscode(cmd, payload)
     println(conn, cmd, ":", sizeof(payload))
@@ -130,18 +46,7 @@ end
         cmd, payload_size_asstring = split(header, ':')
         payload_size = parse(Int, payload_size_asstring)
         payload = read(sock, payload_size)
-        if cmd == "repl/include"
-            text = String(payload)
-            cmod = Core.eval(active_module)
-            ex = Expr(:call, :include, strip(text, '\n'))
-            cmod.eval(ex)
-        elseif cmd == "repl/getVariables"
-            sendMsgToVscode("repl/variables", getVariables())
-        elseif cmd == "debug/info"
-            @info "RECEIVED A debug/info message"
-            @info "With payload_size=$payload_size"
-            @info String(payload)
-        elseif cmd == "repl/runcode"
+        if cmd == "repl/runcode"
             payload_as_string = String(payload)
             end_first_line_pos = findfirst("\n", payload_as_string)[1]
             end_second_line_pos = findnext("\n", payload_as_string, end_first_line_pos+1)[1]


### PR DESCRIPTION
This removes a whole lot of code that isn't currently used. Some of it might come back when we re-add features, but for now I just want to clean up a bit before I start to rewrite the communication part.