### PR TITLE
Use JSON-RPC for REPL-extension comm

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 [submodule "scripts/tasks/sysimageenv/PackageCompiler"]
 	path = scripts/tasks/sysimageenv/PackageCompiler
 	url = https://github.com/JuliaLang/PackageCompiler.jl.git
+[submodule "scripts/packages/JSONRPC"]
+	path = scripts/packages/JSONRPC
+	url = https://github.com/julia-vscode/JSONRPC.jl.git

--- a/scripts/terminalserver/terminalserver.jl
+++ b/scripts/terminalserver/terminalserver.jl
@@ -87,8 +87,6 @@ run(conn_endpoint)
                 try
                     VSCodeDebugger.startdebug(debug_pipename)
                 catch err
-                    Base.display_error(err, catch_backtrace())
-                    sleep(10)
                     VSCodeDebugger.global_err_handler(err, catch_backtrace(), ARGS[4])
                 end
             end

--- a/scripts/terminalserver/terminalserver.jl
+++ b/scripts/terminalserver/terminalserver.jl
@@ -1,59 +1,55 @@
 module _vscodeserver
 
-include("repl.jl")
-include("../debugger/debugger.jl")
-
 using REPL, Sockets, Base64, Pkg, UUIDs
 import Base: display, redisplay
 import Dates
 
+include("../languageserver/packages/JSON/src/JSON.jl")
+
+module JSONRPC
+    import ..JSON
+    import ..UUIDs
+
+    include("../packages/JSONRPC/src/core.jl")
+end
+
+include("repl.jl")
+include("../debugger/debugger.jl")
+
 struct InlineDisplay <: AbstractDisplay end
 
-pid = Base.ARGS[1]
-
-function generate_pipe_name(name)
-    if Sys.iswindows()
-        "\\\\.\\pipe\\vscode-language-julia-$name-$pid"
-    elseif Sys.isunix()
-        joinpath(tempdir(), "vscode-language-julia-$name-$pid")
-    end
-end
+repl_pipename = Base.ARGS[1]
 
 !(Sys.isunix() || Sys.iswindows()) && error("Unknown operating system.")
-
-pipename_fromrepl = generate_pipe_name("fromrepl")
-pipename_torepl = generate_pipe_name("torepl")
-
-if issocket(pipename_torepl)
-    rm(pipename_torepl)
-end
-
-function sendMsgToVscode(cmd, payload)
-    println(conn, cmd, ":", sizeof(payload))
-    print(conn, payload)
-end
 
 function ends_with_semicolon(x)
     return REPL.ends_with_semicolon(split(x,'\n',keepempty = false)[end])
 end
 
-@async begin
-    server = listen(pipename_torepl)
-    global conn = connect(pipename_fromrepl)
-    while true
-        sock = accept(server)
-        header = readline(sock)
-        cmd, payload_size_asstring = split(header, ':')
-        payload_size = parse(Int, payload_size_asstring)
-        payload = read(sock, payload_size)
-        if cmd == "repl/runcode"
-            payload_as_string = String(payload)
-            end_first_line_pos = findfirst("\n", payload_as_string)[1]
-            end_second_line_pos = findnext("\n", payload_as_string, end_first_line_pos+1)[1]
+repl_conn = connect(repl_pipename)
 
-            source_filename = payload_as_string[1:end_first_line_pos-1]
-            code_line, code_column = parse.(Int, split(payload_as_string[end_first_line_pos+1:end_second_line_pos-1], ':'))
-            source_code = payload_as_string[end_second_line_pos+1:end]
+conn_endpoint = JSONRPC.JSONRPCEndpoint(repl_conn, repl_conn)
+
+function sendDisplayMsg(kind, data)
+    JSONRPC.send_notification(conn_endpoint, "display", Dict{String,String}("kind"=>kind, "data"=>data))
+end
+
+
+run(conn_endpoint)
+
+@async begin
+   
+    while true
+        msg = JSONRPC.get_next_message(conn_endpoint)
+
+        if msg["method"] == "repl/runcode"
+            params = msg["params"]
+
+
+            source_filename = params["filename"]
+            code_line = params["line"]
+            code_column = params["column"]
+            source_code = params["code"]
 
             hideprompt() do
                 if isdefined(Main, :Revise) && isdefined(Main.Revise, :revise) && Main.Revise.revise isa Function
@@ -85,12 +81,14 @@ end
                     Base.display_error(stderr, err, catch_backtrace())
                 end
             end
-        elseif cmd == "repl/startdebugger"
+        elseif msg["method"] == "repl/startdebugger"
             hideprompt() do
-                payload_as_string = String(payload)
+                debug_pipename = msg["params"]
                 try
-                    VSCodeDebugger.startdebug(payload_as_string)
+                    VSCodeDebugger.startdebug(debug_pipename)
                 catch err
+                    Base.display_error(err, catch_backtrace())
+                    sleep(10)
                     VSCodeDebugger.global_err_handler(err, catch_backtrace(), ARGS[4])
                 end
             end
@@ -100,28 +98,28 @@ end
 
 function display(d::InlineDisplay, ::MIME{Symbol("image/png")}, x)
     payload = stringmime(MIME("image/png"), x)
-    sendMsgToVscode("image/png", payload)
+    sendDisplayMsg("image/png", payload)
 end
 
 displayable(d::InlineDisplay, ::MIME{Symbol("image/png")}) = true
 
 function display(d::InlineDisplay, ::MIME{Symbol("image/svg+xml")}, x)
     payload = stringmime(MIME("image/svg+xml"), x)
-    sendMsgToVscode("image/svg+xml", payload)
+    sendDisplayMsg("image/svg+xml", payload)
 end
 
 displayable(d::InlineDisplay, ::MIME{Symbol("image/svg+xml")}) = true
 
 function display(d::InlineDisplay, ::MIME{Symbol("text/html")}, x)
     payload = stringmime(MIME("text/html"), x)
-    sendMsgToVscode("text/html", payload)
+    sendDisplayMsg("text/html", payload)
 end
 
 displayable(d::InlineDisplay, ::MIME{Symbol("text/html")}) = true
 
 function display(d::InlineDisplay, ::MIME{Symbol("juliavscode/html")}, x)
     payload = stringmime(MIME("juliavscode/html"), x)
-    sendMsgToVscode("juliavscode/html", payload)
+    sendDisplayMsg("juliavscode/html", payload)
 end
 
 Base.Multimedia.istextmime(::MIME{Symbol("juliavscode/html")}) = true
@@ -130,56 +128,56 @@ displayable(d::InlineDisplay, ::MIME{Symbol("juliavscode/html")}) = true
 
 function display(d::InlineDisplay, ::MIME{Symbol("application/vnd.vegalite.v2+json")}, x)
     payload = stringmime(MIME("application/vnd.vegalite.v2+json"), x)
-    sendMsgToVscode("application/vnd.vegalite.v2+json", payload)
+    sendDisplayMsg("application/vnd.vegalite.v2+json", payload)
 end
 
 displayable(d::InlineDisplay, ::MIME{Symbol("application/vnd.vegalite.v2+json")}) = true
 
 function display(d::InlineDisplay, ::MIME{Symbol("application/vnd.vegalite.v3+json")}, x)
     payload = stringmime(MIME("application/vnd.vegalite.v3+json"), x)
-    sendMsgToVscode("application/vnd.vegalite.v3+json", payload)
+    sendDisplayMsg("application/vnd.vegalite.v3+json", payload)
 end
 
 displayable(d::InlineDisplay, ::MIME{Symbol("application/vnd.vegalite.v3+json")}) = true
 
 function display(d::InlineDisplay, ::MIME{Symbol("application/vnd.vegalite.v4+json")}, x)
     payload = stringmime(MIME("application/vnd.vegalite.v4+json"), x)
-    sendMsgToVscode("application/vnd.vegalite.v4+json", payload)
+    sendDisplayMsg("application/vnd.vegalite.v4+json", payload)
 end
 
 displayable(d::InlineDisplay, ::MIME{Symbol("application/vnd.vegalite.v4+json")}) = true
 
 function display(d::InlineDisplay, ::MIME{Symbol("application/vnd.vega.v3+json")}, x)
     payload = stringmime(MIME("application/vnd.vega.v3+json"), x)
-    sendMsgToVscode("application/vnd.vega.v3+json", payload)
+    sendDisplayMsg("application/vnd.vega.v3+json", payload)
 end
 
 displayable(d::InlineDisplay, ::MIME{Symbol("application/vnd.vega.v3+json")}) = true
 
 function display(d::InlineDisplay, ::MIME{Symbol("application/vnd.vega.v4+json")}, x)
     payload = stringmime(MIME("application/vnd.vega.v4+json"), x)
-    sendMsgToVscode("application/vnd.vega.v4+json", payload)
+    sendDisplayMsg("application/vnd.vega.v4+json", payload)
 end
 
 displayable(d::InlineDisplay, ::MIME{Symbol("application/vnd.vega.v4+json")}) = true
 
 function display(d::InlineDisplay, ::MIME{Symbol("application/vnd.vega.v5+json")}, x)
     payload = stringmime(MIME("application/vnd.vega.v5+json"), x)
-    sendMsgToVscode("application/vnd.vega.v5+json", payload)
+    sendDisplayMsg("application/vnd.vega.v5+json", payload)
 end
 
 displayable(d::InlineDisplay, ::MIME{Symbol("application/vnd.vega.v5+json")}) = true
 
 function display(d::InlineDisplay, ::MIME{Symbol("application/vnd.plotly.v1+json")}, x)
     payload = stringmime(MIME("application/vnd.plotly.v1+json"), x)
-    sendMsgToVscode("application/vnd.plotly.v1+json", payload)
+    sendDisplayMsg("application/vnd.plotly.v1+json", payload)
 end
 
 displayable(d::InlineDisplay, ::MIME{Symbol("application/vnd.dataresource+json")}) = true
 
 function display(d::InlineDisplay, ::MIME{Symbol("application/vnd.dataresource+json")}, x)
     payload = stringmime(MIME("application/vnd.dataresource+json"), x)
-    sendMsgToVscode("application/vnd.dataresource+json", payload)
+    sendDisplayMsg("application/vnd.dataresource+json", payload)
 end
 
 Base.Multimedia.istextmime(::MIME{Symbol("application/vnd.dataresource+json")}) = true
@@ -414,10 +412,10 @@ end
 
 macro enter(command)
     _vscodeserver.remove_lln!(command)
-    :(_vscodeserver.sendMsgToVscode("debugger/enter", $(string(command))))
+    :(_vscodeserver.JSONRPC.send_notification(_vscodeserver.conn_endpoint, "debugger/enter", $(string(command))))
 end
 
 macro run(command)
     _vscodeserver.remove_lln!(command)
-    :(_vscodeserver.sendMsgToVscode("debugger/run", $(string(command))))
+    :(_vscodeserver.JSONRPC.send_notification(_vscodeserver.conn_endpoint, "debugger/run", $(string(command))))
 end

--- a/src/juliaDebug.ts
+++ b/src/juliaDebug.ts
@@ -12,7 +12,7 @@ import { Subject } from 'await-notify';
 import * as readline from 'readline';
 import { generatePipeName } from './utils';
 import { uuid } from 'uuidv4';
-import { sendMessage } from './repl';
+import { replStartDebugger } from './repl';
 import * as vscode from 'vscode';
 import { getCrashReportingPipename } from './telemetry';
 
@@ -233,7 +233,7 @@ export class JuliaDebugSession extends LoggingDebugSession {
 
 		await serverListeningPromise.wait();
 
-		sendMessage('repl/startdebugger', pn);
+		replStartDebugger(pn);
 
 		await connectedPromise.wait();
 

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -10,6 +10,7 @@ import {generatePipeName, inferJuliaNumThreads} from './utils';
 import * as telemetry from './telemetry';
 import * as jlpkgenv from './jlpkgenv';
 import * as fs from 'async-file';
+import { Subject } from 'await-notify';
 
 let g_context: vscode.ExtensionContext = null;
 let g_settings: settings.ISettings = null;
@@ -24,6 +25,8 @@ let g_plotPanel: vscode.WebviewPanel | undefined = undefined;
 let g_replVariables: string = '';
 
 let c_juliaPlotPanelActiveContextKey = 'jlplotpaneFocus';
+
+let g_connection: rpc.MessageConnection = undefined;
 
 function getPlotPaneContent() {
     if (g_plots.length == 0) {
@@ -170,7 +173,10 @@ function get_editor(): string {
 }
 async function startREPL(preserveFocus: boolean) {
     if (g_terminal == null) {
-        let juliaIsConnectedPromise = startREPLMsgServer()
+        let pipename = generatePipeName(process.pid.toString(), 'vsc-julia-repl');
+
+        let juliaIsConnectedPromise = startREPLMsgServer(pipename);
+
         let args = path.join(g_context.extensionPath, 'scripts', 'terminalserver', 'terminalserver.jl')
         let exepath = await juliaexepath.getJuliaExePath();
         let pkgenvpath = await jlpkgenv.getEnvPath();
@@ -178,7 +184,7 @@ async function startREPL(preserveFocus: boolean) {
             let jlarg1 = ['-i','--banner=no'].concat(vscode.workspace.getConfiguration("julia").get("additionalArgs"))
             let jlarg2 = [
                 args,
-                process.pid.toString(),
+                pipename,
                 vscode.workspace.getConfiguration("julia").get("useRevise").toString(),
                 vscode.workspace.getConfiguration("julia").get("usePlotPane").toString(),
                 telemetry.getCrashReportingPipename()
@@ -210,7 +216,7 @@ async function startREPL(preserveFocus: boolean) {
             let jlarg1 = ['-i', '--banner=no', `--project=${pkgenvpath}`].concat(sysImageArgs).concat(vscode.workspace.getConfiguration("julia").get("additionalArgs"))
             let jlarg2 = [
                 args,
-                process.pid.toString(),
+                pipename,
                 vscode.workspace.getConfiguration("julia").get("useRevise").toString(),
                 vscode.workspace.getConfiguration("julia").get("usePlotPane").toString(),
                 telemetry.getCrashReportingPipename()
@@ -226,48 +232,53 @@ async function startREPL(preserveFocus: boolean) {
                     }});
         }
         g_terminal.show(preserveFocus);
-        await juliaIsConnectedPromise;
+        await juliaIsConnectedPromise.wait();
     }
     else {
     g_terminal.show(preserveFocus);
 }
 }
 
-function processMsg(cmd, payload) {
-    if (cmd == 'debugger/run') {
-        let x = {
-            type:'julia',
-            request: 'attach',
-            name: 'Julia REPL',
-            code: payload,
-            stopOnEntry: false
-        }
-        vscode.debug.startDebugging(undefined, x);
+function debuggerRun(code: string) {
+    let x = {
+        type:'julia',
+        request: 'attach',
+        name: 'Julia REPL',
+        code: code,
+        stopOnEntry: false
     }
-    else if (cmd == 'debugger/enter') {
-        let x = {
-            type:'julia',
-            request: 'attach',
-            name: 'Julia REPL',
-            code: payload,
-            stopOnEntry: true
-        }
-        vscode.debug.startDebugging(undefined, x);
+    vscode.debug.startDebugging(undefined, x);
+}
+
+function debuggerEnter(code: string) {
+    let x = {
+        type:'julia',
+        request: 'attach',
+        name: 'Julia REPL',
+        code: code,
+        stopOnEntry: true
     }
-    else if (cmd == 'image/svg+xml') {
+    vscode.debug.startDebugging(undefined, x);
+}
+
+function displayPlot(params: {kind: string, data: string}) {
+    const kind = params.kind;
+    const payload = params.data;
+
+    if (kind == 'image/svg+xml') {
         g_currentPlotIndex = g_plots.push(payload) - 1;
         showPlotPane();
     }
-    else if (cmd == 'image/png') {
+    else if (kind == 'image/png') {
         let plotPaneContent = '<html><img src="data:image/png;base64,' + payload + '" /></html>';
         g_currentPlotIndex = g_plots.push(plotPaneContent) - 1;
         showPlotPane();
     }
-    else if (cmd == 'juliavscode/html') {
+    else if (kind == 'juliavscode/html') {
         g_currentPlotIndex = g_plots.push(payload) - 1;
         showPlotPane();
     }
-    else if (cmd == 'application/vnd.vegalite.v2+json') {
+    else if (kind == 'application/vnd.vegalite.v2+json') {
         let uriVegaEmbed = vscode.Uri.file(path.join(g_context.extensionPath, 'libs', 'vega-embed', 'vega-embed.min.js')).with({ scheme: 'vscode-resource' });
         let uriVegaLite = vscode.Uri.file(path.join(g_context.extensionPath, 'libs', 'vega-lite-2', 'vega-lite.min.js')).with({ scheme: 'vscode-resource' });
         let uriVega = vscode.Uri.file(path.join(g_context.extensionPath, 'libs', 'vega-3', 'vega.min.js')).with({ scheme: 'vscode-resource' });
@@ -301,7 +312,7 @@ function processMsg(cmd, payload) {
         g_currentPlotIndex = g_plots.push(plotPaneContent) - 1;
         showPlotPane();
     }
-    else if (cmd == 'application/vnd.vegalite.v3+json') {
+    else if (kind == 'application/vnd.vegalite.v3+json') {
         let uriVegaEmbed = vscode.Uri.file(path.join(g_context.extensionPath, 'libs', 'vega-embed', 'vega-embed.min.js')).with({ scheme: 'vscode-resource' });
         let uriVegaLite = vscode.Uri.file(path.join(g_context.extensionPath, 'libs', 'vega-lite-3', 'vega-lite.min.js')).with({ scheme: 'vscode-resource' });
         let uriVega = vscode.Uri.file(path.join(g_context.extensionPath, 'libs', 'vega-5', 'vega.min.js')).with({ scheme: 'vscode-resource' });
@@ -335,7 +346,7 @@ function processMsg(cmd, payload) {
         g_currentPlotIndex = g_plots.push(plotPaneContent) - 1;
         showPlotPane();
     }
-    else if (cmd == 'application/vnd.vegalite.v4+json') {
+    else if (kind == 'application/vnd.vegalite.v4+json') {
         let uriVegaEmbed = vscode.Uri.file(path.join(g_context.extensionPath, 'libs', 'vega-embed', 'vega-embed.min.js')).with({ scheme: 'vscode-resource' });
         let uriVegaLite = vscode.Uri.file(path.join(g_context.extensionPath, 'libs', 'vega-lite-4', 'vega-lite.min.js')).with({ scheme: 'vscode-resource' });
         let uriVega = vscode.Uri.file(path.join(g_context.extensionPath, 'libs', 'vega-5', 'vega.min.js')).with({ scheme: 'vscode-resource' });
@@ -369,7 +380,7 @@ function processMsg(cmd, payload) {
         g_currentPlotIndex = g_plots.push(plotPaneContent) - 1;
         showPlotPane();
     }
-    else if (cmd == 'application/vnd.vega.v3+json') {
+    else if (kind == 'application/vnd.vega.v3+json') {
         let uriVegaEmbed = vscode.Uri.file(path.join(g_context.extensionPath, 'libs', 'vega-embed', 'vega-embed.min.js')).with({ scheme: 'vscode-resource' });
         let uriVega = vscode.Uri.file(path.join(g_context.extensionPath, 'libs', 'vega-3', 'vega.min.js')).with({ scheme: 'vscode-resource' });
         let plotPaneContent = `
@@ -401,7 +412,7 @@ function processMsg(cmd, payload) {
         g_currentPlotIndex = g_plots.push(plotPaneContent) - 1;
         showPlotPane();
     }
-    else if (cmd == 'application/vnd.vega.v4+json') {
+    else if (kind == 'application/vnd.vega.v4+json') {
         let uriVegaEmbed = vscode.Uri.file(path.join(g_context.extensionPath, 'libs', 'vega-embed', 'vega-embed.min.js')).with({ scheme: 'vscode-resource' });
         let uriVega = vscode.Uri.file(path.join(g_context.extensionPath, 'libs', 'vega-4', 'vega.min.js')).with({ scheme: 'vscode-resource' });
         let plotPaneContent = `
@@ -433,7 +444,7 @@ function processMsg(cmd, payload) {
         g_currentPlotIndex = g_plots.push(plotPaneContent) - 1;
         showPlotPane();
     }
-    else if (cmd == 'application/vnd.vega.v5+json') {
+    else if (kind == 'application/vnd.vega.v5+json') {
         let uriVegaEmbed = vscode.Uri.file(path.join(g_context.extensionPath, 'libs', 'vega-embed', 'vega-embed.min.js')).with({ scheme: 'vscode-resource' });
         let uriVega = vscode.Uri.file(path.join(g_context.extensionPath, 'libs', 'vega-5', 'vega.min.js')).with({ scheme: 'vscode-resource' });
         let plotPaneContent = `
@@ -465,7 +476,7 @@ function processMsg(cmd, payload) {
         g_currentPlotIndex = g_plots.push(plotPaneContent) - 1;
         showPlotPane();
     }
-    else if (cmd == 'application/vnd.plotly.v1+json') {
+    else if (kind == 'application/vnd.plotly.v1+json') {
         let uriPlotly = vscode.Uri.file(path.join(g_context.extensionPath, 'libs', 'plotly', 'plotly.min.js')).with({ scheme: 'vscode-resource' });
         let plotPaneContent = `
         <html>
@@ -499,7 +510,7 @@ function processMsg(cmd, payload) {
         g_currentPlotIndex = g_plots.push(plotPaneContent) - 1;
         showPlotPane();
     }
-    else if (cmd == 'application/vnd.dataresource+json') {
+    else if (kind == 'application/vnd.dataresource+json') {
         let uriAgGrid = vscode.Uri.file(path.join(g_context.extensionPath, 'libs', 'ag-grid', 'ag-grid-community.min.noStyle.js')).with({ scheme: 'vscode-resource' });
         let uriAgGridCSS = vscode.Uri.file(path.join(g_context.extensionPath, 'libs', 'ag-grid', 'ag-grid.css')).with({ scheme: 'vscode-resource' });
         let uriAgGridTheme = vscode.Uri.file(path.join(g_context.extensionPath, 'libs', 'ag-grid', 'ag-theme-balham.css')).with({ scheme: 'vscode-resource' });
@@ -551,62 +562,40 @@ function processMsg(cmd, payload) {
         let grid_panel = vscode.window.createWebviewPanel('jlgrid', 'Julia Table', {preserveFocus: true, viewColumn: vscode.ViewColumn.Active}, {enableScripts: true, retainContextWhenHidden: true});
         grid_panel.webview.html = grid_content;
     }
-    else if (cmd == 'repl/variables') {
-        g_replVariables = payload;
-        // TODO Enable again
-        // g_REPLTreeDataProvider.refresh();
-    }
     else {
         throw new Error();
     }
 }
 
-function startREPLMsgServer() {
-    let PIPE_PATH = generatePipeName(process.pid.toString(), 'vscode-language-julia-fromrepl');
+const notifyTypeDisplay = new rpc.NotificationType<{kind: string, data: any}, void>('display');
+const notifyTypeDebuggerEnter = new rpc.NotificationType<string, void>('debugger/enter');
+const notifyTypeDebuggerRun = new rpc.NotificationType<string, void>('debugger/run');
+const notifyTypeReplRunCode = new rpc.NotificationType<{filename: string, line: number, column: number, code: string}, void>('repl/runcode');
+const notifyTypeReplStartDebugger = new rpc.NotificationType<string, void>('repl/startdebugger');
 
-    let connectedPromise = new Promise(function (resolveCallback, rejectCallback) {
-        var server = net.createServer(function (socket) {
-            resolveCallback();
+function startREPLMsgServer(pipename: string) {
+    let connected = new Subject();
 
-        let accumulatingBuffer = Buffer.alloc(0);
+    let server = net.createServer((socket: net.Socket) => {
+        socket.on('close', hadError => {server.close()});
 
-            socket.on('data', function (c) {
-            accumulatingBuffer = Buffer.concat([accumulatingBuffer, Buffer.from(c)]);
-            let s = accumulatingBuffer.toString();
-            let index_of_sep_1 = s.indexOf(":");
-            let index_of_sep_2 = s.indexOf("\n");
+        g_connection = rpc.createMessageConnection(
+            new rpc.StreamMessageReader(socket),
+            new rpc.StreamMessageWriter(socket)
+            );
 
-            if (index_of_sep_2 > -1) {
-                let cmd = s.substring(0, index_of_sep_1);
-                let msg_len_as_string = s.substring(index_of_sep_1 + 1, index_of_sep_2);
-                let msg_len = parseInt(msg_len_as_string);
-                if (accumulatingBuffer.length >= cmd.length + msg_len_as_string.length + 2 + msg_len) {
-                    let payload = s.substring(index_of_sep_2 + 1);
-                    if (accumulatingBuffer.length > cmd.length + msg_len_as_string.length + 2 + msg_len) {
-                        accumulatingBuffer = Buffer.from(accumulatingBuffer.slice(cmd.length + msg_len_as_string.length + 2 + msg_len + 1));
-                    }
-                    else {
-                        accumulatingBuffer = Buffer.alloc(0);
-                    }
+        g_connection.onNotification(notifyTypeDisplay, displayPlot);
+        g_connection.onNotification(notifyTypeDebuggerRun, debuggerRun);
+        g_connection.onNotification(notifyTypeDebuggerEnter, debuggerEnter);
 
-                    processMsg(cmd, payload);
-                }
-            }
-        });
+        g_connection.listen();
 
-            socket.on('close', function (hadError) { server.close(); });
+        connected.notify();
     });
 
-        server.on('close', function () {
-            console.log('Server: on close');
-        })
+    server.listen(pipename);
 
-    server.listen(PIPE_PATH, function () {
-        console.log('Server: on listening');
-    })
-    });
-
-    return connectedPromise;
+    return connected;
 }
 
 async function executeCode(text, individualLine) {
@@ -654,9 +643,17 @@ function executeSelection() {
 }
 
 async function executeInRepl(code: string, filename: string, start: vscode.Position) {
-    let msg = filename + '\n' + start.line.toString() + ':' +
-        start.character.toString() + '\n' + code
-    sendMessage('repl/runcode', msg)
+    await startREPL(true);
+
+    g_connection.sendNotification(
+        notifyTypeReplRunCode,
+        {
+            filename: filename,
+            line: start.line,
+            column: start.character,
+            code: code
+        }
+    );
 }
 
 async function executeFile(uri?: vscode.Uri) {
@@ -787,15 +784,10 @@ async function executeJuliaBlockInRepl() {
     }
 }
 
-export async function sendMessage(cmd, msg: string) {
+export async function replStartDebugger(pipename: string) {
     await startREPL(true)
-    let sock = generatePipeName(process.pid.toString(), 'vscode-language-julia-torepl')
 
-    let conn = net.connect(sock)
-    let payload_size = Buffer.byteLength(msg, 'utf8');
-    let outmsg = cmd + ':' + payload_size.toString() + '\n' + msg;
-    conn.write(outmsg)
-    conn.on('error', () => { vscode.window.showErrorMessage("REPL is not open") })
+    g_connection.sendNotification(notifyTypeReplStartDebugger, pipename);
 }
 
 export interface TextDocumentPositionParams {


### PR DESCRIPTION
Improves #1203.

Major changes:
- Uses JSON RPC
- We use the same implementation in the REPL that we use in LS on the Julia side (I moved the code into a package)
- On the TypeScript side we use the vscode-jsonrpc package
- We use only one named pipe instead of multiple in the previous version
- All the weird message format hacks are gone :)
- We vendor JSON.jl into the REPL process, which will be super useful for lots of other things as well
- I'm starting to move all the Julia packages that we ship into the folder `scripts/packages`, right now they are all over the place.

Once we have this merged, I'll also use this for the debugger communication.

I don't yet have the kind of callback implementation that Juno has. The main reason is that I realized that won't work in the simple form for LS, but I want the JSONRPC package to work for that scenario as well. I'll open another issue to discuss the specific problem.