### PR TITLE
Add a status bar item for LS startup

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,11 +25,16 @@ import { JuliaDebugSession } from './juliaDebug';
 let g_settings: settings.ISettings = null;
 let g_languageClient: LanguageClient = null;
 let g_context: vscode.ExtensionContext = null;
+let g_lsStartup: vscode.StatusBarItem = null;
 
 export async function activate(context: vscode.ExtensionContext) {
     await telemetry.init(context);
 
     telemetry.traceEvent('activate');
+
+    g_lsStartup = vscode.window.createStatusBarItem();
+    g_lsStartup.text = "Starting Julia Language Server..."
+    g_lsStartup.show();
 
     telemetry.startLsCrashServer();
 
@@ -188,6 +193,9 @@ async function startLanguageServer() {
         else if (data.command=='symserv_pkgload_crash') {
             telemetry.tracePackageLoadError(data.name, data.message)
         }
+    });
+    g_languageClient.onReady().then(()=>{
+        g_lsStartup.hide();
     });
 
     // Push the disposable to the context's subscriptions so that the


### PR DESCRIPTION
I'm not actually sure this is a great idea, would like to hear some feedback.

This adds a status bar item that says "Starting Julia Language Server..." that will disappear as soon as the LS is read to accept requests, for example requests to identify the current block for say the Alt+Enter command.

It does add busy UI, but on the other hand it might be useful until we fix the LS startup performance problems?