### PR TITLE
refactor: listen for onSetLanguageClient, onDidChangeConfig event

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,7 +45,7 @@ export async function activate(context: vscode.ExtensionContext) {
     g_settings = settings.loadSettings();
 
     // Config change
-    context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(configChanged));
+    context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(changeConfig));
 
     // Language settings
     vscode.languages.setLanguageConfiguration('julia', {
@@ -92,47 +92,27 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 
 // this method is called when your extension is deactivated
-export function deactivate() {
-}
+export function deactivate() {}
 
+const _onSetLanguageClient = new vscode.EventEmitter<vslc.LanguageClient>()
+export const onSetLanguageClient = _onSetLanguageClient.event
 function setLanguageClient(languageClient: vslc.LanguageClient) {
+    _onSetLanguageClient.fire(languageClient)
     g_languageClient = languageClient;
-
-    juliaexepath.onNewLanguageClient(g_languageClient);
-    repl.onNewLanguageClient(g_languageClient);
-    weave.onNewLanguageClient(g_languageClient);
-    tasks.onNewLanguageClient(g_languageClient);
-    smallcommands.onNewLanguageClient(g_languageClient);
-    packagepath.onNewLanguageClient(g_languageClient);
-    openpackagedirectory.onNewLanguageClient(g_languageClient);
-    jlpkgenv.onNewLanguageClient(g_languageClient);
 }
 
-function configChanged(params) {
-    let newSettings = settings.loadSettings();
+const _onDidChangeConfig = new vscode.EventEmitter<settings.ISettings>()
+export const onDidChangeConfig = _onDidChangeConfig.event
+function changeConfig(params: vscode.ConfigurationChangeEvent) {
+    const newSettings = settings.loadSettings()
+    _onDidChangeConfig.fire(newSettings)
 
-    telemetry.onDidChangeConfiguration(newSettings);
-    juliaexepath.onDidChangeConfiguration(newSettings);
-    repl.onDidChangeConfiguration(newSettings);
-    weave.onDidChangeConfiguration(newSettings);
-    tasks.onDidChangeConfiguration(newSettings);
-    smallcommands.onDidChangeConfiguration(newSettings);
-    packagepath.onDidChangeConfiguration(newSettings);
-    openpackagedirectory.onDidChangeConfiguration(newSettings);
-    jlpkgenv.onDidChangeConfiguration(newSettings);
-
-    let need_to_restart_server = false;
-
-    if (g_settings.juliaExePath != newSettings.juliaExePath) {
-        need_to_restart_server = true;
-    }
-
+    const need_to_restart_server = g_settings.juliaExePath != newSettings.juliaExePath ? true : false
     if (need_to_restart_server) {
         if (g_languageClient != null) {
             g_languageClient.stop();
             setLanguageClient(null);
         }
-
         startLanguageServer();
     }
 }
@@ -249,7 +229,7 @@ export class JuliaDebugConfigurationProvider
                 config.cwd = '${workspaceFolder}';
             }
 
-            if (!config.juliaEnv && config.request != 'attach') {                
+            if (!config.juliaEnv && config.request != 'attach') {
                 config.juliaEnv = '${command:activeJuliaEnvironment}';
             }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -94,18 +94,18 @@ export async function activate(context: vscode.ExtensionContext) {
 // this method is called when your extension is deactivated
 export function deactivate() {}
 
-const _onSetLanguageClient = new vscode.EventEmitter<vslc.LanguageClient>()
-export const onSetLanguageClient = _onSetLanguageClient.event
+const g_onSetLanguageClient = new vscode.EventEmitter<vslc.LanguageClient>()
+export const onSetLanguageClient = g_onSetLanguageClient.event
 function setLanguageClient(languageClient: vslc.LanguageClient) {
-    _onSetLanguageClient.fire(languageClient)
+    g_onSetLanguageClient.fire(languageClient)
     g_languageClient = languageClient;
 }
 
-const _onDidChangeConfig = new vscode.EventEmitter<settings.ISettings>()
-export const onDidChangeConfig = _onDidChangeConfig.event
+const g_onDidChangeConfig = new vscode.EventEmitter<settings.ISettings>()
+export const onDidChangeConfig = g_onDidChangeConfig.event
 function changeConfig(params: vscode.ConfigurationChangeEvent) {
     const newSettings = settings.loadSettings()
-    _onDidChangeConfig.fire(newSettings)
+    g_onDidChangeConfig.fire(newSettings)
 
     const need_to_restart_server = g_settings.juliaExePath != newSettings.juliaExePath ? true : false
     if (need_to_restart_server) {

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -14,7 +14,6 @@ import { Subject } from 'await-notify';
 
 import * as plots from './plots'
 import * as workspace from './workspace'
-import { DocumentColorRequest } from 'vscode-languageclient';
 import { onSetLanguageClient, onDidChangeConfig } from '../extension';
 
 let g_context: vscode.ExtensionContext = null;

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -14,6 +14,8 @@ import { Subject } from 'await-notify';
 
 import * as plots from './plots'
 import * as workspace from './workspace'
+import { DocumentColorRequest } from 'vscode-languageclient';
+import { onSetLanguageClient, onDidChangeConfig } from '../extension';
 
 let g_context: vscode.ExtensionContext = null;
 let g_settings: settings.ISettings = null;
@@ -334,7 +336,7 @@ async function executeJuliaBlockInRepl() {
             let start_pos = new vscode.Position(ret_val[0].line, ret_val[0].character)
             let end_pos = new vscode.Position(ret_val[1].line, ret_val[1].character)
             let next_pos = new vscode.Position(ret_val[2].line, ret_val[2].character)
-            
+
             let code_to_run = vscode.window.activeTextEditor.document.getText(new vscode.Range(start_pos, end_pos))
             executeInRepl(code_to_run, vscode.window.activeTextEditor.document.fileName, start_pos)
 
@@ -369,6 +371,13 @@ export function activate(context: vscode.ExtensionContext, settings: settings.IS
     g_context = context;
     g_settings = settings;
 
+    context.subscriptions.push(onSetLanguageClient(languageClient => {
+        g_languageClient = languageClient
+    }))
+    context.subscriptions.push(onDidChangeConfig(newSettings => {
+        g_settings = newSettings
+    }))
+
     context.subscriptions.push(vscode.commands.registerCommand('language-julia.startREPL', startREPLCommand));
 
     context.subscriptions.push(vscode.commands.registerCommand('language-julia.executeJuliaCodeInREPL', executeSelection));
@@ -390,12 +399,4 @@ export function activate(context: vscode.ExtensionContext, settings: settings.IS
 
     plots.activate(context);
     workspace.activate(context);
-}
-
-export function onDidChangeConfiguration(newSettings: settings.ISettings) {
-
-}
-
-export function onNewLanguageClient(newLanguageClient: vslc.LanguageClient) {
-    g_languageClient = newLanguageClient;
 }

--- a/src/jlpkgenv.ts
+++ b/src/jlpkgenv.ts
@@ -8,6 +8,7 @@ import * as os from 'os';
 import * as path from 'path'
 import * as juliaexepath from './juliaexepath';
 import {exec} from 'child-process-promise';
+import { onSetLanguageClient, onDidChangeConfig } from './extension';
 
 let g_context: vscode.ExtensionContext = null;
 let g_settings: settings.ISettings = null;
@@ -192,6 +193,12 @@ export async function getEnvName() {
 export async function activate(context: vscode.ExtensionContext, settings: settings.ISettings) {
     g_context = context;
     g_settings = settings;
+
+    context.subscriptions.push(onSetLanguageClient(languageClient => {
+        g_languageClient = languageClient
+    }))
+    context.subscriptions.push(onDidChangeConfig(newSettings => {}))
+
     context.subscriptions.push(vscode.commands.registerCommand('language-julia.changeCurrentEnvironment', changeJuliaEnvironment));
     // Environment status bar
     g_current_environment = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
@@ -200,11 +207,4 @@ export async function activate(context: vscode.ExtensionContext, settings: setti
     g_current_environment.command = "language-julia.changeCurrentEnvironment";
     context.subscriptions.push(g_current_environment);
     await switchEnvToPath(await getEnvPath(), false); // We don't need to notify the LS here because it will start with that env already
-}
-
-export function onDidChangeConfiguration(newSettings: settings.ISettings) {
-}
-
-export function onNewLanguageClient(newLanguageClient: vslc.LanguageClient) {
-    g_languageClient = newLanguageClient;
 }

--- a/src/juliaexepath.ts
+++ b/src/juliaexepath.ts
@@ -9,6 +9,7 @@ import * as which from 'which';
 import * as child_process from 'child_process';
 import { setCurrentJuliaVersion, traceEvent } from './telemetry';
 import {exec} from 'child-process-promise';
+import { onSetLanguageClient, onDidChangeConfig } from './extension';
 const whichAsync = util.promisify(which);
 
 let g_context: vscode.ExtensionContext = null;
@@ -107,14 +108,12 @@ export async function getJuliaExePath() {
 export function activate(context: vscode.ExtensionContext, settings: settings.ISettings) {
     g_context = context;
     g_settings = settings;
-}
-
-export function onDidChangeConfiguration(newSettings: settings.ISettings) {
-    if (g_settings.juliaExePath != newSettings.juliaExePath) {
-        actualJuliaExePath = null;
-    }
-}
-
-export function onNewLanguageClient(newLanguageClient: vslc.LanguageClient) {
-    g_languageClient = newLanguageClient;
+    context.subscriptions.push(onSetLanguageClient(languageClient => {
+        g_languageClient = languageClient
+    }))
+    context.subscriptions.push(onDidChangeConfig(newSettings => {
+        if (g_settings.juliaExePath != newSettings.juliaExePath) {
+            actualJuliaExePath = null;
+        }
+    }))
 }

--- a/src/openpackagedirectory.ts
+++ b/src/openpackagedirectory.ts
@@ -5,6 +5,7 @@ import * as settings from './settings';
 import * as packagepath from './packagepath'
 import * as vslc from 'vscode-languageclient';
 import * as telemetry from './telemetry';
+import { onSetLanguageClient, onDidChangeConfig } from './extension';
 
 let g_context: vscode.ExtensionContext = null;
 let g_settings: settings.ISettings = null;
@@ -13,7 +14,7 @@ let g_languageClient: vslc.LanguageClient = null;
 // This method implements the language-julia.openPackageDirectory command
 async function openPackageDirectoryCommand() {
     telemetry.traceEvent('command-openpackagedirectory');
-    
+
     const optionsPackage: vscode.QuickPickOptions = {
         placeHolder: 'Select package'
     };
@@ -52,13 +53,9 @@ export function activate(context: vscode.ExtensionContext, settings: settings.IS
     g_context = context;
     g_settings = settings;
 
-    context.subscriptions.push(vscode.commands.registerCommand('language-julia.openPackageDirectory', openPackageDirectoryCommand));
-}
-
-export function onDidChangeConfiguration(newSettings: settings.ISettings) {
-
-}
-
-export function onNewLanguageClient(newLanguageClient: vslc.LanguageClient) {
-    g_languageClient = newLanguageClient;
+    context.subscriptions.push(onSetLanguageClient(languageClient => {
+        g_languageClient = languageClient
+    }))
+    context.subscriptions.push(onDidChangeConfig(newSettings => {}))
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.openPackageDirectory', openPackageDirectoryCommand))
 }

--- a/src/packagepath.ts
+++ b/src/packagepath.ts
@@ -6,6 +6,7 @@ import { FILE } from 'dns';
 import { join } from 'path';
 import * as fs from 'async-file';
 import {exec} from 'child-process-promise';
+import { onSetLanguageClient, onDidChangeConfig } from './extension';
 
 let g_context: vscode.ExtensionContext = null;
 let g_settings: settings.ISettings = null;
@@ -34,17 +35,16 @@ export async function getPkgDepotPath() {
     return juliaDepotPath;
 }
 
-export function activate(context: vscode.ExtensionContext, settings: settings.ISettings) {    
+export function activate(context: vscode.ExtensionContext, settings: settings.ISettings) {
     g_context = context;
     g_settings = settings;
-}   
 
-export function onDidChangeConfiguration(newSettings: settings.ISettings) {
-    if (g_settings.juliaExePath != newSettings.juliaExePath) {
-        juliaPackagePath = null;        
-    }
-}
-
-export function onNewLanguageClient(newLanguageClient: vslc.LanguageClient) {
-    g_languageClient = newLanguageClient;
+    context.subscriptions.push(onSetLanguageClient(languageClient => {
+        g_languageClient = languageClient
+    }))
+    context.subscriptions.push(onDidChangeConfig(newSettings => {
+        if (g_settings.juliaExePath != newSettings.juliaExePath) {
+            juliaPackagePath = null;
+        }
+    }))
 }

--- a/src/smallcommands.ts
+++ b/src/smallcommands.ts
@@ -2,6 +2,8 @@ import * as vscode from 'vscode';
 import * as settings from './settings'
 import * as vslc from 'vscode-languageclient';
 import * as telemetry from './telemetry';
+import { onSetLanguageClient, onDidChangeConfig } from './extension';
+import { ContextTagKeys } from 'applicationinsights/out/Declarations/Contracts';
 
 let g_context: vscode.ExtensionContext = null;
 let g_settings: settings.ISettings = null;
@@ -49,14 +51,11 @@ export function activate(context: vscode.ExtensionContext, settings: settings.IS
     g_context = context;
     g_settings = settings;
 
+    context.subscriptions.push(onSetLanguageClient(languageClient => {
+        g_languageClient = languageClient
+    }))
+    context.subscriptions.push(onDidChangeConfig(newSettings => {}))
+
     context.subscriptions.push(vscode.commands.registerCommand('language-julia.applytextedit', applyTextEdit));
     context.subscriptions.push(vscode.commands.registerCommand('language-julia.toggleLinter', toggleLinter));
-}
-
-export function onDidChangeConfiguration(newSettings: settings.ISettings) {
-
-}
-
-export function onNewLanguageClient(newLanguageClient: vslc.LanguageClient) {
-    g_languageClient = newLanguageClient;
 }

--- a/src/smallcommands.ts
+++ b/src/smallcommands.ts
@@ -3,7 +3,6 @@ import * as settings from './settings'
 import * as vslc from 'vscode-languageclient';
 import * as telemetry from './telemetry';
 import { onSetLanguageClient, onDidChangeConfig } from './extension';
-import { ContextTagKeys } from 'applicationinsights/out/Declarations/Contracts';
 
 let g_context: vscode.ExtensionContext = null;
 let g_settings: settings.ISettings = null;

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -7,6 +7,7 @@ import * as juliaexepath from './juliaexepath';
 import * as jlpkgenv from './jlpkgenv';
 import * as telemetry from './telemetry';
 import { inferJuliaNumThreads } from './utils';
+import { onSetLanguageClient, onDidChangeConfig } from './extension';
 
 let g_context: vscode.ExtensionContext = null;
 let g_settings: settings.ISettings = null;
@@ -112,6 +113,11 @@ export function activate(context: vscode.ExtensionContext, settings: settings.IS
     g_context = context;
     g_settings = settings;
 
+    context.subscriptions.push(onSetLanguageClient(languageClient => {
+        g_languageClient = languageClient
+    }))
+    context.subscriptions.push(onDidChangeConfig(newSettings => {}))
+
     taskProvider = vscode.workspace.registerTaskProvider('julia', {
         provideTasks: () => {
             return provideJuliaTasks();
@@ -120,12 +126,4 @@ export function activate(context: vscode.ExtensionContext, settings: settings.IS
             return undefined;
         }
     });
-}
-
-export function onDidChangeConfiguration(newSettings: settings.ISettings) {
-
-}
-
-export function onNewLanguageClient(newLanguageClient: vslc.LanguageClient) {
-    g_languageClient = newLanguageClient;
 }

--- a/src/weave.ts
+++ b/src/weave.ts
@@ -6,6 +6,7 @@ import * as fs from 'async-file';
 import * as settings from './settings'
 import * as juliaexepath from './juliaexepath';
 import * as telemetry from './telemetry';
+import { onSetLanguageClient, onDidChangeConfig } from './extension';
 
 var tempfs = require('promised-temp').track();
 var kill = require('async-child-process').kill;
@@ -167,17 +168,12 @@ export function activate(context: vscode.ExtensionContext, settings: settings.IS
     g_context = context;
     g_settings = settings;
 
+    context.subscriptions.push(onSetLanguageClient(languageClient => {
+        g_languageClient = languageClient
+    }))
+    context.subscriptions.push(onDidChangeConfig(newSettings => {}))
+
     context.subscriptions.push(vscode.commands.registerCommand('language-julia.weave-open-preview', open_preview));
-
     context.subscriptions.push(vscode.commands.registerCommand('language-julia.weave-open-preview-side', open_preview_side));
-
     context.subscriptions.push(vscode.commands.registerCommand('language-julia.weave-save', save));
-}
-
-export function onDidChangeConfiguration(newSettings: settings.ISettings) {
-
-}
-
-export function onNewLanguageClient(newLanguageClient: vslc.LanguageClient) {
-    g_languageClient = newLanguageClient;
 }


### PR DESCRIPTION
- make each sub file listen for those events
- now we don't need to modify extensions.ts when we add another feature
- ~~... and if we start to dispose things, those subscriptions will also just be cleared correctly~~ nvm, vscode will automatically cleans up subscription pushed into `context.subscriptions`, so these will be cleaned up correctly as is