### PR TITLE
Fix how we handle unsupported types for vscodedisplay

### DIFF
--- a/scripts/terminalserver/terminalserver.jl
+++ b/scripts/terminalserver/terminalserver.jl
@@ -208,7 +208,7 @@ function display(d::InlineDisplay, x)
     elseif showable("image/png", x)
         display(d,"image/png", x)
     else
-        @warn "VS Code cannot display this type."
+        throw(MethodError(display,(d,x)))
     end
 end
 
@@ -216,7 +216,15 @@ function _display(d::InlineDisplay, x)
     if showable("application/vnd.dataresource+json", x)
         display(d, "application/vnd.dataresource+json", x)
     else
-        display(d, x)
+        try
+            display(d, x)
+        catch err
+            if err isa MethodError
+                @warn "Cannot display values of type $(typeof(x)) in VS Code."
+            else
+                rethrow(err)
+            end
+        end
     end
 end
 


### PR DESCRIPTION
What I did in https://github.com/julia-vscode/julia-vscode/pull/1258 was wrong, this fixes things.

This is high priority because our current `master` now shows a warning after each eval in the REPL :) It hasn't gone out to the release channel (good), but we need to merge this before we can ship a new version.