### PR TITLE
update ignore settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 *.vsix
-out
-node_modules
-scripts/languageserver/julia_pkgdir/lib/
 .vscode/.browse.VC.db*
-.vscode-test/
-out/scripts/**
-dist/**
+/.vscode-test/
+/node_modules/
+/dist/
+/out/
+/scripts/languageserver/julia_pkgdir/lib/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,15 @@
 // Place your settings in this file to overwrite default and user settings.
 {
+    // tweak these settings to include/exclude folders in explorer or search results
     "files.exclude": {
-        "out": false // set this to true to hide the "out" folder with the compiled JS files
+        "dist": true,
+        "out": true,
+        "libs": true,
     },
     "search.exclude": {
-        "out": true // set this to false to include "out" folder in search results
+        "dist": true,
+        "out": true,
+        "libs": true,
     },
     // we want to use the TS server from our node_modules folder to control its version
     "typescript.tsdk": "./node_modules/typescript/lib",


### PR DESCRIPTION
let's exclude `dist` and `out` from workspace search.