### PR TITLE
Add different cloudRole properties to crash reports

### DIFF
--- a/scripts/debugger/run_debugger.jl
+++ b/scripts/debugger/run_debugger.jl
@@ -7,6 +7,6 @@ let
     try
         VSCodeDebugger.startdebug(pipenames[1])
     catch err
-        VSCodeDebugger.global_err_handler(err, catch_backtrace(), pipenames[2])
+        VSCodeDebugger.global_err_handler(err, catch_backtrace(), pipenames[2], "Debugger")
     end
 end

--- a/scripts/error_handler.jl
+++ b/scripts/error_handler.jl
@@ -1,12 +1,14 @@
 using Sockets
 import InteractiveUtils
 
-function global_err_handler(e, bt, vscode_pipe_name)
+function global_err_handler(e, bt, vscode_pipe_name, cloudRole)
     @warn "Some Julia code in the VS Code extension crashed with" e
 
     st = stacktrace(bt)
     pipe_to_vscode = connect(vscode_pipe_name)
     try
+        # Send cloudRole as one line
+        println(pipe_to_vscode, cloudRole)
         # Send error type as one line
         println(pipe_to_vscode, typeof(e))
 

--- a/scripts/languageserver/main.jl
+++ b/scripts/languageserver/main.jl
@@ -53,10 +53,10 @@ try
         conn,
         Base.ARGS[1],
         Base.ARGS[4],
-        (err, bt)->global_err_handler(err, bt, Base.ARGS[3]),
+        (err, bt)->global_err_handler(err, bt, Base.ARGS[3], "Language Server"),
         symserver_store_path
     )
     run(server)
 catch err
-    global_err_handler(err, catch_backtrace(), Base.ARGS[3])
+    global_err_handler(err, catch_backtrace(), Base.ARGS[3], "Language Server")
 end

--- a/scripts/terminalserver/terminalserver.jl
+++ b/scripts/terminalserver/terminalserver.jl
@@ -89,7 +89,7 @@ run(conn_endpoint)
                 try
                     VSCodeDebugger.startdebug(debug_pipename)
                 catch err
-                    VSCodeDebugger.global_err_handler(err, catch_backtrace(), ARGS[4])
+                    VSCodeDebugger.global_err_handler(err, catch_backtrace(), ARGS[4], "Debugger")
                 end
             end
         end

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -168,7 +168,7 @@ async function startLanguageServer() {
         }
         else if (data.command == 'symserv_crash') {
             telemetry.traceEvent('symservererror');
-            telemetry.handleNewCrashReport(data.name, data.message, data.stacktrace);
+            telemetry.handleNewCrashReport(data.name, data.message, data.stacktrace, 'Symbol Server');
         }
         else if (data.command == 'symserv_pkgload_crash') {
             telemetry.tracePackageLoadError(data.name, data.message)


### PR DESCRIPTION
This segments crash reports into different roles: "Language Server", "Extension", "Symbol Server" and "Debugger". Makes it easier to filter things on Azure.