### PR TITLE
Tweak title for a command

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
             },
             {
                 "command": "language-julia.executeJuliaCodeInREPL",
-                "title": "Julia: Execute Selection"
+                "title": "Julia: Send Current Line or Selection to REPL"
             },
             {
                 "command": "language-julia.executeCodeBlockOrSelectionAndMove",


### PR DESCRIPTION
Small tweak to the description. The idea is that we don't use the work `execute` for the copy-paste situation, to somehow signal that this command is different from our other execute commands.