### PR TITLE
Update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-## 0.15.39
-* Improve cell delimiter regex so that it won't recognize YAS-style section headers as cell separator anymore (#1256, #1259)
+## 0.16
+* Inline display of evaluation results
+* Workspace view
 
 ## 0.15
 * Add an experimental debugger
+* Improve cell delimiter regex so that it won't recognize YAS-style section headers as cell separator anymore (#1256, #1259)
 
 ## 0.14
 * Make Language Server indexing async


### PR DESCRIPTION
I would suggest we only differentiate by minor version, given how often we ship patch versions now, I think it is too cumbersome to list in which patch version exactly something shipped (also, would anyone care?).