### PR TITLE
Ship Revise

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
     "typescript.tsdk": "./node_modules/typescript/lib",
     "git.detectSubmodulesLimit": 20,
     "editor.formatOnPaste": true,
-    "editor.formatOnSave": true,
+    "editor.formatOnSave": false,
     "editor.formatOnType": true,
     "files.trimTrailingWhitespace": true,
     "files.trimFinalNewlines": true,

--- a/package.json
+++ b/package.json
@@ -659,7 +659,7 @@
                 },
                 "julia.useRevise": {
                     "type": "boolean",
-                    "default": true,
+                    "default": false,
                     "description": "Load Revise.jl on startup of the REPL."
                 },
                 "julia.usePlotPane": {

--- a/scripts/packages/VSCodeServer/Project.toml
+++ b/scripts/packages/VSCodeServer/Project.toml
@@ -15,6 +15,9 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+FileWatching = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [compat]
 julia = "1"

--- a/scripts/packages/VSCodeServer/src/eval.jl
+++ b/scripts/packages/VSCodeServer/src/eval.jl
@@ -114,11 +114,10 @@ function repl_runcode_request(conn, params::ReplRunCodeRequestParams)
 
         rendered_result = nothing
         f = () -> hideprompt() do
-            if isdefined(Main, :Revise) && isdefined(Main.Revise, :revise) && Main.Revise.revise isa Function
-                let mode = get(ENV, "JULIA_REVISE", "auto")
-                    mode == "auto" && Main.Revise.revise()
+            if g_use_revise[]
+                Revise.revise()
                 end
-            end
+
             if show_code
                 add_code_to_repl_history(source_code)
 

--- a/scripts/packages/VSCodeServer/src/repl.jl
+++ b/scripts/packages/VSCodeServer/src/repl.jl
@@ -87,6 +87,11 @@ end
 function evalrepl(m, line, repl, main_mode)
     return try
         JSONRPC.send_notification(conn_endpoint[], "repl/starteval", nothing)
+
+        if g_use_revise[]
+            Revise.revise()
+        end
+
         r = run_with_backend() do
             fix_displays()
             f = () -> repleval(m, line, REPL.repl_filename(repl, main_mode.hist))

--- a/scripts/terminalserver/terminalserver.jl
+++ b/scripts/terminalserver/terminalserver.jl
@@ -1,23 +1,15 @@
 # this script basially only handles `ARGS`
 
+ENV["JULIA_REVISE"] = "manual"
+
 pushfirst!(LOAD_PATH, joinpath(@__DIR__, "..", "packages"))
 using VSCodeServer
 popfirst!(LOAD_PATH)
 
 let
     args = [popfirst!(Base.ARGS) for _ in 1:5]
-    # load Revise ?
-    if "USE_REVISE=true" in args
-        try
-            @static if VERSION ≥ v"1.5"
-                using Revise
-            else
-                @eval using Revise
-                Revise.async_steal_repl_backend()
-            end
-        catch err
-        end
-    end
+
+    VSCodeServer.g_use_revise[] = "USE_REVISE=true" in args
 
     atreplinit() do repl
         VSCodeServer.toggle_plot_pane(nothing, (;enable="USE_PLOTPANE=true" in args))

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -68,7 +68,8 @@ async function startREPL(preserveFocus: boolean, showTerminal: boolean = true) {
 
         const env = {
             JULIA_EDITOR: get_editor(),
-            JULIA_NUM_THREADS: inferJuliaNumThreads()
+            JULIA_NUM_THREADS: inferJuliaNumThreads(),
+            JULIA_REVISE: 'manual'
         }
 
         const pkgServer: string = vscode.workspace.getConfiguration('julia').get('packageServer')


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/1091. Fixes #1391.

@timholy: this is roughly how I imagine we would ship Revise with the extension itself.

I think there are a few minor things we would need to work out, but overall I think this is pretty close.

This does require some code moving in Revise.jl, LoweredCodeUtils.jl and JuliaInterpreter.jl, see https://github.com/JuliaDebug/JuliaInterpreter.jl/pull/401, https://github.com/JuliaDebug/LoweredCodeUtils.jl/pull/33 and https://github.com/timholy/Revise.jl/pull/501.

@julia-vscode/core: if we get this ready say by the end of the week, we might even include this in v0.16?