### PR TITLE
improve inline results

### DIFF
--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -336,6 +336,17 @@ async function evaluateBlockOrSelection(shouldMove: boolean = false) {
             editor.revealRange(new vscode.Range(nextBlock, nextBlock))
         }
 
+
+        const tempDecoration = vscode.window.createTextEditorDecorationType({
+            backgroundColor: new vscode.ThemeColor("editor.hoverHighlightBackground"),
+            isWholeLine: true
+        })
+        editor.setDecorations(tempDecoration, [range])
+
+        setTimeout(() => {
+            editor.setDecorations(tempDecoration, [])
+        }, 200)
+
         await evaluate(editor, range, text, module)
     }
 }

--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -11,7 +11,6 @@ export class Result {
     document: vscode.TextDocument
     text: string
     range: vscode.Range
-    decorationRange: vscode.Range
     content: ResultContent
     decoration: vscode.TextEditorDecorationType
     destroyed: boolean
@@ -21,8 +20,6 @@ export class Result {
         this.document = editor.document
         this.text = editor.document.getText(this.range)
         this.destroyed = false
-
-        this.updateDecorationRange()
 
         this.setContent(content)
     }
@@ -69,8 +66,8 @@ export class Result {
         }
     }
 
-    updateDecorationRange() {
-        this.decorationRange = new vscode.Range(this.range.end.translate(0, 9999), this.range.end.translate(0, 9999))
+    get decorationRange(): vscode.Range {
+        return new vscode.Range(this.range.end.translate(0, 9999), this.range.end.translate(0, 9999))
     }
 
     draw() {
@@ -110,8 +107,6 @@ export class Result {
             this.remove()
             return false
         }
-
-        this.updateDecorationRange()
 
         return true
     }

--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -11,20 +11,23 @@ export class Result {
     document: vscode.TextDocument
     text: string
     range: vscode.Range
+    decorationRange: vscode.Range
     content: ResultContent
     decoration: vscode.TextEditorDecorationType
     destroyed: boolean
 
-    constructor (editor: vscode.TextEditor, range: vscode.Range, content: ResultContent) {
+    constructor(editor: vscode.TextEditor, range: vscode.Range, content: ResultContent) {
         this.range = range
         this.document = editor.document
         this.text = editor.document.getText(this.range)
         this.destroyed = false
 
+        this.updateDecorationRange()
+
         this.setContent(content)
     }
 
-    setContent (content: ResultContent) {
+    setContent(content: ResultContent) {
         if (this.destroyed) {
             return
         }
@@ -38,7 +41,7 @@ export class Result {
         const color = new vscode.ThemeColor(content.isError ? 'editorError.foreground' : 'editor.foreground')
 
         let decoration = {
-            after: {
+            before: {
                 contentIconPath: undefined,
                 contentText: undefined,
                 backgroundColor: new vscode.ThemeColor('editorWidget.background'),
@@ -49,9 +52,9 @@ export class Result {
         }
 
         if (content.isIcon) {
-            decoration.after.contentIconPath = content.content
+            decoration.before.contentIconPath = content.content
         } else {
-            decoration.after.contentText = content.content
+            decoration.before.contentText = content.content
         }
 
         this.decoration = vscode.window.createTextEditorDecorationType(decoration)
@@ -60,18 +63,21 @@ export class Result {
             if (ed.document == this.document) {
                 ed.setDecorations(this.decoration, [{
                     hoverMessage: this.content.hoverContent,
-                    range: this.range
+                    range: this.decorationRange
                 }])
             }
         }
-
     }
 
-    draw () {
+    updateDecorationRange() {
+        this.decorationRange = new vscode.Range(this.range.end.translate(0, 9999), this.range.end.translate(0, 9999))
+    }
+
+    draw() {
         this.setContent(this.content)
     }
 
-    validate (e: vscode.TextDocumentChangeEvent) {
+    validate(e: vscode.TextDocumentChangeEvent) {
         if (this.document !== e.document) {
             return true
         }
@@ -86,12 +92,12 @@ export class Result {
 
             if (change.range.end.line < this.range.start.line ||
                 (change.range.end.line === this.range.start.line &&
-                change.range.end.character <= this.range.start.character)) {
+                    change.range.end.character <= this.range.start.character)) {
                 const lines = change.text.split('\n')
 
                 const lineOffset = lines.length - 1 - (change.range.end.line - change.range.start.line)
                 const charOffset = change.range.end.line == this.range.start.line ?
-                                   lines[lines.length - 1].length : 0
+                    lines[lines.length - 1].length : 0
 
                 this.range = new vscode.Range(
                     this.range.start.translate(lineOffset, charOffset),
@@ -105,10 +111,12 @@ export class Result {
             return false
         }
 
+        this.updateDecorationRange()
+
         return true
     }
 
-    remove (destroy: boolean = false) {
+    remove(destroy: boolean = false) {
         this.destroyed = destroy
         for (const ed of vscode.window.visibleTextEditors) {
             ed.setDecorations(this.decoration, [])
@@ -127,9 +135,9 @@ export function activate(context) {
     context.subscriptions.push(vscode.commands.registerCommand('language-julia.clearCurrentInlineResult', () => removeCurrent(vscode.window.activeTextEditor)));
 }
 
-export function deactivate() {}
+export function deactivate() { }
 
-export function addResult (editor: vscode.TextEditor, range: vscode.Range, content: ResultContent) {
+export function addResult(editor: vscode.TextEditor, range: vscode.Range, content: ResultContent) {
     for (let i = results.length - 1; i > -1; i--) {
         const result = results[i]
         if (result.document == editor.document && result.range.intersection(range) !== undefined) {
@@ -153,7 +161,7 @@ export function refreshResults(editors: vscode.TextEditor[]) {
     }
 }
 
-export function validateResults (e: vscode.TextDocumentChangeEvent) {
+export function validateResults(e: vscode.TextDocumentChangeEvent) {
     for (let i = results.length - 1; i > -1; i--) {
         const result = results[i]
         const isvalid = result.validate(e)
@@ -163,7 +171,7 @@ export function validateResults (e: vscode.TextDocumentChangeEvent) {
     }
 }
 
-export function removeResult (result: Result) {
+export function removeResult(result: Result) {
     let index = results.indexOf(result)
 
     if (index > -1) {
@@ -172,7 +180,7 @@ export function removeResult (result: Result) {
     }
 }
 
-export function removeAll (editor: vscode.TextEditor | null = null) {
+export function removeAll(editor: vscode.TextEditor | null = null) {
     for (let i = results.length - 1; i > -1; i--) {
         const result = results[i]
         if (editor === null || result.document === editor.document) {
@@ -181,7 +189,7 @@ export function removeAll (editor: vscode.TextEditor | null = null) {
     }
 }
 
-export function removeCurrent (editor: vscode.TextEditor) {
+export function removeCurrent(editor: vscode.TextEditor) {
     for (const selection of editor.selections) {
         for (let i = results.length - 1; i > -1; i--) {
             const result = results[i]


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6735977/83624956-919d4480-a593-11ea-92a4-4db31bb69c82.png)
![image](https://user-images.githubusercontent.com/6735977/83625366-1ab47b80-a594-11ea-8b00-77f044c4fc3e.png)


Fixes https://github.com/julia-vscode/julia-vscode/issues/1279 (the highlighting happens because of git lens in the first screenshot above).
Also makes our inline results compatible with git lens (as requested by @aviatesk).