### PR TITLE
improve communication

### DIFF
--- a/src/interactive/modules.ts
+++ b/src/interactive/modules.ts
@@ -14,8 +14,8 @@ const isLanguageClientActive = () => g_languageClient !== null
 
 const manuallySetDocuments = []
 
-const requestTypeGetModules = new rpc.RequestType<void, string[], void, void>('repl/loadedModules');
-const requestTypeIsModuleLoaded = new rpc.RequestType<string, boolean, void, void>('repl/isModuleLoaded');
+const requestTypeGetModules = new rpc.RequestType<void, string[], void, void>('rpc/loadedModules');
+const requestTypeIsModuleLoaded = new rpc.RequestType<string, boolean, void, void>('rpc/isModuleLoaded');
 
 const automaticallyChooseOption = 'Choose Automatically'
 

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -149,12 +149,12 @@ const requestTypeReplRunCode = new rpc.RequestType<{
     module: string,
     showCodeInREPL: boolean,
     showResultInREPL: boolean
-}, void, void, void>('repl/runcode');
+}, void, void, void>('rpc/runcode');
 
 const notifyTypeDisplay = new rpc.NotificationType<{ kind: string, data: any }, void>('display');
 const notifyTypeDebuggerEnter = new rpc.NotificationType<string, void>('debugger/enter');
 const notifyTypeDebuggerRun = new rpc.NotificationType<string, void>('debugger/run');
-const notifyTypeReplStartDebugger = new rpc.NotificationType<string, void>('repl/startdebugger');
+const notifyTypeReplStartDebugger = new rpc.NotificationType<string, void>('msg/startdebugger');
 
 const g_onInit = new vscode.EventEmitter<rpc.MessageConnection>()
 export const onInit = g_onInit.event


### PR DESCRIPTION
- add two different handlers, `rpc_handler` returns response, while `msg_handler` not
- simplify core communication handling point using those handlers

things I would like to do:
- [ ] maybe fix `rpc/msg` naming ? they may sound same
- [ ] split terminalserver.jl into multiple subfiles, say, communication.jl, display.jl, evaluation.jl, and misc.jl

---

If we want to merge this, other big PR with new communication methods like #1003 may be better to be merged in advance.

