### PR TITLE
improve render/strlimit etc

### DIFF
--- a/scripts/terminalserver/misc.jl
+++ b/scripts/terminalserver/misc.jl
@@ -1,0 +1,57 @@
+# https://github.com/JuliaDebug/Debugger.jl/blob/4cf99c662ab89da0fe7380c1e81461e2428e8b00/src/limitio.jl
+
+mutable struct LimitIO{IO_t <: IO} <: IO
+    io::IO_t
+    maxbytes::Int
+    n::Int
+end
+LimitIO(io::IO, maxbytes) = LimitIO(io, maxbytes, 0)
+
+struct LimitIOException <: Exception end
+
+function Base.write(io::LimitIO, v::UInt8)
+    io.n > io.maxbytes && throw(LimitIOException())
+    io.n += write(io.io, v)
+end
+
+function sprintlimited(args...; func = show, limit::Int = 30, ellipsis::AbstractString = "…", color = false)
+    io = IOBuffer()
+    ioctx = IOContext(LimitIO(io, limit - length(ellipsis)), :limit => true, :color => color, :displaysize => (30, 64))
+
+    try
+        Base.invokelatest(func, ioctx, args...)
+    catch err
+        if err isa LimitIOException
+            print(io, ellipsis)
+        else
+            rethrow(err)
+        end
+    end
+
+    str = filter(isvalid, String(take!(io)))
+
+    return color ? str : remove_ansi_control_chars(str)
+end
+
+function strlimit(str; limit::Int = 30, ellipsis::AbstractString = "…")
+    will_append = length(str) > limit
+
+    io = IOBuffer()
+    i = 1
+    for c in str
+        will_append && i > limit - length(ellipsis) && break
+        isvalid(c) || continue
+
+        print(io, c)
+        i += 1
+    end
+    will_append && print(io, ellipsis)
+
+    return String(take!(io))
+end
+
+# https://stackoverflow.com/a/33925425/12113178
+
+function remove_ansi_control_chars(str::String)
+    replace(str, r"(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]" => "")
+end

--- a/scripts/terminalserver/terminalserver.jl
+++ b/scripts/terminalserver/terminalserver.jl
@@ -19,6 +19,9 @@ include("misc.jl")
 include("repl.jl")
 include("../debugger/debugger.jl")
 
+const INLINE_RESULT_LENGTH = 100
+const MAX_RESULT_LENGTH = 10_000
+
 function getVariables()
     M = Main
     variables = []
@@ -62,15 +65,15 @@ end
 
 Produce a representation of `x` that can be displayed by a UI. Must return a dictionary with
 the following fields:
-- `inline`: Short one-line plain text representation of `x`. Typically limited to 100 characters.
+- `inline`: Short one-line plain text representation of `x`. Typically limited to `INLINE_RESULT_LENGTH` characters.
 - `all`: Plain text string (that may contain linebreaks and other signficant whitespace) to further describe `x`.
 - `iserr`: Boolean. The frontend may style the UI differently depending on this value.
 """
 function render(x)
-    str = sprintlimited(MIME"text/plain"(), x, limit = 10_000)
+    str = sprintlimited(MIME"text/plain"(), x, limit = MAX_RESULT_LENGTH)
 
     return Dict(
-        "inline" => strlimit(first(split(str, "\n")), limit = 100),
+        "inline" => strlimit(first(split(str, "\n")), limit = INLINE_RESULT_LENGTH),
         "all" => str,
         "iserr" => false
     )
@@ -90,10 +93,10 @@ struct EvalError
 end
 
 function render(err::EvalError)
-    str = sprintlimited(err.err, err.bt, func = Base.display_error, limit = 10_000)
+    str = sprintlimited(err.err, err.bt, func = Base.display_error, limit = MAX_RESULT_LENGTH)
 
     return Dict(
-        "inline" => strlimit(first(split(str, "\n")), limit = 100),
+        "inline" => strlimit(first(split(str, "\n")), limit = INLINE_RESULT_LENGTH),
         "all" => str,
         "iserr" => true
     )

--- a/scripts/terminalserver/terminalserver.jl
+++ b/scripts/terminalserver/terminalserver.jl
@@ -15,6 +15,7 @@ module JSONRPC
     include("../packages/JSONRPC/src/core.jl")
 end
 
+include("misc.jl")
 include("repl.jl")
 include("../debugger/debugger.jl")
 
@@ -31,7 +32,7 @@ function getVariables()
         n_as_string=="@enter" && continue
         startswith(n_as_string, "#") && continue
         t = typeof(x)
-        value_as_string = show_with_strlimit(x)
+        value_as_string = sprintlimited(MIME"text/plain"(), x, limit = 100)
 
         push!(variables, (name=string(n), type=string(t), value=value_as_string))
     end
@@ -56,30 +57,6 @@ function sendDisplayMsg(kind, data)
     JSONRPC.send_notification(conn_endpoint, "display", Dict{String,String}("kind"=>kind, "data"=>data))
 end
 
-function strlimit(str::AbstractString, limit::Int = 30, ellipsis::AbstractString = "…")
-    will_append = length(str) > limit
-
-    io = IOBuffer()
-    i = 1
-    for c in str
-        will_append && i > limit - length(ellipsis) && break
-        isvalid(c) || continue
-
-        print(io, c)
-        i += 1
-    end
-    will_append && print(io, ellipsis)
-
-    return String(take!(io))
-end
-
-# TODO Rewrite this so that we don't allocate any string beyond the result string at all
-function show_with_strlimit(x)
-    str = strlimit(sprint(io -> Base.invokelatest(show, IOContext(io, :limit => true, :color => false, :displaysize => (100, 64)), MIME"text/plain"(), x)), 10_000)
-
-    return str
-end
-
 """
     render(x)
 
@@ -90,10 +67,10 @@ the following fields:
 - `iserr`: Boolean. The frontend may style the UI differently depending on this value.
 """
 function render(x)
-    str = show_with_strlimit(x)
+    str = sprintlimited(MIME"text/plain"(), x, limit = 10_000)
 
     return Dict(
-        "inline" => strlimit(first(split(str, "\n")), 100),
+        "inline" => strlimit(first(split(str, "\n")), limit = 100),
         "all" => str,
         "iserr" => false
     )
@@ -113,10 +90,10 @@ struct EvalError
 end
 
 function render(err::EvalError)
-    str = filter(isvalid, strlimit(sprint(io -> Base.invokelatest(Base.display_error, IOContext(io, :limit => true, :color => false, :displaysize => (100, 64)), err.err, err.bt)), 10_000))
+    str = sprintlimited(err.err, err.bt, func = Base.display_error, limit = 10_000)
 
     return Dict(
-        "inline" => strlimit(first(split(str, "\n")), 100),
+        "inline" => strlimit(first(split(str, "\n")), limit = 100),
         "all" => str,
         "iserr" => true
     )


### PR DESCRIPTION
This makes two improvements to the Julia side of our rendering code (for inline results and the workspace):
- Removes ANSI control chars since we can't handle them.
- Improve performance for expensive (or even non-terminating) `show` methods by returning early once `limit` bytes have been written to the IO.