### PR TITLE
workspace module

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,6 +220,10 @@
             {
                 "command": "language-julia.chooseModule",
                 "title": "Julia: Select Current Module"
+            },
+            {
+                "command": "language-julia.chooseWorkspaceModule",
+                "title": "Julia: Select Workspace Module"
             }
         ],
         "menus": {
@@ -280,7 +284,7 @@
             "view/item/context": [
                 {
                     "command": "language-julia.showInVSCode",
-                    "when": "view == REPLVariables && viewItem == globalvariable",
+                    "when": "view == julia-workspace && viewItem == globalvariable",
                     "group": "inline"
                 }
             ]
@@ -618,16 +622,16 @@
         "viewsContainers": {
             "activitybar": [
                 {
-                    "id": "julia-explorer",
-                    "title": "Julia Explorer",
+                    "id": "julia-workspace",
+                    "title": "Julia Workspace",
                     "icon": "images/julia-dots.svg"
                 }
             ]
         },
         "views": {
-            "julia-explorer": [
+            "julia-workspace": [
                 {
-                    "id": "REPLVariables",
+                    "id": "julia-workspace",
                     "name": "Julia Workspace"
                 }
             ]

--- a/package.json
+++ b/package.json
@@ -223,7 +223,8 @@
             },
             {
                 "command": "language-julia.chooseWorkspaceModule",
-                "title": "Julia: Select Workspace Module"
+                "title": "Julia: Select Workspace Module",
+                "icon": "$(package)"
             }
         ],
         "menus": {
@@ -279,6 +280,13 @@
                 {
                     "when": "false",
                     "command": "language-julia.plotpane-previous"
+                }
+            ],
+            "view/title": [
+                {
+                    "command": "language-julia.chooseWorkspaceModule",
+                    "when": "view == julia-workspace",
+                    "group": "navigation@1"
                 }
             ],
             "view/item/context": [

--- a/src/interactive/modules.ts
+++ b/src/interactive/modules.ts
@@ -106,6 +106,11 @@ async function updateModuleForEditor(editor: vscode.TextEditor) {
 }
 
 export async function selectModule(special = automaticallyChooseOption) {
+    if (!isConnectionActive()) {
+        vscode.window.showInformationMessage('Setting a module requires an active REPL.')
+        return new Promise<string>(resolve => resolve('Main'))
+    }
+
     const possibleModules = await g_connection.sendRequest(requestTypeGetModules, null)
     possibleModules.sort()
     possibleModules.splice(0, 0, special)

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -118,7 +118,6 @@ async function startREPL(preserveFocus: boolean) {
     else {
         g_terminal.show(preserveFocus);
     }
-    workspace.setTerminal(g_terminal)
 }
 
 function debuggerRun(code: string) {
@@ -152,11 +151,6 @@ const requestTypeReplRunCode = new rpc.RequestType<{
     showCodeInREPL: boolean,
     showResultInREPL: boolean
 }, void, void, void>('repl/runcode');
-
-export const requestTypeGetVariables = new rpc.RequestType<
-    void,
-    { name: string, type: string, value: any }[],
-    void, void>('repl/getvariables');
 
 const notifyTypeDisplay = new rpc.NotificationType<{ kind: string, data: any }, void>('display');
 const notifyTypeDebuggerEnter = new rpc.NotificationType<string, void>('debugger/enter');
@@ -242,7 +236,7 @@ async function executeFile(uri?: vscode.Uri) {
         }
     )
 
-    await workspace.updateReplVariables();
+    await workspace.updateWorkspace();
 }
 
 async function selectJuliaBlock() {
@@ -406,7 +400,7 @@ async function evaluate(editor: vscode.TextEditor, range: vscode.Range, text: st
         })
     }
 
-    await workspace.updateReplVariables();
+    await workspace.updateWorkspace();
 }
 
 async function executeCodeCopyPaste(text, individualLine) {
@@ -492,8 +486,7 @@ export function activate(context: vscode.ExtensionContext, settings: settings.IS
 
     vscode.window.onDidCloseTerminal(terminal => {
         if (terminal == g_terminal) {
-            g_terminal = null;
-            workspace.setTerminal(null)
+            g_terminal = null
         }
     })
 


### PR DESCRIPTION
and bunch of improvements:
- show variables correctly (we need `all` option for modules other than `Main`)
- simplify TS code
- update workspace on module selection, REPL init

remaining TODOs:
- [x] add icon for workspace view to toggle workspace module selector
- [ ] fix `show` method -- it currently fails on `show`ing `Enum` and thus we can't get workspace for `Base`, for instance