### PR TITLE
Update recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,8 +3,11 @@
     // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
     // List of extensions which should be recommended for users of this workspace.
     "recommendations": [
-        "dbaeumer.vscode-eslint"
+        "dbaeumer.vscode-eslint",
+        "julialang.language-julia"
     ],
     // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
-    "unwantedRecommendations": []
+    "unwantedRecommendations": [
+        "julialang.language-julia-insider"
+    ]
 }


### PR DESCRIPTION
This adds the Julia extension to the list of recommended extensions, and excludes the insider extension. The latter because the whole debug F5 story of the extension doesn't work very well if the insider edition is installed.