### PR TITLE
fix repl again

### DIFF
--- a/scripts/packages/VSCodeServer/src/VSCodeServer.jl
+++ b/scripts/packages/VSCodeServer/src/VSCodeServer.jl
@@ -490,35 +490,6 @@ function pkgload(pkg)
     end
 end
 
-function hook_repl(repl)
-    if !isdefined(repl, :interface)
-        repl.interface = REPL.setup_interface(repl)
-    end
-    main_mode = get_main_mode(repl)
-
-    main_mode.on_done = REPL.respond(repl, main_mode; pass_empty = false) do line
-
-        x = Base.parse_input_line(line,filename=REPL.repl_filename(repl, main_mode.hist))
-
-        q = quote
-            try
-                try
-                    $(JSONRPC.send_notification)($conn_endpoint[], "repl/starteval", nothing)
-                catch err
-                end
-                $(Main.eval(x))
-            finally
-                try
-                    $(JSONRPC.send_notification)($conn_endpoint[], "repl/finisheval", nothing)
-                catch err
-                end
-            end
-        end
-
-        return q
-    end
-end
-
 function remove_lln!(ex::Expr)
     for i in length(ex.args):-1:1
         if ex.args[i] isa LineNumberNode

--- a/scripts/packages/VSCodeServer/src/VSCodeServer.jl
+++ b/scripts/packages/VSCodeServer/src/VSCodeServer.jl
@@ -256,7 +256,7 @@ function handle_message(; crashreporting_pipename::Union{AbstractString,Nothing}
             withpath(source_filename) do
                 res = try
                     ans = Base.invokelatest(include_string, resolved_mod, '\n'^code_line * ' '^code_column *  source_code, source_filename)
-                    @eval Main ans = $ans
+                    @eval Main ans = $(QuoteNode(ans))
                 catch err
                     EvalError(err, catch_backtrace())
                 end


### PR DESCRIPTION
fixes #1328 by wrapping evaluation in our own functions (i.e. `evalrepl`)
accompanied with:
- cutting off internal calls from stacktrace
- use `include_string` and more graceful stack trace

and I've found the same kind of error can happen for `Main.ans` update, so fixed it as well.
