### PR TITLE
Add telemetry for invalid positions

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -159,7 +159,8 @@ async function startLanguageServer() {
                 const validatedPosition = document.validatePosition(position)
 
                 if (validatedPosition !== position) {
-                    telemetry.traceTrace({ message: `Middleware found a change in position in . Original ${position.line}:${position.character}, validated ${validatedPosition.line}:${validatedPosition.character}`})
+                    telemetry.traceTrace({ message: `Middleware found a change in position in provideCompletionItem. Original ${position.line}:${position.character}, validated ${validatedPosition.line}:${validatedPosition.character}`})
+
                 }
 
                 return await next(document, position, context, token)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -152,7 +152,29 @@ async function startLanguageServer() {
             fileEvents: vscode.workspace.createFileSystemWatcher('**/*.{jl,jmd}')
         },
         revealOutputChannelOn: RevealOutputChannelOn.Never,
-        traceOutputChannel: vscode.window.createOutputChannel('Julia Language Server trace')
+        traceOutputChannel: vscode.window.createOutputChannel('Julia Language Server trace'),
+        middleware: {
+            provideCompletionItem: async (document, position, context, token, next) => {
+
+                const validatedPosition = document.validatePosition(position)
+
+                if (validatedPosition !== position) {
+                    telemetry.traceTrace({ message: `Middleware found a change in position in . Original ${position.line}:${position.character}, validated ${validatedPosition.line}:${validatedPosition.character}`})
+                }
+
+                return await next(document, position, context, token)
+            },
+            provideDefinition: async (document, position, token, next) => {
+
+                const validatedPosition = document.validatePosition(position)
+
+                if (validatedPosition !== position) {
+                    telemetry.traceTrace({ message: `Middleware found a change in position in provideDefinition. Original ${position.line}:${position.character}, validated ${validatedPosition.line}:${validatedPosition.character}` })
+                }
+
+                return await next(document, position, token)
+            }
+        }
     }
 
     // Create the language client and start the client.

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -160,6 +160,10 @@ export function tracePackageLoadError(packagename, message) {
     extensionClient.trackTrace({ message: `Package ${packagename} crashed.\n\n${message}` })
 }
 
+export function traceTrace(msg) {
+    extensionClient.trackTrace(msg)
+}
+
 function sendCrashReportQueue() {
     const own_copy = crashReporterQueue
     crashReporterQueue = []


### PR DESCRIPTION
We have a whole number of crashes in the LS where we think that the client is sending us invalid positions. BUT, we are not sure, it could also be the case that the client is sending us invalid positions and we still have some bug in our document management story that makes the LS crash because we try to apply the positions we get from the client to the wrong doc version.

This PR adds diagnostics that might help us get to the bottom of this. It essentially adds a middle layer between the message communication between the client and the LS, and sends a trace if there is a position requested that is already clearly invalid on the client.

If it turns out that every crash report from an invalid position in the LS is preceded with one of these traces here, then we can rule out that the original bug is in our LS code, and we can just ignore those invalid positions.

I'd like to get this out as part of v0.16 because this has been such an endless story to figure out what is wrong, and this is also one of the bugs that affects a fair number of users.