### PR TITLE
Mark julia.executablePath as machine-overridable

### DIFF
--- a/package.json
+++ b/package.json
@@ -380,7 +380,7 @@
                     "type": "string",
                     "default": "",
                     "description": "Points to the julia executable.",
-                    "scope": "window"
+                    "scope": "machine-overridable"
                 },
                 "julia.lint.run": {
                     "type": "boolean",


### PR DESCRIPTION
I think right now any user settings are automatically also used in a remote setting, which doesn't make sense. I believe that with this change, a user setting wouldn't automatically be used for a remote session, but it would still allow a user to override the setting in a workspace specific setting.

Would fix https://github.com/JuliaLang/julia/pull/36257.