### PR TITLE
Use kwspacing for format option

### DIFF
--- a/package.json
+++ b/package.json
@@ -574,7 +574,7 @@
                     "description": "Ensure single spacing following keywords.",
                     "scope": "window"
                 },
-                "julia.format.kwarg": {
+                "julia.format.kwspacing": {
                     "type": "string",
                     "default": "none",
                     "description": "Format whitespace around function keyword arguments.",


### PR DESCRIPTION
LanguageServer.jl is asking for that name, so without this PR it will never get a value for this config.