### PR TITLE
fix display for zero dimensional array

### DIFF
--- a/scripts/packages/VSCodeServer/src/trees.jl
+++ b/scripts/packages/VSCodeServer/src/trees.jl
@@ -31,6 +31,7 @@ const MAX_PARTITION_LENGTH = 20
 treeid() = (ID[] += 1)
 
 pluralize(n::Int, one, more = one) = string(n, " ", n == 1 ? one : more)
+pluralize(n::Tuple{}, one, more = one) = ""
 pluralize(n, one, more = one) = string(length(n) > 1 ? join(n, '×') : first(n), " ", prod(n) == 1 ? one : more)
 
 function treerender(x::LazyTree)


### PR DESCRIPTION
Without this, the following code errors and in fact hangs all subsequent vscode inline printing:

```julia
struct ZeroDimArray <: AbstractArray{Float64,0} end
Base.size(::ZeroDimArray) = ()
Base.print_array(io::IO, ::ZeroDimArray) = nothing

ZeroDimArray() # displaying this causes error
```

An edge case no-doubt but this is a type of object I actually have, plus it doesn't error in the REPL or Juno. 

This fixes this particular case, but its kind of worrisome that it crashed all subsequent inline printing. Is this a general problem that an error in printing isn't recoverable? (and can that be fixed?) 