### PR TITLE
use vscode-builtin icons

### DIFF
--- a/media/delete-inverse.svg
+++ b/media/delete-inverse.svg
@@ -1,7 +1,0 @@
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#C5C5C5;}
-</style>
-<path class="st0" d="M10,3V2c0-0.6-0.4-1-1-1H6C5.4,1,5,1.4,5,2v1H2v1h1v10c0,0.6,0.4,1,1,1h7c0.6,0,1-0.4,1-1V4h1V3H10z M6,12H5V6
-	h1V12z M6,2h3v1H6V2z M8,12H7V6h1V12z M10,12H9V6h1V12z"/>
-</svg>

--- a/media/delete.svg
+++ b/media/delete.svg
@@ -1,7 +1,0 @@
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#424242;}
-</style>
-<path class="st0" d="M10,3V2c0-0.6-0.4-1-1-1H6C5.4,1,5,1.4,5,2v1H2v1h1v10c0,0.6,0.4,1,1,1h7c0.6,0,1-0.4,1-1V4h1V3H10z M6,12H5V6
-	h1V12z M6,2h3v1H6V2z M8,12H7V6h1V12z M10,12H9V6h1V12z"/>
-</svg>

--- a/media/next-inverse.svg
+++ b/media/next-inverse.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="-1 -3 16 16" enable-background="new -1 -3 16 16"><path fill="#C5C5C5" d="M1 4h7l-3-3h3l4 4-4 4h-3l3-3h-7v-2z"/></svg>

--- a/media/next.svg
+++ b/media/next.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="-1 -3 16 16" enable-background="new -1 -3 16 16"><path fill="#656565" d="M1 4h7l-3-3h3l4 4-4 4h-3l3-3h-7v-2z"/></svg>

--- a/media/previous-inverse.svg
+++ b/media/previous-inverse.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="-1 -3 16 16" enable-background="new -1 -3 16 16"><polygon fill="#C5C5C5" points="13,4 6,4 9,1 6,1 2,5 6,9 9,9 6,6 13,6"/></svg>

--- a/media/previous.svg
+++ b/media/previous.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="-1 -3 16 16" enable-background="new -1 -3 16 16"><polygon fill="#656565" points="13,4 6,4 9,1 6,1 2,5 6,9 9,9 6,6 13,6"/></svg>

--- a/package.json
+++ b/package.json
@@ -155,18 +155,12 @@
             {
                 "command": "language-julia.plotpane-next",
                 "title": "Julia: Show Next Plot",
-                "icon": {
-                    "light": "./media/next.svg",
-                    "dark": "./media/next-inverse.svg"
-                }
+                "icon": "$(arrow-right)"
             },
             {
                 "command": "language-julia.plotpane-previous",
                 "title": "Julia: Show Previous Plot",
-                "icon": {
-                    "light": "./media/previous.svg",
-                    "dark": "./media/previous-inverse.svg"
-                }
+                "icon": "$(arrow-left)"
             },
             {
                 "command": "language-julia.plotpane-first",
@@ -179,10 +173,7 @@
             {
                 "command": "language-julia.plotpane-delete",
                 "title": "Julia: Delete plot",
-                "icon": {
-                    "light": "./media/delete.svg",
-                    "dark": "./media/delete-inverse.svg"
-                }
+                "icon": "$(trash)"
             },
             {
                 "command": "language-julia.plotpane-delete-all",


### PR DESCRIPTION
How about using VSCode's builtin [product icon](https://code.visualstudio.com/api/references/icons-in-labels), which will automatically adjusts to user's theme ?