### PR TITLE
Simplify the search for Julia binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -752,8 +752,7 @@
         "uuidv4": "^6.1.0",
         "vscode-debugadapter": "^1.41.0",
         "vscode-jsonrpc": "^5.0.1",
-        "vscode-languageclient": "^6.1.3",
-        "which": "^1.3.1"
+        "vscode-languageclient": "^6.1.3"
     },
     "devDependencies": {
         "@types/cson-parser": "^4.0.4",


### PR DESCRIPTION
This changes how we search for the Julia binary and hopefully makes it simpler. Highlights:
- we no longer try to find out an absolute path for the Julia binary. If `julia` is enough to start Julia, then we just use that as the binary path. Technical that makes the name of the config setting a misnomer now: it should probably be `juliaCommand` or something like that. But I'd say we just leave as is.
- it reduces the number of times Julia is started during the detection phase, because we no longer start it to get the install path, but only once start it with `--version`. That should speed up this phase quite a bit.
- I think there was a situation in the old code where an exception could leave this part, and I think that explains why we sometimes get these "command not registered" errors: an exception in the detection phase breaks somewhere in `activate`, and not everything actually runs in that function.
- I removed the use of `null` and went back to `undefined`. Two reasons: the MS style guides for TypeScript blanket say one should use `undefined`, not `null`. Also, the various null coalescing operators in TypeScript return `undefined`, so it makes code simpler.
- we no longer need a dep on the `which` package.