### PR TITLE
Settings - resouce scope for formatting options

### DIFF
--- a/package.json
+++ b/package.json
@@ -509,61 +509,61 @@
                     "type": "integer",
                     "default": 4,
                     "description": "Indent size for formatting.",
-                    "scope": "window"
+                    "scope": "resource"
                 },
                 "julia.format.indents": {
                     "type": "boolean",
                     "default": true,
                     "description": "Format file indents.",
-                    "scope": "window"
+                    "scope": "resource"
                 },
                 "julia.format.ops": {
                     "type": "boolean",
                     "default": true,
                     "description": "Format whitespace around operators.",
-                    "scope": "window"
+                    "scope": "resource"
                 },
                 "julia.format.tuples": {
                     "type": "boolean",
                     "default": true,
                     "description": "Format tuples.",
-                    "scope": "window"
+                    "scope": "resource"
                 },
                 "julia.format.curly": {
                     "type": "boolean",
                     "default": true,
                     "description": "Format braces.",
-                    "scope": "window"
+                    "scope": "resource"
                 },
                 "julia.format.calls": {
                     "type": "boolean",
                     "default": true,
                     "description": "Format function calls.",
-                    "scope": "window"
+                    "scope": "resource"
                 },
                 "julia.format.iterOps": {
                     "type": "boolean",
                     "default": true,
                     "description": "Format loop iterators.",
-                    "scope": "window"
+                    "scope": "resource"
                 },
                 "julia.format.comments": {
                     "type": "boolean",
                     "default": true,
                     "description": "Format comments.",
-                    "scope": "window"
+                    "scope": "resource"
                 },
                 "julia.format.docs": {
                     "type": "boolean",
                     "default": true,
                     "description": "Format inline documentation.",
-                    "scope": "window"
+                    "scope": "resource"
                 },
                 "julia.format.keywords": {
                     "type": "bool",
                     "default": true,
                     "description": "Ensure single spacing following keywords.",
-                    "scope": "window"
+                    "scope": "resource"
                 },
                 "julia.format.kwarg": {
                     "type": "string",
@@ -574,7 +574,7 @@
                         "single",
                         "off"
                     ],
-                    "scope": "window"
+                    "scope": "resource"
                 },
                 "julia.execution.resultType": {
                     "type": "string",


### PR DESCRIPTION
This changes the `"scope"` of formatting options from `"window"` to `"resource"`.

This means that repositories can _fix these settings for a repository_ by saving these settings inside `[git-root]/.vscode/settings` (normally done through UI, see screenshot). This helps open source: people who contribute to a project can call `Julia extension -> Format` on code they write, and it will match the maintainers' preferred style (and not modify other parts of the document).

(I learned about these values from [prettier-vscode](https://github.com/prettier/prettier-vscode/blob/v5.1.0/package.json#L188-L319))

Screenshot showing that these settings are currently not available at the folder/repository level:
![image](https://user-images.githubusercontent.com/6933510/85186879-d2879f80-b29b-11ea-80fd-e0e9687711e2.png)
