### PR TITLE
Guard against user exceptions and world age errors

### DIFF
--- a/scripts/packages/VSCodeServer/src/trees.jl
+++ b/scripts/packages/VSCodeServer/src/trees.jl
@@ -122,9 +122,21 @@ function treerender(x::Module)
 end
 
 function treerender(x::AbstractArray{T,N}) where {T,N}
-    treerender(LazyTree(string(typeof(x), " with $(pluralize(size(x), "element", "elements"))"), wsicon(x), length(x) == 0, function ()
-        if length(x) > MAX_PARTITION_LENGTH
-            partition_by_keys(x, sz = MAX_PARTITION_LENGTH)
+    size_of_x = try
+        Base.invokelatest(size, x)
+    catch err
+        # TODO Gracefully handle this error in user code
+    end
+
+    length_of_x = try
+        Base.invokelatest(length, x)
+    catch err
+        # TODO Gracefully handle this error in user code
+    end
+
+    treerender(LazyTree(string(typeof(x), " with $(pluralize(size_of_x, "element", "elements"))"), wsicon(x), length_of_x == 0, function ()
+        if length_of_x > MAX_PARTITION_LENGTH
+            partition_by_keys(x, sz=MAX_PARTITION_LENGTH)
         else
             [SubTree(repr(k), wsicon(v), v) for (k, v) in zip(keys(x), vec(x))]
         end


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/1338.

@aviatesk I think this is the kind of code pattern we should use to a) guard against errors in user code and b) solve our world age error problems. I _do_ think we need these very narrow `try catch` blocks no matter what to harden the REPL server against errors in user code. And I think these `try catch` blocks should be as narrow as in this example, so that they _really_ only catch errors in user code, but not errors in our code. If we do that already, we might as well put the `invokelatest` call at that location as well, right?

Unclear to me what the correct response here is if we end up in the `catch` block. Show some error node in the tree, probably?