### PR TITLE
Rename DebugAdapter2 to DebugAdapter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -38,5 +38,5 @@
 	path = scripts/packages/JSONRPC
 	url = https://github.com/julia-vscode/JSONRPC.jl.git
 [submodule "scripts/packages/DebugAdapter"]
-	path = scripts/packages/DebugAdapter2
+	path = scripts/packages/DebugAdapter
 	url = https://github.com/julia-vscode/DebugAdapter.jl.git

--- a/scripts/packages/VSCodeDebugger/src/VSCodeDebugger.jl
+++ b/scripts/packages/VSCodeDebugger/src/VSCodeDebugger.jl
@@ -26,7 +26,7 @@ module DebugAdapter
     import ..JSONRPC
     import ..JSONRPC: @dict_readable, Outbound
 
-    include("../../DebugAdapter2/src/packagedef.jl")
+    include("../../DebugAdapter/src/packagedef.jl")
 end
 
 function startdebugger()

--- a/scripts/packages/VSCodeServer/src/VSCodeServer.jl
+++ b/scripts/packages/VSCodeServer/src/VSCodeServer.jl
@@ -40,7 +40,7 @@ module DebugAdapter
     import ..JSONRPC
     import ..JSONRPC: @dict_readable, Outbound
 
-    include("../../DebugAdapter2/src/packagedef.jl")
+    include("../../DebugAdapter/src/packagedef.jl")
 end
 
 const conn_endpoint = Ref{Union{Nothing,JSONRPC.JSONRPCEndpoint}}(nothing)

--- a/src/scripts/updateDeps.ts
+++ b/src/scripts/updateDeps.ts
@@ -59,7 +59,7 @@ async function main() {
 
     await download_and_convert_grammar(juliaPath)
 
-    for (const pkg of ['JSONRPC', 'CSTParser', 'LanguageServer', 'DocumentFormat', 'StaticLint', 'SymbolServer', 'DebugAdapter2']) {
+    for (const pkg of ['JSONRPC', 'CSTParser', 'LanguageServer', 'DocumentFormat', 'StaticLint', 'SymbolServer', 'DebugAdapter']) {
         await cp.exec('git checkout master', { cwd: path.join(process.cwd(), `scripts/packages/${pkg}`) })
         await cp.exec('git pull', { cwd: path.join(process.cwd(), `scripts/packages/${pkg}`) })
     }


### PR DESCRIPTION
I used `DebugAdapter2` because otherwise it got difficult to switch between branches. Now that things are merged, this should be renamed back to the proper name.

I'm going to merge this without review: if something goes wrong, we'll know immediately, and this is one of those PRs that are painful to have hanging around, because of submodule updates.