### PR TITLE
improve result interaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -298,7 +298,7 @@
             },
             {
                 "command": "language-julia.clearCurrentInlineResult",
-                "key": "Escape",
+                "key": "Ctrl+I Ctrl+D",
                 "when": "editorTextFocus && !editorHasSelection && !findWidgetVisible && !markerNavigationVisible && !parameterHintsVisible && !inSnippetMode && !isInEmbeddedEditor && !suggestWidgetVisible && !onTypeRenameInputVisible && !renameInputVisible && editorLangId == julia && juliaHasInlineResult"
             },
             {

--- a/package.json
+++ b/package.json
@@ -240,6 +240,10 @@
                 {
                     "when": "jlplotpaneFocus",
                     "command": "language-julia.plotpane-delete-all"
+                },
+                {
+                    "when": "editorLangId == julia",
+                    "command": "language-julia.clearAllInlineResultsInEditor"
                 }
             ],
             "commandPalette": [
@@ -294,8 +298,8 @@
             },
             {
                 "command": "language-julia.clearCurrentInlineResult",
-                "key": "Ctrl+I Ctrl+D",
-                "when": "editorTextFocus && editorLangId == julia"
+                "key": "Escape",
+                "when": "editorTextFocus && editorLangId == julia && juliaHasInlineResult"
             },
             {
                 "command": "language-julia.clearAllInlineResultsInEditor",

--- a/package.json
+++ b/package.json
@@ -299,7 +299,7 @@
             {
                 "command": "language-julia.clearCurrentInlineResult",
                 "key": "Escape",
-                "when": "editorTextFocus && editorLangId == julia && juliaHasInlineResult"
+                "when": "editorTextFocus && !editorHasSelection && !findWidgetVisible && !markerNavigationVisible && !parameterHintsVisible && !inSnippetMode && !isInEmbeddedEditor && !suggestWidgetVisible && !onTypeRenameInputVisible && !renameInputVisible && editorLangId == julia && juliaHasInlineResult"
             },
             {
                 "command": "language-julia.clearAllInlineResultsInEditor",

--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -195,9 +195,26 @@ export function activate(context) {
             gotoNextFrame(frameArg.frame)
         }),
         vscode.commands.registerCommand('language-julia.gotoLastFrame', gotoLastFrame),
-        vscode.commands.registerCommand('language-julia.clearStackTrace', clearStackTrace)
+        vscode.commands.registerCommand('language-julia.clearStackTrace', clearStackTrace),
+        vscode.window.onDidChangeTextEditorSelection(changeEvent => updateResultContextKey(changeEvent))
     )
 }
+
+function updateResultContextKey(changeEvent: vscode.TextEditorSelectionChangeEvent) {
+    if (changeEvent.textEditor.document.languageId !== 'julia') {
+        return
+    }
+    for (const selection of changeEvent.selections) {
+        for (const r of results) {
+            if (isResultInLineRange(changeEvent.textEditor, r, selection)) {
+                vscode.commands.executeCommand('setContext', 'juliaHasInlineResult', true)
+                return
+            }
+        }
+    }
+    vscode.commands.executeCommand('setContext', 'juliaHasInlineResult', false)
+}
+
 
 export function deactivate() { }
 
@@ -351,12 +368,16 @@ export function removeAll(editor: vscode.TextEditor | null = null) {
 
 export function removeCurrent(editor: vscode.TextEditor) {
     editor.selections.forEach(selection => {
-        const isvalid = (result: Result) => {
-            const intersect = selection.intersection(result.range)
-            return result.document === editor.document && intersect !== undefined
-        }
-        results.filter(isvalid).forEach(removeResult)
+        results.filter(r => isResultInLineRange(editor, r, selection)).forEach(removeResult)
     })
+}
+
+function isResultInLineRange(editor: vscode.TextEditor, result: Result, range: vscode.Selection | vscode.Range) {
+    const intersect = range.intersection(result.range)
+    const lineRange = new vscode.Range(range.start.with(undefined, 0), editor.document.validatePosition(range.start.with(undefined, LINE_INF)))
+    const lineIntersect = lineRange.intersection(result.range)
+    console.log(result.document === editor.document, intersect, lineIntersect)
+    return result.document === editor.document && (intersect !== undefined || lineIntersect !== undefined)
 }
 
 // goto frame utilties

--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -178,6 +178,7 @@ export function activate(context) {
         // subscriptions
         vscode.workspace.onDidChangeTextDocument((e) => validateResults(e)),
         vscode.window.onDidChangeVisibleTextEditors((editors) => refreshResults(editors)),
+        vscode.window.onDidChangeTextEditorSelection(changeEvent => updateResultContextKey(changeEvent)),
 
         // public commands
         vscode.commands.registerCommand('language-julia.clearAllInlineResults', removeAll),
@@ -196,8 +197,7 @@ export function activate(context) {
             gotoNextFrame(frameArg.frame)
         }),
         vscode.commands.registerCommand('language-julia.gotoLastFrame', gotoLastFrame),
-        vscode.commands.registerCommand('language-julia.clearStackTrace', clearStackTrace),
-        vscode.window.onDidChangeTextEditorSelection(changeEvent => updateResultContextKey(changeEvent))
+        vscode.commands.registerCommand('language-julia.clearStackTrace', clearStackTrace)
     )
 }
 

--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode'
+import { setContext } from '../utils'
 
 const LINE_INF = 9999
 
@@ -207,12 +208,12 @@ function updateResultContextKey(changeEvent: vscode.TextEditorSelectionChangeEve
     for (const selection of changeEvent.selections) {
         for (const r of results) {
             if (isResultInLineRange(changeEvent.textEditor, r, selection)) {
-                vscode.commands.executeCommand('setContext', 'juliaHasInlineResult', true)
+                setContext('juliaHasInlineResult', true)
                 return
             }
         }
     }
-    vscode.commands.executeCommand('setContext', 'juliaHasInlineResult', false)
+    setContext('juliaHasInlineResult', false)
 }
 
 
@@ -370,7 +371,7 @@ export function removeCurrent(editor: vscode.TextEditor) {
     editor.selections.forEach(selection => {
         results.filter(r => isResultInLineRange(editor, r, selection)).forEach(removeResult)
     })
-    vscode.commands.executeCommand('setContext', 'juliaHasInlineResult', false)
+    setContext('juliaHasInlineResult', false)
 }
 
 function isResultInLineRange(editor: vscode.TextEditor, result: Result, range: vscode.Selection | vscode.Range) {

--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -370,6 +370,7 @@ export function removeCurrent(editor: vscode.TextEditor) {
     editor.selections.forEach(selection => {
         results.filter(r => isResultInLineRange(editor, r, selection)).forEach(removeResult)
     })
+    vscode.commands.executeCommand('setContext', 'juliaHasInlineResult', false)
 }
 
 function isResultInLineRange(editor: vscode.TextEditor, result: Result, range: vscode.Selection | vscode.Range) {

--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -374,11 +374,12 @@ export function removeCurrent(editor: vscode.TextEditor) {
 }
 
 function isResultInLineRange(editor: vscode.TextEditor, result: Result, range: vscode.Selection | vscode.Range) {
+    if (result.document !== editor.document) { return false }
     const intersect = range.intersection(result.range)
     const lineRange = new vscode.Range(range.start.with(undefined, 0), editor.document.validatePosition(range.start.with(undefined, LINE_INF)))
     const lineIntersect = lineRange.intersection(result.range)
     console.log(result.document === editor.document, intersect, lineIntersect)
-    return result.document === editor.document && (intersect !== undefined || lineIntersect !== undefined)
+    return intersect !== undefined || lineIntersect !== undefined
 }
 
 // goto frame utilties

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,10 @@ import * as os from 'os'
 import * as path from 'path'
 import * as vscode from 'vscode'
 
+export function setContext(contextKey: string, state: boolean) {
+    vscode.commands.executeCommand('setContext', contextKey, state)
+}
+
 export function generatePipeName(pid: string, name: string) {
     if (process.platform === 'win32') {
         return '\\\\.\\pipe\\' + name + '-' + pid


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/1396.

Adds the `Clear Inline Results in Editor` command to the text editor title context menu:
![image](https://user-images.githubusercontent.com/6735977/85999288-2b79d500-ba0c-11ea-97b2-44851faf3be9.png)

Also uses `Escape` for clearing the current inline result (without messing with other keybindings too much) *and* improves the removal logic a bit.