### PR TITLE
Replace isnothing with comparison

### DIFF
--- a/scripts/packages/VSCodeServer/src/misc.jl
+++ b/scripts/packages/VSCodeServer/src/misc.jl
@@ -7,7 +7,7 @@ function find_frame_index(bt::Vector{<:Union{Base.InterpreterIP,Ptr{Cvoid}}}, fi
     for (i, ip) in enumerate(bt)
         st = Base.StackTraces.lookup(ip)
         ind = find_frame_index(st, file, func)
-        isnothing(ind) || return i
+        ind===nothing || return i
     end
     return
 end


### PR DESCRIPTION
Fixes a crash reporting bug: `isnothing` doesn't exist on Julia 1.0.