### PR TITLE
add clear inline results buttons

### DIFF
--- a/scripts/packages/VSCodeServer/src/eval.jl
+++ b/scripts/packages/VSCodeServer/src/eval.jl
@@ -67,6 +67,7 @@ function repl_runcode_request(conn, params::ReplRunCodeRequestParams)
             end
 
             rendered_result = safe_render(res)
+            add_clear_cmds!(rendered_result, source_filename, code_line)
         end
     end
     return rendered_result
@@ -174,4 +175,12 @@ function backtrace_string(bt)
         linktitle = string("Go to ", linktext)
         return "$(i-1). `$(m[:body])` at [$(linktext)]($(linkbody) \"$(linktitle)\")"
     end |> joinlines
+end
+
+function add_clear_cmds!(res, path, line)
+    linewise_cmd = vscode_cmd_uri("language-julia.clearAtLine"; path = path, line = line)
+    linewise_link = "[`x`]($(linewise_cmd) \"Remove this inline result\")"
+    editorwise_cmd = vscode_cmd_uri("language-julia.clearInEditor"; path = path)
+    editorwise_link = "[`\u20E0`]($(editorwise_cmd) \"Remove inline results in this editor\")"
+    res.all = string(join((linewise_link, editorwise_link), " "), '\n', res.all)
 end

--- a/scripts/packages/VSCodeServer/src/repl_protocol.jl
+++ b/scripts/packages/VSCodeServer/src/repl_protocol.jl
@@ -14,7 +14,7 @@ struct Frame
 end
 Frame(st::Base.StackFrame) = Frame(fullpath(string(st.file)), st.line)
 
-JSONRPC.@dict_readable struct ReplRunCodeRequestReturn <: JSONRPC.Outbound
+JSONRPC.@dict_readable mutable struct ReplRunCodeRequestReturn <: JSONRPC.Outbound
     inline::String
     all::String
     stackframe::Union{Nothing,Vector{Frame}}

--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -197,7 +197,13 @@ export function activate(context: vscode.ExtensionContext) {
             gotoNextFrame(frameArg.frame)
         }),
         vscode.commands.registerCommand('language-julia.gotoLastFrame', gotoLastFrame),
-        vscode.commands.registerCommand('language-julia.clearStackTrace', clearStackTrace)
+        vscode.commands.registerCommand('language-julia.clearAtLine', (arg: { path: string, line: number }) => {
+            removeAtLine(arg.path, arg.line)
+        }),
+        vscode.commands.registerCommand('language-julia.clearInEditor', (arg: { path: string }) => {
+            removeAllInEditorFromPath(arg.path)
+        }),
+        vscode.commands.registerCommand('language-julia.clearStackTrace', clearStackTrace),
     )
 }
 
@@ -379,6 +385,19 @@ export function removeCurrent(editor: vscode.TextEditor) {
         results.filter(r => isResultInLineRange(editor, r, selection)).forEach(removeResult)
     })
     setContext('juliaHasInlineResult', false)
+}
+
+function removeAtLine(path: string, line: number) {
+    const range = new vscode.Range(new vscode.Position(line, 0), new vscode.Position(line, LINE_INF))
+    vscode.window.visibleTextEditors.filter(editor => isEditorPath(editor, path)).forEach(editor => {
+        results.filter(result => isResultInLineRange(editor, result, range)).forEach(removeResult)
+    })
+}
+
+function removeAllInEditorFromPath(path: string) {
+    vscode.window.visibleTextEditors.filter(editor => isEditorPath(editor, path)).forEach(editor => {
+        removeAll(editor)
+    })
 }
 
 function isResultInLineRange(editor: vscode.TextEditor, result: Result, range: vscode.Selection | vscode.Range) {


### PR DESCRIPTION
adds "clear inline results" utility buttons in each result hover:
- linewise clear
- editorwise clear

<img width="657" alt="Screen Shot 2020-06-30 at 13 29 50" src="https://user-images.githubusercontent.com/40514306/86083654-d73b2780-bad5-11ea-8a96-112f0b8be923.png">

May look verbose, so not sure we really like this.
