### PR TITLE
rendering improvement

### DIFF
--- a/scripts/packages/VSCodeServer/src/eval.jl
+++ b/scripts/packages/VSCodeServer/src/eval.jl
@@ -115,7 +115,8 @@ end
 
 render(::Nothing) = ReplRunCodeRequestReturn("✓", codeblock("nothing"))
 
-codeblock(s) = string("```julia", '\n', s, '\n', "```")
+indent4(s) = string(' ' ^ 4, s)
+codeblock(s) = joinlines(indent4.(splitlines(s)))
 
 struct EvalError
     err
@@ -133,7 +134,7 @@ function render(err::EvalError)
 
     errstr = sprint_error(err.err)
     inline = strlimit(first(split(errstr, "\n")), limit = INLINE_RESULT_LENGTH)
-    all = string(codeblock(errstr), '\n', backtrace_string(bt))
+    all = string('\n', codeblock(errstr), '\n', backtrace_string(bt))
 
     # handle duplicates e.g. from recursion
     st = unique!(stacktrace(bt))

--- a/scripts/packages/VSCodeServer/src/misc.jl
+++ b/scripts/packages/VSCodeServer/src/misc.jl
@@ -101,6 +101,7 @@ function ends_with_semicolon(x)
     return REPL.ends_with_semicolon(split(x, '\n', keepempty=false)[end])
 end
 
+const splitlines = Base.Fix2(split, '\n')
 const joinlines = Base.Fix2(join, '\n')
 
 

--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -85,7 +85,7 @@ export class Result {
 
     createResultDecoration(): vscode.DecorationRenderOptions {
 
-        const border = this.content.isError ? '1px solid #ff000044' : undefined
+        const borderColor = this.content.isError ? '#d11111' : '#159eed'
         return {
             before: {
                 contentIconPath: undefined,
@@ -93,8 +93,8 @@ export class Result {
                 color: new vscode.ThemeColor('editor.foreground'),
                 backgroundColor: '#ffffff22',
                 margin: '0 0 0 10px',
-                textDecoration: 'none; white-space: pre', // HACK sneak in the whitespace styling
-                border
+                // HACK: CSS injection to get custom styling in:
+                textDecoration: `none; white-space: pre; border-left: 2px ${borderColor} solid; border-radius: 2px`
             },
             dark: {
                 before: {

--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -93,6 +93,7 @@ export class Result {
                 color: new vscode.ThemeColor('editor.foreground'),
                 backgroundColor: '#ffffff22',
                 margin: '0 0 0 10px',
+                textDecoration: 'none; white-space: pre', // HACK sneak in the whitespace styling
                 border
             },
             dark: {


### PR DESCRIPTION
1. indent hover content instead of enclosing by code block

```julia
using Markdown
md = @doc sin
md.content # <- hover over this would look weird without this PR
```

2. preserve whitespaces in inline result

```julia
"       " # <- inline result will only show one-whitespace without this PR
```