### PR TITLE
Add run and debug button and move code around

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
         "onCommand:language-julia.executeJuliaBlockInREPL",
         "onCommand:language-julia.selectBlock",
         "onCommand:language-julia.debug.getActiveJuliaEnvironment",
+        "onCommand:language-julia.debugEditorContents",
+        "onCommand:language-julia.runEditorContents",
         "onLanguage:julia",
         "onLanguage:juliamarkdown",
         "workspaceContains:deps/build.jl",
@@ -211,6 +213,16 @@
             {
                 "command": "language-julia.chooseModule",
                 "title": "Julia: Select Current Module"
+            },
+            {
+                "command": "language-julia.debugEditorContents",
+                "title": "Debug Julia File",
+                "icon": "$(debug-alt)"
+            },
+            {
+                "command": "language-julia.runEditorContents",
+                "title": "Run Julia File",
+                "icon": "$(play)"
             }
         ],
         "menus": {
@@ -240,6 +252,16 @@
                 {
                     "when": "jlplotpaneFocus",
                     "command": "language-julia.plotpane-delete-all"
+                },
+                {
+                    "command": "language-julia.runEditorContents",
+                    "when": "resourceLangId == julia",
+                    "group": "navigation@1"
+                },
+                {
+                    "command": "language-julia.debugEditorContents",
+                    "when": "resourceLangId == julia",
+                    "group": "navigation@2"
                 }
             ],
             "commandPalette": [

--- a/src/debugger/debugFeature.ts
+++ b/src/debugger/debugFeature.ts
@@ -1,0 +1,101 @@
+import * as vscode from 'vscode'
+import { getEnvPath } from '../jlpkgenv'
+import { getJuliaExePath } from '../juliaexepath'
+import { JuliaDebugSession } from './juliaDebug'
+
+export class JuliaDebugFeature {
+    constructor(private context: vscode.ExtensionContext) {
+        const provider = new JuliaDebugConfigurationProvider()
+        const factory = new InlineDebugAdapterFactory(this.context)
+
+        this.context.subscriptions.push(
+            vscode.debug.registerDebugConfigurationProvider('julia', provider),
+            vscode.debug.registerDebugAdapterDescriptorFactory('julia', factory),
+            vscode.commands.registerCommand('language-julia.debug.getActiveJuliaEnvironment', async config => {
+                const pkgenvpath = await getEnvPath()
+                return pkgenvpath
+            }),
+            vscode.commands.registerCommand('language-julia.runEditorContents', (resource: vscode.Uri) => {
+                vscode.debug.startDebugging(undefined, {
+                    type: 'julia',
+                    name: 'Run Editor Contents',
+                    request: 'launch',
+                    program: resource.fsPath,
+                    noDebug: true
+                },/* upcoming proposed API:
+				{
+					noDebug: true
+				}
+			*/)
+            }),
+            vscode.commands.registerCommand('language-julia.debugEditorContents', (resource: vscode.Uri) => {
+                vscode.debug.startDebugging(undefined, {
+                    type: 'julia',
+                    name: 'Debug Editor Contents',
+                    request: 'launch',
+                    program: resource.fsPath
+                })
+            })
+        )
+    }
+
+    public dispose() { }
+}
+
+export class JuliaDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
+
+    public resolveDebugConfiguration(
+        folder: vscode.WorkspaceFolder | undefined,
+        config: vscode.DebugConfiguration,
+        token?: vscode.CancellationToken,
+    ): vscode.ProviderResult<vscode.DebugConfiguration> {
+
+        return (async () => {
+            if (!config.request) {
+                config.request = 'launch'
+            }
+
+            if (!config.type) {
+                config.type = 'julia'
+            }
+
+            if (!config.name) {
+                config.name = 'Launch Julia'
+            }
+
+            if (!config.program && config.request !== 'attach') {
+                config.program = vscode.window.activeTextEditor.document.fileName
+            }
+
+            if (!config.internalConsoleOptions) {
+                config.internalConsoleOptions = 'neverOpen'
+            }
+
+            if (!config.stopOnEntry) {
+                config.stopOnEntry = false
+            }
+
+            if (!config.cwd && config.request !== 'attach') {
+                config.cwd = '${workspaceFolder}'
+            }
+
+            if (!config.juliaEnv && config.request !== 'attach') {
+                config.juliaEnv = '${command:activeJuliaEnvironment}'
+            }
+
+            return config
+        })()
+    }
+
+}
+
+class InlineDebugAdapterFactory implements vscode.DebugAdapterDescriptorFactory {
+
+    constructor(private context: vscode.ExtensionContext) { }
+
+    createDebugAdapterDescriptor(_session: vscode.DebugSession): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+        return (async () => {
+            return new vscode.DebugAdapterInlineImplementation(<any>new JuliaDebugSession(this.context, await getJuliaExePath()))
+        })()
+    }
+}


### PR DESCRIPTION
Implements an [upcoming recommendation](https://github.com/microsoft/vscode-docs/blob/vnext/release-notes/v1_47.md#single-file-debugging).

Also moves all the debugger code out of the `extension.ts` file and into a class.