### PR TITLE
few more cleanups against #1458

### DIFF
--- a/src/docbrowser/documentation.ts
+++ b/src/docbrowser/documentation.ts
@@ -84,6 +84,7 @@ function showDocumentationPane() {
                 enableFindWidget: true,
                 // retainContextWhenHidden: true, // comment in if loading is slow, while there would be high memory overhead
                 enableScripts: true,
+                enableCommandUris: true
             }
         )
 

--- a/src/docbrowser/documentation.ts
+++ b/src/docbrowser/documentation.ts
@@ -84,7 +84,6 @@ function showDocumentationPane() {
                 enableFindWidget: true,
                 // retainContextWhenHidden: true, // comment in if loading is slow, while there would be high memory overhead
                 enableScripts: true,
-                enableCommandUris: true
             }
         )
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
         "target": "es6",
         "outDir": "out",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "sourceMap": true,
         "rootDir": "src",


### PR DESCRIPTION
A few improvements against #1458 
- add `dom` library for TS compile, which will make CI pass again
- ~disable no-longer needed command URI option~ nvm: we will use this in the future for handling links, etc
- simplify the get/set documentation logic
- handle "no-editor" case
