### PR TITLE
Put the run and debug button in proper nav group

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "preview": false,
     "publisher": "julialang",
     "engines": {
-        "vscode": "^1.43.0"
+        "vscode": "^1.47.0"
     },
     "license": "SEE LICENSE IN LICENSE",
     "bugs": {
@@ -256,12 +256,12 @@
                 {
                     "command": "language-julia.runEditorContents",
                     "when": "resourceLangId == julia",
-                    "group": "navigation@1"
+                    "group": "1_run@10"
                 },
                 {
                     "command": "language-julia.debugEditorContents",
                     "when": "resourceLangId == julia",
-                    "group": "navigation@2"
+                    "group": "1_run@20"
                 },
                 {
                     "command": "language-julia.clearAllInlineResultsInEditor",


### PR DESCRIPTION
This is where they belong, but we needed to wait until the release of VS Code 1.47, where this starts to be supported.