### PR TITLE
Handle errors in julia binary search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1436,6 +1436,16 @@
             "requires": {
                 "lru-cache": "^4.0.1",
                 "which": "^1.2.9"
+            },
+            "dependencies": {
+                "which": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
             }
         },
         "crypto-browserify": {
@@ -2745,6 +2755,17 @@
                         "ini": "^1.3.5",
                         "kind-of": "^6.0.2",
                         "which": "^1.3.1"
+                    },
+                    "dependencies": {
+                        "which": {
+                            "version": "1.3.1",
+                            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+                            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+                            "dev": true,
+                            "requires": {
+                                "isexe": "^2.0.0"
+                            }
+                        }
                     }
                 }
             }
@@ -2760,6 +2781,17 @@
                 "ini": "^1.3.4",
                 "is-windows": "^1.0.1",
                 "which": "^1.2.14"
+            },
+            "dependencies": {
+                "which": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
             }
         },
         "globals": {
@@ -3859,6 +3891,15 @@
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
                     "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
                     "dev": true
+                },
+                "which": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
                 }
             }
         },
@@ -6711,6 +6752,17 @@
                         "semver": "^5.5.0",
                         "shebang-command": "^1.2.0",
                         "which": "^1.2.9"
+                    },
+                    "dependencies": {
+                        "which": {
+                            "version": "1.3.1",
+                            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+                            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+                            "dev": true,
+                            "requires": {
+                                "isexe": "^2.0.0"
+                            }
+                        }
                     }
                 },
                 "supports-color": {
@@ -6749,9 +6801,9 @@
             }
         },
         "which": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "requires": {
                 "isexe": "^2.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -792,7 +792,7 @@
         "vscode-debugadapter": "^1.41.1",
         "vscode-jsonrpc": "^5.0.1",
         "vscode-languageclient": "^6.1.3",
-        "which": "^1.3.1"
+        "which": "^2.0.2"
     },
     "devDependencies": {
         "@types/cson-parser": "^4.0.4",


### PR DESCRIPTION
This is a minimal bug fix that solves the most immediate problem with our julia.exe binary search: currently, if something goes wrong with that search, an uncaught error can escape the `getJuliaExePath` function. Because that one is called early on in the `activate` function of the extension, that interrupts the core initialization of the extension if one of those error situations occurs. This is _really_ bad because even if the user later changes the user config setting for the julia binary path to a valid value, the extension initialization is broken and nothing works.

There is a lot more we should do, but I think those other things should come after Juliacon: a) we should provide a proper UI story when the extension can't find a julia binary, b) we need to harden every part of the extension against the case that no valid julia binary is configured. I think we'll be forced to do b) automatically once we continue with the strict mode stuff.

I'll write some inline comments that explain the situation each change her addresses.