### PR TITLE
Add diagnostics for line in getModuleForEditor

### DIFF
--- a/src/interactive/modules.ts
+++ b/src/interactive/modules.ts
@@ -1,3 +1,4 @@
+import { SeverityLevel } from 'applicationinsights/out/Declarations/Contracts'
 import * as vscode from 'vscode'
 import * as rpc from 'vscode-jsonrpc'
 import * as vslc from 'vscode-languageclient'
@@ -56,6 +57,13 @@ export async function getModuleForEditor(editor: vscode.TextEditor, position: vs
             textDocument: vslc.TextDocumentIdentifier.create(editor.document.uri.toString()),
             version: editor.document.version,
             position: position
+        }
+
+        if (position.line > editor.document.lineCount) {
+            telemetry.traceTrace({
+                message: `getModuleForEditor is about to send a request with an invalid line. Request is asking for line ${position.line}, but doc only has ${editor.document.lineCount} lines.}`,
+                severity: SeverityLevel.Error
+            })
         }
 
         try {


### PR DESCRIPTION
The most common crash report error we get right now is that in the get module request in the LS we are trying to convert a position into an offset, and the LS thinks the position is invalid. There are two possible explanations for this: 1) we might still have an error in the sync engine, making the LS error incorrect, or 2) we might actually be sending incorrect positions from the client.

This adds diagnostics that should allow us to narrow down which of these two it is.

The plan would be to push this PR out as quickly as possible to everyone, and then hope that we get good feedback that allows us narrow down what is going on here.