### PR TITLE
Fix a getModuleForEditor race condition

### DIFF
--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -318,9 +318,9 @@ async function executeCell(shouldMove: boolean = false) {
     const nextpos = ed.document.validatePosition(new vscode.Position(end + 1, 0))
     const code = doc.getText(new vscode.Range(startpos, endpos))
 
-    await startREPL(true, false)
-
     const module: string = await modules.getModuleForEditor(ed, startpos)
+
+    await startREPL(true, false)
 
     if (shouldMove) {
         vscode.window.activeTextEditor.selection = new vscode.Selection(nextpos, nextpos)


### PR DESCRIPTION
This is an alternative to https://github.com/julia-vscode/julia-vscode/pull/1473, maybe we should try this PR here first and see whether it gets rid of the crash reports.

The idea is that we don't want any `await` between recording the position from the selection and the call to `getModuleForEditor`.

I think this particular problem should not occur [here](https://github.com/julia-vscode/julia-vscode/blob/master/src/interactive/repl.ts#L343), but that whole code section should probably also be reviewed for other type of race conditions later.