### PR TITLE
Wrap a call to user code in a try catch

### DIFF
--- a/scripts/packages/VSCodeServer/src/eval.jl
+++ b/scripts/packages/VSCodeServer/src/eval.jl
@@ -53,7 +53,11 @@ function repl_runcode_request(conn, params::ReplRunCodeRequestParams)
                     Base.display_error(stderr, res)
 
                 elseif res !== nothing && !ends_with_semicolon(source_code)
-                    Base.invokelatest(display, res)
+                    try
+                        Base.invokelatest(display, res)
+                    catch err
+                        Base.display_error(stderr, err, catch_backtrace())
+                    end
                 end
             else
                 try


### PR DESCRIPTION
Fixes a bug from crash reporting.

Currently a bug in a user defined `display` method crashes us, this puts in the necessary try catch block to prevent that.