### PR TITLE
enable run/debug julia file via commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -215,14 +215,14 @@
                 "title": "Julia: Select Current Module"
             },
             {
-                "command": "language-julia.debugEditorContents",
-                "title": "Debug Julia File",
-                "icon": "$(debug-alt)"
+                "command": "language-julia.runEditorContents",
+                "title": "Julia: Run File",
+                "icon": "$(play)"
             },
             {
-                "command": "language-julia.runEditorContents",
-                "title": "Run Julia File",
-                "icon": "$(play)"
+                "command": "language-julia.debugEditorContents",
+                "title": "Julia: Debug File",
+                "icon": "$(debug-alt)"
             }
         ],
         "menus": {

--- a/src/debugger/debugFeature.ts
+++ b/src/debugger/debugFeature.ts
@@ -52,12 +52,10 @@ export class JuliaDebugFeature {
     public dispose() { }
 }
 
-function getActiveUri(
+const getActiveUri = (
     uri: vscode.Uri | undefined,
     editor: vscode.TextEditor | undefined = vscode.window.activeTextEditor
-) {
-    return uri ? uri.fsPath : editor ? editor.document.fileName : undefined
-}
+) => uri ? uri.fsPath : editor ? editor.document.fileName : undefined
 
 export class JuliaDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
 

--- a/src/debugger/debugFeature.ts
+++ b/src/debugger/debugFeature.ts
@@ -16,12 +16,11 @@ export class JuliaDebugFeature {
                 return pkgenvpath
             }),
             vscode.commands.registerCommand('language-julia.runEditorContents', (resource: vscode.Uri | undefined) => {
-                const editor = vscode.window.activeTextEditor
-                if (!(resource || editor)) {
+                const program = getActiveUri(resource)
+                if (!program) {
                     vscode.window.showInformationMessage('No active editor found.')
                     return
                 }
-                const program = resource === undefined ? editor.document.fileName : resource.fsPath
                 vscode.debug.startDebugging(undefined, {
                     type: 'julia',
                     name: 'Run Editor Contents',
@@ -35,12 +34,11 @@ export class JuliaDebugFeature {
 			*/)
             }),
             vscode.commands.registerCommand('language-julia.debugEditorContents', (resource: vscode.Uri | undefined) => {
-                const editor = vscode.window.activeTextEditor
-                if (!(resource || editor)) {
+                const program = getActiveUri(resource)
+                if (!program) {
                     vscode.window.showInformationMessage('No active editor found.')
                     return
                 }
-                const program = resource === undefined ? editor.document.fileName : resource.fsPath
                 vscode.debug.startDebugging(undefined, {
                     type: 'julia',
                     name: 'Debug Editor Contents',
@@ -53,6 +51,10 @@ export class JuliaDebugFeature {
 
     public dispose() { }
 }
+
+const getActiveUri = (
+    uri: vscode.Uri | undefined, editor: vscode.TextEditor | undefined = vscode.window.activeTextEditor
+) => uri ? uri.fsPath : editor ? editor.document.fileName : undefined
 
 export class JuliaDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
 

--- a/src/debugger/debugFeature.ts
+++ b/src/debugger/debugFeature.ts
@@ -53,7 +53,8 @@ export class JuliaDebugFeature {
 }
 
 const getActiveUri = (
-    uri: vscode.Uri | undefined, editor: vscode.TextEditor | undefined = vscode.window.activeTextEditor
+    uri: vscode.Uri | undefined,
+    editor: vscode.TextEditor | undefined = vscode.window.activeTextEditor
 ) => uri ? uri.fsPath : editor ? editor.document.fileName : undefined
 
 export class JuliaDebugConfigurationProvider implements vscode.DebugConfigurationProvider {

--- a/src/debugger/debugFeature.ts
+++ b/src/debugger/debugFeature.ts
@@ -15,12 +15,18 @@ export class JuliaDebugFeature {
                 const pkgenvpath = await getEnvPath()
                 return pkgenvpath
             }),
-            vscode.commands.registerCommand('language-julia.runEditorContents', (resource: vscode.Uri) => {
+            vscode.commands.registerCommand('language-julia.runEditorContents', (resource: vscode.Uri | undefined) => {
+                const editor = vscode.window.activeTextEditor
+                if (!(resource || editor)) {
+                    vscode.window.showInformationMessage('No active editor found.')
+                    return
+                }
+                const program = resource === undefined ? editor.document.fileName : resource.fsPath
                 vscode.debug.startDebugging(undefined, {
                     type: 'julia',
                     name: 'Run Editor Contents',
                     request: 'launch',
-                    program: resource.fsPath,
+                    program,
                     noDebug: true
                 },/* upcoming proposed API:
 				{
@@ -28,12 +34,18 @@ export class JuliaDebugFeature {
 				}
 			*/)
             }),
-            vscode.commands.registerCommand('language-julia.debugEditorContents', (resource: vscode.Uri) => {
+            vscode.commands.registerCommand('language-julia.debugEditorContents', (resource: vscode.Uri | undefined) => {
+                const editor = vscode.window.activeTextEditor
+                if (!(resource || editor)) {
+                    vscode.window.showInformationMessage('No active editor found.')
+                    return
+                }
+                const program = resource === undefined ? editor.document.fileName : resource.fsPath
                 vscode.debug.startDebugging(undefined, {
                     type: 'julia',
                     name: 'Debug Editor Contents',
                     request: 'launch',
-                    program: resource.fsPath
+                    program
                 })
             })
         )

--- a/src/debugger/debugFeature.ts
+++ b/src/debugger/debugFeature.ts
@@ -52,10 +52,12 @@ export class JuliaDebugFeature {
     public dispose() { }
 }
 
-const getActiveUri = (
+function getActiveUri(
     uri: vscode.Uri | undefined,
     editor: vscode.TextEditor | undefined = vscode.window.activeTextEditor
-) => uri ? uri.fsPath : editor ? editor.document.fileName : undefined
+) {
+    return uri ? uri.fsPath : editor ? editor.document.fileName : undefined
+}
 
 export class JuliaDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
 


### PR DESCRIPTION
Currently these commands will result in an error when we call them from command (not via icon).
Will use active editor as fallback resource.