### PR TITLE
Fix error handling

### DIFF
--- a/scripts/packages/VSCodeServer/src/eval.jl
+++ b/scripts/packages/VSCodeServer/src/eval.jl
@@ -96,7 +96,7 @@ function safe_render(x)
         return ReplRunCodeRequestReturn(
             string("Display Error: ", out.inline),
             string("Display Error: ", out.all),
-            out.iserr
+            out.stackframe
         )
     end
 end
@@ -127,7 +127,8 @@ struct EvalError
     bt
 end
 
-sprint_error(err::LoadError) = sprint_error(err.error)
+sprint_error_unwrap(err::LoadError) = sprint_error(err.error)
+sprint_error_unwrap(err) = sprint_error(err)
 
 function sprint_error(err)
     sprintlimited(err, [], func = Base.display_error, limit = MAX_RESULT_LENGTH)
@@ -136,7 +137,7 @@ end
 function render(err::EvalError)
     bt = crop_backtrace(err.bt)
 
-    errstr = sprint_error(err.err)
+    errstr = sprint_error_unwrap(err.err)
     inline = strlimit(first(split(errstr, "\n")), limit = INLINE_RESULT_LENGTH)
     all = string('\n', codeblock(errstr), '\n', backtrace_string(bt))
 


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/1474 (in that we now correctly throw a display error) and fixes https://github.com/julia-vscode/julia-vscode/issues/1468 (by only unwrapping at most one `LoadError`).