### PR TITLE
Fix another getModuleForEditor race condition

### DIFF
--- a/src/interactive/modules.ts
+++ b/src/interactive/modules.ts
@@ -48,13 +48,13 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(statusBarItem)
 }
 
-export async function getModuleForEditor(editor: vscode.TextEditor, position: vscode.Position = editor.selection.start) {
-    let mod = manuallySetDocuments[editor.document.fileName]
+export async function getModuleForEditor(document: vscode.TextDocument, position: vscode.Position) {
+    let mod = manuallySetDocuments[document.fileName]
 
     if (mod === undefined) {
         const params: VersionedTextDocumentPositionParams = {
-            textDocument: vslc.TextDocumentIdentifier.create(editor.document.uri.toString()),
-            version: editor.document.version,
+            textDocument: vslc.TextDocumentIdentifier.create(document.uri.toString()),
+            version: document.version,
             position: position
         }
 
@@ -90,7 +90,7 @@ async function updateModuleForSelectionEvent(event: vscode.TextEditorSelectionCh
 async function updateModuleForEditor(editor: vscode.TextEditor) {
     let mod = 'Main'
     try {
-        mod = await getModuleForEditor(editor)
+        mod = await getModuleForEditor(editor.document, editor.selection.start)
     } catch (err) {
         if (g_languageClient) {
             telemetry.handleNewCrashReportFromException(err, 'Extension')

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -225,7 +225,7 @@ async function executeFile(uri?: vscode.Uri) {
         path = editor.document.fileName
         code = editor.document.getText()
 
-        module = await modules.getModuleForEditor(editor, new vscode.Position(0, 0))
+        module = await modules.getModuleForEditor(editor.document, new vscode.Position(0, 0))
     }
 
     await g_connection.sendRequest(
@@ -318,7 +318,7 @@ async function executeCell(shouldMove: boolean = false) {
     const nextpos = ed.document.validatePosition(new vscode.Position(end + 1, 0))
     const code = doc.getText(new vscode.Range(startpos, endpos))
 
-    const module: string = await modules.getModuleForEditor(ed, startpos)
+    const module: string = await modules.getModuleForEditor(ed.document, startpos)
 
     await startREPL(true, false)
 
@@ -350,7 +350,7 @@ async function evaluateBlockOrSelection(shouldMove: boolean = false) {
             position: startpos
         }
 
-        const module: string = await modules.getModuleForEditor(editor, startpos)
+        const module: string = await modules.getModuleForEditor(editor.document, startpos)
 
         if (selection.isEmpty) {
             const currentBlock = await getBlockRange(params)


### PR DESCRIPTION
The only other potential place that I could find where there might be an `await` between recording the selection position and recording the version of the document was in the default handling of `getModuleForEditor` itself. It is an async function, and it is not clear to me at which point the default argument is evaluated in those situations: pre or post the await call happening. So this could be another source of the discrepancies that we seem to be having.

I also changed the argument to be the doc itself, maybe that also helps, who knows.

If that doesn't fix it, I'm kind of out of ideas :)