### PR TITLE
Remove Revise load warning

### DIFF
--- a/scripts/terminalserver/terminalserver.jl
+++ b/scripts/terminalserver/terminalserver.jl
@@ -10,7 +10,6 @@ if "USE_REVISE" in Base.ARGS
         @eval using Revise
         Revise.async_steal_repl_backend()
     catch err
-        @warn "failed to load Revise: $err"
     end
 end
 


### PR DESCRIPTION
We have load revise by default `true`, so in a vanilla installation users will get a warning, which is not a good user experience. For now, just remove the warning. Will no longer be needed if we manage to ship Revise out of the box.