### PR TITLE
Change default for missingrefs to none

### DIFF
--- a/package.json
+++ b/package.json
@@ -411,7 +411,7 @@
                 },
                 "julia.lint.missingrefs": {
                     "type": "string",
-                    "default": "all",
+                    "default": "none",
                     "enum": [
                         "none",
                         "symbols",


### PR DESCRIPTION
@ZacLN  are you ok with this? I think we just have too many complaints on the forums about false positives, so maybe we should just disable this by default for now, until we fix the environment story.