### PR TITLE
:wrench:  trying add problemMatchers

### DIFF
--- a/package.json
+++ b/package.json
@@ -761,6 +761,21 @@
                     "activeJuliaEnvironment": "language-julia.debug.getActiveJuliaEnvironment"
                 }
             }
+        ],
+        "problemMatchers": [
+            {
+                "name": "julia",
+                "owner": "language-julia",
+                "fileLocation": [
+                    "autoDetect"
+                ],
+                "pattern": {
+                    "regexp": "^\\[\\d+\\]\\s(?<body>.+)\\sat\\s(?<path>.+)\\:(?<line>\\d+)",
+                    "file": 2,
+                    "line": 3,
+                    "message": 1
+                }
+            }
         ]
     },
     "scripts": {


### PR DESCRIPTION
I' m trying to add a problem matcher so that I could use it when running julia in tasks.json. But after adding this and package and install in vscode the option to use julia problem matcher doesn' t  show up. Do you have idea why?