### PR TITLE
package server setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -635,6 +635,12 @@
                     "default": false,
                     "description": "Print executed code in REPL.",
                     "scope": "window"
+                },
+                "julia.packageServer": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Julia package server. Set's the `JULIA_PKG_SERVER` environment variable *before* starting a Julia process. Leave this empty to use the systemwide default. Requires a restart of the Julia process.",
+                    "scope": "machine-overridable"
                 }
             }
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,12 +73,15 @@ export async function activate(context: vscode.ExtensionContext) {
         context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider('juliavsodeprofilerresults', new ProfilerResultsProvider()))
 
         const api = {
-            version: 1,
+            version: 2,
             async getEnvironment() {
                 return await jlpkgenv.getEnvPath()
             },
             async getJuliaPath() {
                 return await juliaexepath.getJuliaExePath()
+            },
+            getPkgServer() {
+                return vscode.workspace.getConfiguration('julia').get('packageServer')
             }
         }
 

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -58,6 +58,16 @@ async function startREPL(preserveFocus: boolean, showTerminal: boolean = true) {
             return jlarg2
         }
 
+        const env = {
+            JULIA_EDITOR: get_editor(),
+            JULIA_NUM_THREADS: inferJuliaNumThreads()
+        }
+
+        const pkgServer: string = vscode.workspace.getConfiguration('julia').get('packageServer')
+        if (pkgServer.length !== 0) {
+            env['JULIA_PKG_SERVER'] = pkgServer
+        }
+
         const juliaIsConnectedPromise = startREPLMsgServer(pipename)
         const exepath = await juliaexepath.getJuliaExePath()
         const pkgenvpath = await jlpkgenv.getEnvPath()
@@ -68,10 +78,7 @@ async function startREPL(preserveFocus: boolean, showTerminal: boolean = true) {
                     name: 'Julia REPL',
                     shellPath: exepath,
                     shellArgs: jlarg1.concat(getArgs()),
-                    env: {
-                        JULIA_EDITOR: get_editor(),
-                        JULIA_NUM_THREADS: inferJuliaNumThreads()
-                    }
+                    env: env
                 })
         }
         else {
@@ -95,10 +102,7 @@ async function startREPL(preserveFocus: boolean, showTerminal: boolean = true) {
                     name: 'Julia REPL',
                     shellPath: exepath,
                     shellArgs: jlarg1.concat(getArgs()),
-                    env: {
-                        JULIA_EDITOR: get_editor(),
-                        JULIA_NUM_THREADS: inferJuliaNumThreads()
-                    }
+                    env: env
                 })
         }
         g_terminal.show(preserveFocus)


### PR DESCRIPTION
Now that Julia 1.5 is out it probably makes sense to allow the package server to be set from within VSCode. Setting it in `startup.jl` takes precedence, of course.