### PR TITLE
add stopREPL command

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "onCommand:language-julia.openPackageDirectory",
         "onCommand:language-julia.changeCurrentEnvironment",
         "onCommand:language-julia.startREPL",
+        "onCommand:language-julia.stopREPL",
         "onCommand:language-julia.executeCodeBlockOrSelection",
         "onCommand:language-julia.executeFile",
         "onCommand:language-julia.toggleLinter",
@@ -117,6 +118,10 @@
             {
                 "command": "language-julia.startREPL",
                 "title": "Julia: Start REPL"
+            },
+            {
+                "command": "language-julia.stopREPL",
+                "title": "Julia: Stop REPL"
             },
             {
                 "command": "language-julia.executeCodeBlockOrSelection",
@@ -332,6 +337,14 @@
                 "command": "language-julia.chooseModule",
                 "key": "Alt+J Alt+M",
                 "when": "editorTextFocus && editorLangId == julia"
+            },
+            {
+                "command": "language-julia.startREPL",
+                "key": "Alt+J Alt+O"
+            },
+            {
+                "command": "language-julia.stopREPL",
+                "key": "Alt+J Alt+K"
             },
             {
                 "command": "language-julia.changeCurrentEnvironment",

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -113,6 +113,12 @@ async function startREPL(preserveFocus: boolean, showTerminal: boolean = true) {
     }
 }
 
+function killREPL() {
+    if (g_terminal) {
+        g_terminal.dispose()
+    }
+}
+
 function debuggerRun(code: string) {
     const x = {
         type: 'julia',
@@ -487,6 +493,7 @@ export function activate(context: vscode.ExtensionContext) {
     }))
 
     context.subscriptions.push(vscode.commands.registerCommand('language-julia.startREPL', startREPLCommand))
+    context.subscriptions.push(vscode.commands.registerCommand('language-julia.stopREPL', killREPL))
 
     context.subscriptions.push(vscode.commands.registerCommand('language-julia.selectBlock', selectJuliaBlock))
 


### PR DESCRIPTION
Fixes the part of https://github.com/julia-vscode/julia-vscode/issues/1593 we can fix (persistent terminals without a wrapper process require upstream support).