### PR TITLE
Changed activity bar from filled to outline

### DIFF
--- a/images/julia-dots-outline.svg
+++ b/images/julia-dots-outline.svg
@@ -3,9 +3,8 @@
 	circle {
 		stroke: #d7dae0;
 		fill: transparent;
-		stroke-width: 18;
-		stroke-linejoin: round;
-		r: 67;
+		stroke-width: 20;
+		r: 65;
 	}
 </style>
 <circle cx="75.8" cy="225" />

--- a/images/julia-dots-outline.svg
+++ b/images/julia-dots-outline.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="24" height="24" viewBox="0 0 325 300" version="1.1" xml:space="preserve">
+<style type="text/css">
+	circle {
+		stroke: #d7dae0;
+		fill: transparent;
+		stroke-width: 18;
+		stroke-linejoin: round;
+		r: 67;
+	}
+</style>
+<circle cx="75.8" cy="225" />
+<circle cx="162.5" cy="75" />
+<circle cx="249.1" cy="225" />
+</svg>

--- a/package.json
+++ b/package.json
@@ -667,7 +667,7 @@
                 {
                     "id": "julia-explorer",
                     "title": "Julia Explorer",
-                    "icon": "images/julia-dots.svg"
+                    "icon": "images/julia-dots-outline.svg"
                 }
             ]
         },


### PR DESCRIPTION
Fixes #1601 

The new svg was crafted based on the vscode spec and on `images/julia-dots.svg`. After that change `images/julia-dots.svg` is not used anywhere, it can removed.

Before (left) and after (right) in light and dark themes:

![image](https://user-images.githubusercontent.com/29288116/90248244-d82add00-de27-11ea-9b15-4fcda6c634b2.png) ![image](https://user-images.githubusercontent.com/29288116/90248249-dbbe6400-de27-11ea-8412-65d1ad482020.png)

