### PR TITLE
softscope on Julia >=1.5

### DIFF
--- a/scripts/packages/VSCodeServer/src/repl.jl
+++ b/scripts/packages/VSCodeServer/src/repl.jl
@@ -94,7 +94,10 @@ function evalrepl(m, line, repl, main_mode)
 end
 
 # don't inline this so we can find it in the stacktrace
-@noinline repleval(m, code, file) = include_string(m, code, file)
+@noinline function repleval(m, code, file)
+    args = VERSION >= v"1.5" ? (REPL.softscope, m, code, file) : (m, code, file)
+    return include_string(args...)
+end
 
 # basically the same as Base's `display_error`, with internal frames removed
 function display_repl_error(io, err, st)

--- a/scripts/packages/VSCodeServer/src/repl_protocol.jl
+++ b/scripts/packages/VSCodeServer/src/repl_protocol.jl
@@ -6,6 +6,7 @@ JSONRPC.@dict_readable struct ReplRunCodeRequestParams <: JSONRPC.Outbound
     mod::String
     showCodeInREPL::Bool
     showResultInREPL::Bool
+    softscope::Bool
 end
 
 struct Frame

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -154,7 +154,8 @@ const requestTypeReplRunCode = new rpc.RequestType<{
     code: string,
     mod: string,
     showCodeInREPL: boolean,
-    showResultInREPL: boolean
+    showResultInREPL: boolean,
+    softscope: boolean
 }, ReturnResult, void, void>('repl/runcode')
 
 const notifyTypeDisplay = new rpc.NotificationType<{ kind: string, data: any }, void>('display')
@@ -242,7 +243,8 @@ async function executeFile(uri?: vscode.Uri) {
             mod: module,
             code: code,
             showCodeInREPL: false,
-            showResultInREPL: true
+            showResultInREPL: true,
+            softscope: false
         }
     )
     await workspace.replFinishEval()
@@ -418,7 +420,8 @@ async function evaluate(editor: vscode.TextEditor, range: vscode.Range, text: st
             code: text,
             mod: module,
             showCodeInREPL: codeInREPL,
-            showResultInREPL: resultType !== 'inline'
+            showResultInREPL: resultType !== 'inline',
+            softscope: true
         }
     )
 


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/1556.

This implements the following behaviour on Julia 1.5+ (everything stays the same on older versions):
- The REPL always uses softscoping.
- Inline evaluation always uses softscoping.
- Evaluating the whole file with `Julia: Execute File` always uses hardscoping.

I thought about making this user configurable, but I don't think that's a good idea.