### PR TITLE
Improve telemetry dialogues

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,10 +68,14 @@ export async function activate(context: vscode.ExtensionContext) {
         startLanguageServer()
 
         if (vscode.workspace.getConfiguration('julia').get<boolean>('enableTelemetry') === null) {
-            vscode.window.showInformationMessage('To help improve the Julia extension, you can allow the development team to collect usage data. Read our [privacy statement](https://github.com/julia-vscode/julia-vscode/wiki/Privacy-Policy) to learn more how we use usage data and how to permanently hide this notification.', 'I agree to usage data collection')
-                .then(telemetry_choice => {
-                    if (telemetry_choice === 'I agree to usage data collection') {
+            const agree = 'Yes'
+            const disagree = 'No'
+            vscode.window.showInformationMessage('To help improve the Julia extension, you can allow the development team to collect usage data. Read our [privacy statement](https://github.com/julia-vscode/julia-vscode/wiki/Privacy-Policy) to learn more about how we use usage data. Do you agree to usage data collection?', agree, disagree)
+                .then(choice => {
+                    if (choice === agree) {
                         vscode.workspace.getConfiguration('julia').update('enableTelemetry', true, true)
+                    } else if (choice === disagree) {
+                        vscode.workspace.getConfiguration('julia').update('enableTelemetry', false, true)
                     }
                 })
         }
@@ -174,7 +178,6 @@ async function startLanguageServer() {
                     telemetry.traceTrace({
                         message: `Middleware found a change in position in provideCompletionItem. Original ${position.line}:${position.character}, validated ${validatedPosition.line}:${validatedPosition.character}`,
                         severity: SeverityLevel.Error
-
                     })
 
                 }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -196,13 +196,17 @@ async function showCrashReporterUIConsent() {
     else {
         crashReporterUIVisible = true
         try {
-            const choice = await vscode.window.showInformationMessage('The Julia language extension crashed. Do you want to send more information about the problem to the development team? Read our [privacy statement](https://github.com/julia-vscode/julia-vscode/wiki/Privacy-Policy) to learn more how we use crash reports, what data will be transmitted and how to permanently hide this notification.', 'Yes, send a crash report', 'Yes, always send a crash report')
-
-            if (choice === 'Yes, always send a crash report') {
+            const agree = 'Yes'
+            const agreeAlways = 'Yes, always'
+            const disagree = 'No, never'
+            const choice = await vscode.window.showInformationMessage('The Julia language extension crashed. Do you want to send more information about the problem to the development team? Read our [privacy statement](https://github.com/julia-vscode/julia-vscode/wiki/Privacy-Policy) to learn more about how we use crash reports and what data will be transmitted.', agree, agreeAlways, disagree)
+            if (choice === disagree) {
+                vscode.workspace.getConfiguration('julia').update('enableCrashReporter', false, true)
+            }
+            if (choice === agreeAlways) {
                 vscode.workspace.getConfiguration('julia').update('enableCrashReporter', true, true)
             }
-
-            if (choice === 'Yes, send a crash report' || choice === 'Yes, always send a crash report') {
+            if (choice === agree || choice === agreeAlways) {
                 sendCrashReportQueue()
             }
         }


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/514.

![image](https://user-images.githubusercontent.com/6735977/94126107-7e222c00-fe57-11ea-85b7-d33458ad3bb5.png)

I think we have enough users opting into telemetry without a nag message now, so let's go with this as a more user-friendly alternative.