### PR TITLE
fix stacktrace rendering

### DIFF
--- a/scripts/packages/VSCodeServer/src/eval.jl
+++ b/scripts/packages/VSCodeServer/src/eval.jl
@@ -175,7 +175,7 @@ function backtrace_string(bt)
     s = sprintlimited(bt, func = Base.show_backtrace, limit = MAX_RESULT_LENGTH)
     lines = strip.(split(s, '\n'))
 
-    return map(enumerate(lines)) do (i, line)
+    return join(map(enumerate(lines)) do (i, line)
         i === 1 && return line # "Stacktrace:"
         m = match(LOCATION_REGEX, line)
         m === nothing && return line
@@ -183,5 +183,5 @@ function backtrace_string(bt)
         linkbody = vscode_cmd_uri("language-julia.openFile"; path = fullpath(m[:path]), line = m[:line])
         linktitle = string("Go to ", linktext)
         return "$(i-1). `$(m[:body])` at [$(linktext)]($(linkbody) \"$(linktitle)\")"
-    end |> joinlines
+    end, "\n\n")
 end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6735977/95188857-58891100-07cd-11eb-9b2a-35c765b7434a.png)

This broke at some point in the past; seems we now need two new lines instead of only one for proper list rendering.