### PR TITLE
Set JULIA_VSCODE_LANGUAGESERVER=1 for language server processes.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -147,7 +147,8 @@ async function startLanguageServer() {
         env: {
             JULIA_DEPOT_PATH: path.join(g_context.extensionPath, 'scripts', 'languageserver', 'julia_pkgdir'),
             JULIA_LOAD_PATH: process.platform === 'win32' ? ';' : ':',
-            HOME: process.env.HOME ? process.env.HOME : os.homedir()
+            HOME: process.env.HOME ? process.env.HOME : os.homedir(),
+            JULIA_LANGUAGESERVER: '1'
         }
     }
 

--- a/src/juliaexepath.ts
+++ b/src/juliaexepath.ts
@@ -13,7 +13,11 @@ let actualJuliaExePath: string = null
 async function setNewJuliaExePath(newPath: string) {
     actualJuliaExePath = newPath
 
-    child_process.exec(`"${newPath}" --version`, (error, stdout, stderr) => {
+    const env = {
+        JULIA_LANGUAGESERVER: '1'
+    }
+
+    child_process.exec(`"${newPath}" --version`, { env: env }, (error, stdout, stderr) => {
         if (error) {
             actualJuliaExePath = null
             return


### PR DESCRIPTION
This makes it possible to use `direnv` with the VSCode extension by setting `Julia: Executable Path` to the following script:
```bash
!#/bin/bash
export DIRENV_BASH=/bin/bash
exec /bin/direnv exec "${JULIA_VSCODE_WORKSPACE}" julia "$@"
```