### PR TITLE
improve workspace error handling

### DIFF
--- a/scripts/packages/VSCodeServer/src/trees.jl
+++ b/scripts/packages/VSCodeServer/src/trees.jl
@@ -30,9 +30,9 @@ const MAX_PARTITION_LENGTH = 20
 
 treeid() = (ID[] += 1)
 
-pluralize(n::Int, one, more = one) = string(n, " ", n == 1 ? one : more)
-pluralize(::Tuple{}, one, more = one) = string(0, " ", more)
-pluralize(n, one, more = one) = string(length(n) > 1 ? join(n, '×') : first(n), " ", prod(n) == 1 ? one : more)
+pluralize(n::Int, one, more=one) = string(n, " ", n == 1 ? one : more)
+pluralize(::Tuple{}, one, more=one) = string(0, " ", more)
+pluralize(n, one, more=one) = string(length(n) > 1 ? join(n, '×') : first(n), " ", prod(n) == 1 ? one : more)
 
 function treerender(x::LazyTree)
     id = treeid()
@@ -78,7 +78,7 @@ function treerender(x::Leaf)
     )
 end
 
-getfield_safe(x, f, default = UNDEF) = isdefined(x, f) ? getfield(x, f) : default
+getfield_safe(x, f, default=UNDEF) = isdefined(x, f) ? getfield(x, f) : default
 
 function treerender(x)
     fields = fieldnames(typeof(x))
@@ -92,10 +92,10 @@ function treerender(x)
     end
 end
 
-function treerender(x::AbstractDict{K,V}) where {K,V}
+function treerender(x::Dict{K,V}) where {K,V}
     treerender(LazyTree(string(nameof(typeof(x)), "{$(K), $(V)} with $(pluralize(length(keys(x)), "element", "elements"))"), wsicon(x), length(keys(x)) == 0, function ()
         if length(keys(x)) > MAX_PARTITION_LENGTH
-            partition_by_keys(x, sz = MAX_PARTITION_LENGTH)
+            partition_by_keys(x, sz=MAX_PARTITION_LENGTH)
         else
             collect([SubTree(repr(k), wsicon(v), v) for (k, v) in x])
         end
@@ -104,7 +104,7 @@ end
 
 function treerender(x::Module)
     treerender(LazyTree(string(x), wsicon(x), function ()
-        ns = names(x, all = true)
+        ns = names(x, all=true)
         out = []
         for n in ns
             isdefined(x, n) || continue
@@ -130,39 +130,55 @@ function assign_undefs(xs)
     for i in eachindex(xs)
         xs′[i] = isassigned(xs, i) ? xs[i] : UNDEF
     end
+
+    # make sure not to leave any unassigned locations around even when
+    # `similar` (i.e. `size`) and `eachindex` disagree; `prod(size(x)) ==
+    # length(eachindex(x))` should hold, but doesn't always
+    for i in eachindex(xs′)
+        if !isassigned(xs′, i)
+            xs′[i] = UNDEF
+        end
+    end
+
     return xs′
 end
 
-function treerender(x::AbstractArray{T,N}) where {T,N}
+function treerender(x::Array{T,N}) where {T,N}
     treerender(LazyTree(string(typeof(x), " with $(pluralize(size(x), "element", "elements"))"), wsicon(x), length(x) == 0, function ()
         if length(x) > MAX_PARTITION_LENGTH
-            partition_by_keys(x, sz = MAX_PARTITION_LENGTH)
+            partition_by_keys(x, sz=MAX_PARTITION_LENGTH)
         else
             collect([SubTree(repr(k), wsicon(v), v) for (k, v) in zip(keys(x), vec(assign_undefs(x)))])
         end
     end))
 end
 
-treerender(x::Number) = treerender(Leaf(strlimit(repr(x), limit = 100), wsicon(x)))
-treerender(x::AbstractString) = treerender(Leaf(strlimit(repr(x), limit = 100), wsicon(x)))
-treerender(x::AbstractChar) = treerender(Leaf(strlimit(repr(x), limit = 100), wsicon(x)))
-treerender(x::Symbol) = treerender(Leaf(strlimit(repr(x), limit = 100), wsicon(x)))
-treerender(x::Nothing) = treerender(Leaf(strlimit(repr(x), limit = 100), wsicon(x)))
-treerender(x::Missing) = treerender(Leaf(strlimit(repr(x), limit = 100), wsicon(x)))
-treerender(x::Ptr) = treerender(Leaf(string(typeof(x), ": 0x", string(UInt(x), base = 16, pad = Sys.WORD_SIZE >> 2)), wsicon(x)))
-treerender(x::Text) = treerender(Leaf(x.content, wsicon(x)))
-treerender(x::Function) = treerender(Leaf(strlimit(string(x), limit = 100), wsicon(x)))
-treerender(x::Type) = treerender(Leaf(strlimit(string(x), limit = 100), wsicon(x)))
-treerender(x::Undef) = treerender(Leaf("#undef", wsicon(x)))
+function treerender(err, bt)
+    st = stacktrace(bt)
+    treerender(LazyTree(string("Internal Error: ", err), wsicon(err), length(st) == 0, () -> [Leaf(sprint(show, x), wsicon(x)) for x in st]))
+end
 
-function partition_by_keys(x, _keys = keys(x); sz = 20, maxparts = 100)
+treerender(x::Number) = treerender(Leaf(strlimit(repr(x), limit=100), wsicon(x)))
+treerender(x::AbstractString) = treerender(Leaf(strlimit(repr(x), limit=100), wsicon(x)))
+treerender(x::AbstractChar) = treerender(Leaf(strlimit(repr(x), limit=100), wsicon(x)))
+treerender(x::Symbol) = treerender(Leaf(strlimit(repr(x), limit=100), wsicon(x)))
+treerender(x::Nothing) = treerender(Leaf(strlimit(repr(x), limit=100), wsicon(x)))
+treerender(x::Missing) = treerender(Leaf(strlimit(repr(x), limit=100), wsicon(x)))
+treerender(x::Ptr) = treerender(Leaf(string(typeof(x), ": 0x", string(UInt(x), base=16, pad=Sys.WORD_SIZE >> 2)), wsicon(x)))
+treerender(x::Text) = treerender(Leaf(x.content, wsicon(x)))
+treerender(x::Function) = treerender(Leaf(strlimit(string(x), limit=100), wsicon(x)))
+treerender(x::Type) = treerender(Leaf(strlimit(string(x), limit=100), wsicon(x)))
+treerender(x::Undef) = treerender(Leaf("#undef", wsicon(x)))
+treerender(x::StackTraces.StackFrame) = treerender(Leaf(string(x), wsicon(x)))
+
+function partition_by_keys(x, _keys=keys(x); sz=20, maxparts=100)
     partitions = Iterators.partition(_keys, max(sz, length(_keys) ÷ maxparts))
     out = []
     for part in partitions
         head = string(repr(first(part)), " ... ", repr(last(part)))
         if length(part) > sz
             push!(out, LazyTree(head, function ()
-                partition_by_keys(x, collect(part), sz = sz, maxparts = maxparts)
+                partition_by_keys(x, collect(part), sz=sz, maxparts=maxparts)
             end))
         else
             push!(out, LazyTree(head, function ()
@@ -182,7 +198,7 @@ function getvariables()
     variables = []
     clear_lazy()
 
-    for n in names(M, all = true, imported = true)
+    for n in names(M, all=true, imported=true)
         !isdefined(M, n) && continue
         Base.isdeprecated(M, n) && continue
 
@@ -201,7 +217,7 @@ function getvariables()
             # FIXME: This should end up in the tree view as an "error child".
             # Ref: https://github.com/julia-vscode/julia-vscode/issues/1491
             #
-            # printstyled("Internal Error: ", bold = true, color = Base.error_color())
+            # printstyled("Internal Error: ", bold=true, color=Base.error_color())
             # Base.display_error(err, catch_backtrace())
         end
     end
@@ -209,7 +225,7 @@ function getvariables()
     return variables
 end
 
-function clear_lazy(ids = [])
+function clear_lazy(ids=[])
     if isempty(ids)
         empty!(TREES)
     else
@@ -244,11 +260,7 @@ function get_lazy(id::Int)
             return [treerender(Text("[out of date result]"))]
         end
     catch err
-        # FIXME: This should end up in the tree view as an "error child".
-        # Ref: https://github.com/julia-vscode/julia-vscode/issues/1491
-        #
-        # printstyled("Internal Error: ", bold = true, color = Base.error_color())
-        # Base.display_error(err, catch_backtrace())
-        return []
+        # show internal error in workspace:
+        return [treerender(err, catch_backtrace())]
     end
 end


### PR DESCRIPTION
We now show an informative error in the workspace for errors somewhere in the lazy tree view display:
![image](https://user-images.githubusercontent.com/6735977/96475602-82621f00-1234-11eb-80ff-3243a63b06fd.png)

This also only special cases `Base`s `Array` and `Dict` types instead of all `AbstractArray`s and `AbstractDict`s, so that e.g. `ODESolutions` are displayed properly:
![image](https://user-images.githubusercontent.com/6735977/96475821-c2290680-1234-11eb-83dc-39c04f52cc6f.png)

It also makes super duper extra sure that every index is assigned when showing arrays -- in theory this shouldn't be necessary since `prod(size(x)) == length(eachindex(x))` holds for `Array`s, but can't hurt either.