### PR TITLE
default play button to "run file"

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,12 +233,12 @@
             },
             {
                 "command": "language-julia.runEditorContents",
-                "title": "Julia: Run File",
+                "title": "Julia: Run File in new process",
                 "icon": "$(play)"
             },
             {
                 "command": "language-julia.debugEditorContents",
-                "title": "Julia: Debug File",
+                "title": "Julia: Debug File in new process",
                 "icon": "$(debug-alt)"
             }
         ],
@@ -271,7 +271,7 @@
                     "command": "language-julia.plotpane-delete-all"
                 },
                 {
-                    "command": "language-julia.runEditorContents",
+                    "command": "language-julia.executeFile",
                     "when": "resourceLangId == julia",
                     "group": "1_run@10"
                 },

--- a/package.json
+++ b/package.json
@@ -233,7 +233,7 @@
             },
             {
                 "command": "language-julia.runEditorContents",
-                "title": "Julia: Run File in new process",
+                "title": "Julia: Run File in New Process",
                 "icon": "$(play)"
             },
             {

--- a/package.json
+++ b/package.json
@@ -238,7 +238,7 @@
             },
             {
                 "command": "language-julia.debugEditorContents",
-                "title": "Julia: Debug File in new process",
+                "title": "Julia: Debug File in New Process",
                 "icon": "$(debug-alt)"
             }
         ],


### PR DESCRIPTION
We've gotten a bunch of reports of people being annoyed/confused about the play button starting a new process/taking a long time/not using the correct launch config (this last one is because of a VSCode bug, I think).

This switches it to the in-process "Run File" command, which imho people should be using anyways. It also changes the names for "Run File"/"Debug File" to clarify that those start a new process.