### PR TITLE
fix plot pane setting

### DIFF
--- a/scripts/packages/VSCodeServer/src/VSCodeServer.jl
+++ b/scripts/packages/VSCodeServer/src/VSCodeServer.jl
@@ -97,6 +97,7 @@ function serve(args...; is_dev=false, crashreporting_pipename::Union{AbstractStr
         msg_dispatcher[repl_loadedModules_request_type] = repl_loadedModules_request
         msg_dispatcher[repl_isModuleLoaded_request_type] = repl_isModuleLoaded_request
         msg_dispatcher[repl_startdebugger_notification_type] = (conn, params) -> repl_startdebugger_request(conn, params, crashreporting_pipename)
+        msg_dispatcher[repl_toggle_plot_pane_notification_type] = toggle_plot_pane
 
         while true
             msg = JSONRPC.get_next_message(conn_endpoint[])

--- a/scripts/packages/VSCodeServer/src/display.jl
+++ b/scripts/packages/VSCodeServer/src/display.jl
@@ -19,7 +19,7 @@ function sendDisplayMsg(kind, data)
     JSONRPC.send_notification(conn_endpoint[], "display", Dict{String,String}("kind" => kind, "data" => data))
 end
 
-function display(_::InlineDisplay, m::MIME, x)
+function display(d::InlineDisplay, m::MIME, x)
     mime = string(m)
     if PLOT_PANE_ENABLED[] && mime in DISPLAYABLE_MIMES
         payload = stringmime(m, x)

--- a/scripts/packages/VSCodeServer/src/display.jl
+++ b/scripts/packages/VSCodeServer/src/display.jl
@@ -1,104 +1,49 @@
 struct InlineDisplay <: AbstractDisplay end
 
+const PLOT_PANE_ENABLED = Ref(true)
+
+function toggle_plot_pane(_, enable::Bool)
+    PLOT_PANE_ENABLED[] = enable
+end
+
+function fix_displays()
+    for d in reverse(Base.Multimedia.displays)
+        if d isa InlineDisplay
+            popdisplay(InlineDisplay())
+        end
+    end
+    pushdisplay(InlineDisplay())
+end
+
 function sendDisplayMsg(kind, data)
     JSONRPC.send_notification(conn_endpoint[], "display", Dict{String,String}("kind" => kind, "data" => data))
 end
 
-
-function display(d::InlineDisplay, ::MIME{Symbol("image/png")}, x)
-    payload = stringmime(MIME("image/png"), x)
-    sendDisplayMsg("image/png", payload)
-end
-
-displayable(d::InlineDisplay, ::MIME{Symbol("image/png")}) = true
-
-function display(d::InlineDisplay, ::MIME{Symbol("image/gif")}, x)
-    payload = stringmime(MIME("image/gif"), x)
-    sendDisplayMsg("image/gif", payload)
-end
-
-displayable(d::InlineDisplay, ::MIME{Symbol("image/gif")}) = true
-
-function display(d::InlineDisplay, ::MIME{Symbol("image/svg+xml")}, x)
-    payload = stringmime(MIME("image/svg+xml"), x)
-    sendDisplayMsg("image/svg+xml", payload)
-end
-
-displayable(d::InlineDisplay, ::MIME{Symbol("image/svg+xml")}) = true
-
-function display(d::InlineDisplay, ::MIME{Symbol("text/html")}, x)
-    payload = stringmime(MIME("text/html"), x)
-    sendDisplayMsg("text/html", payload)
-end
-
-displayable(d::InlineDisplay, ::MIME{Symbol("text/html")}) = true
-
-function display(d::InlineDisplay, ::MIME{Symbol("juliavscode/html")}, x)
-    payload = stringmime(MIME("juliavscode/html"), x)
-    sendDisplayMsg("juliavscode/html", payload)
+function display(_::InlineDisplay, m::MIME, x)
+    mime = string(m)
+    if PLOT_PANE_ENABLED[] && mime in DISPLAYABLE_MIMES
+        payload = stringmime(m, x)
+        sendDisplayMsg(mime, payload)
+    else
+        throw(MethodError(display, (d, m, x)))
+    end
+    return nothing
 end
 
 Base.Multimedia.istextmime(::MIME{Symbol("juliavscode/html")}) = true
 
-displayable(d::InlineDisplay, ::MIME{Symbol("juliavscode/html")}) = true
-
-function display(d::InlineDisplay, ::MIME{Symbol("application/vnd.vegalite.v2+json")}, x)
-    payload = stringmime(MIME("application/vnd.vegalite.v2+json"), x)
-    sendDisplayMsg("application/vnd.vegalite.v2+json", payload)
-end
-
-displayable(d::InlineDisplay, ::MIME{Symbol("application/vnd.vegalite.v2+json")}) = true
-
-function display(d::InlineDisplay, ::MIME{Symbol("application/vnd.vegalite.v3+json")}, x)
-    payload = stringmime(MIME("application/vnd.vegalite.v3+json"), x)
-    sendDisplayMsg("application/vnd.vegalite.v3+json", payload)
-end
-
-displayable(d::InlineDisplay, ::MIME{Symbol("application/vnd.vegalite.v3+json")}) = true
-
-function display(d::InlineDisplay, ::MIME{Symbol("application/vnd.vegalite.v4+json")}, x)
-    payload = stringmime(MIME("application/vnd.vegalite.v4+json"), x)
-    sendDisplayMsg("application/vnd.vegalite.v4+json", payload)
-end
-
-displayable(d::InlineDisplay, ::MIME{Symbol("application/vnd.vegalite.v4+json")}) = true
-
-function display(d::InlineDisplay, ::MIME{Symbol("application/vnd.vega.v3+json")}, x)
-    payload = stringmime(MIME("application/vnd.vega.v3+json"), x)
-    sendDisplayMsg("application/vnd.vega.v3+json", payload)
-end
-
-displayable(d::InlineDisplay, ::MIME{Symbol("application/vnd.vega.v3+json")}) = true
-
-function display(d::InlineDisplay, ::MIME{Symbol("application/vnd.vega.v4+json")}, x)
-    payload = stringmime(MIME("application/vnd.vega.v4+json"), x)
-    sendDisplayMsg("application/vnd.vega.v4+json", payload)
-end
-
-displayable(d::InlineDisplay, ::MIME{Symbol("application/vnd.vega.v4+json")}) = true
-
-function display(d::InlineDisplay, ::MIME{Symbol("application/vnd.vega.v5+json")}, x)
-    payload = stringmime(MIME("application/vnd.vega.v5+json"), x)
-    sendDisplayMsg("application/vnd.vega.v5+json", payload)
-end
-
-displayable(d::InlineDisplay, ::MIME{Symbol("application/vnd.vega.v5+json")}) = true
-
-function display(d::InlineDisplay, ::MIME{Symbol("application/vnd.plotly.v1+json")}, x)
-    payload = stringmime(MIME("application/vnd.plotly.v1+json"), x)
-    sendDisplayMsg("application/vnd.plotly.v1+json", payload)
-end
-
 displayable(d::InlineDisplay, ::MIME{Symbol("application/vnd.dataresource+json")}) = true
 
 function display(d::InlineDisplay, ::MIME{Symbol("application/vnd.dataresource+json")}, x)
-    payload = stringmime(MIME("application/vnd.dataresource+json"), x)
+    payload = stringmime(MIME("application/vnd.datareso urce+json"), x)
     sendDisplayMsg("application/vnd.dataresource+json", payload)
 end
 
 Base.Multimedia.istextmime(::MIME{Symbol("application/vnd.dataresource+json")}) = true
 
 displayable(d::InlineDisplay, ::MIME{Symbol("application/vnd.plotly.v1+json")}) = true
+
+displayable(_::InlineDisplay, mime::MIME) = PLOT_PANE_ENABLED[] && string(mime) in DISPLAYABLE_MIMES
 
 const DISPLAYABLE_MIMES = [
     "application/vnd.vegalite.v4+json",
@@ -136,9 +81,11 @@ function can_display(x)
 end
 
 function Base.display(d::InlineDisplay, x)
-    for mime in DISPLAYABLE_MIMES
-        if showable(mime, x)
-            return display(d, mime, x)
+    if PLOT_PANE_ENABLED[]
+        for mime in DISPLAYABLE_MIMES
+            if showable(mime, x)
+                return display(d, mime, x)
+            end
         end
     end
 
@@ -164,8 +111,8 @@ end
 const tabletraits_uuid = UUIDs.UUID("3783bdb8-4a98-5b6b-af9a-565f29a5fe9c")
 const datavalues_uuid = UUIDs.UUID("e7dc6d0d-1eca-5fa6-8ad6-5aecde8b7ea5")
 
-global _isiterabletable = i->false
-global _getiterator = i->i
+global _isiterabletable = i -> false
+global _getiterator = i -> i
 
 function pkgload(pkg)
     if pkg.uuid == tabletraits_uuid
@@ -229,4 +176,4 @@ function internal_vscodedisplay(x)
 end
 
 vscodedisplay(x) = internal_vscodedisplay(x)
-vscodedisplay() = i->vscodedisplay(i)
+vscodedisplay() = i -> vscodedisplay(i)

--- a/scripts/packages/VSCodeServer/src/eval.jl
+++ b/scripts/packages/VSCodeServer/src/eval.jl
@@ -50,6 +50,8 @@ end
 
 function repl_runcode_request(conn, params::ReplRunCodeRequestParams)
     return run_with_backend() do
+        fix_displays()
+
         source_filename = params.filename
         code_line = params.line
         code_column = params.column
@@ -99,7 +101,6 @@ function repl_runcode_request(conn, params::ReplRunCodeRequestParams)
                     if show_result
                         if res isa EvalError
                             Base.display_error(stderr, res)
-
                         elseif res !== nothing && !ends_with_semicolon(source_code)
                             try
                                 Base.invokelatest(display, res)

--- a/scripts/packages/VSCodeServer/src/repl.jl
+++ b/scripts/packages/VSCodeServer/src/repl.jl
@@ -79,6 +79,7 @@ function evalrepl(m, line, repl, main_mode)
     return try
         JSONRPC.send_notification(conn_endpoint[], "repl/starteval", nothing)
         r = run_with_backend() do
+            fix_displays()
             Logging.with_logger(VSCodeLogger()) do
                 repleval(m, line, REPL.repl_filename(repl, main_mode.hist))
             end

--- a/scripts/packages/VSCodeServer/src/repl_protocol.jl
+++ b/scripts/packages/VSCodeServer/src/repl_protocol.jl
@@ -43,3 +43,4 @@ const repl_isModuleLoaded_request_type = JSONRPC.RequestType("repl/isModuleLoade
 const repl_startdebugger_notification_type = JSONRPC.NotificationType("repl/startdebugger", String)
 const repl_showprofileresult_notification_type = JSONRPC.NotificationType("repl/showprofileresult", String)
 const repl_showprofileresult_file_notification_type = JSONRPC.NotificationType("repl/showprofileresult_file", String)
+const repl_toggle_plot_pane_notification_type = JSONRPC.NotificationType("repl/togglePlotPane", Bool)

--- a/scripts/terminalserver/terminalserver.jl
+++ b/scripts/terminalserver/terminalserver.jl
@@ -21,9 +21,9 @@ let
     end
 
     atreplinit() do repl
-        "USE_PLOTPANE=true" in args && Base.Multimedia.pushdisplay(VSCodeServer.InlineDisplay())
+        VSCodeServer.toggle_plot_pane(nothing, "USE_PLOTPANE=true" in args)
     end
 
     conn_pipeline, telemetry_pipeline = args[1:2]
-    VSCodeServer.serve(conn_pipeline; is_dev = "DEBUG_MODE=true" in args, crashreporting_pipename = telemetry_pipeline)
+    VSCodeServer.serve(conn_pipeline; is_dev="DEBUG_MODE=true" in args, crashreporting_pipename=telemetry_pipeline)
 end

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -569,6 +569,15 @@ export function activate(context: vscode.ExtensionContext) {
     // copy-paste selection into REPL. doesn't require LS to be started
     context.subscriptions.push(vscode.commands.registerCommand('language-julia.executeJuliaCodeInREPL', executeSelectionCopyPaste))
 
+    context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((event: vscode.ConfigurationChangeEvent) => {
+        if (event.affectsConfiguration('julia.usePlotPane')) {
+            try {
+                g_connection.sendNotification('repl/togglePlotPane', vscode.workspace.getConfiguration('julia').get('usePlotPane'))
+            } catch (err) {
+                console.warn(err)
+            }
+        }
+    }))
 
     vscode.window.onDidCloseTerminal(terminal => {
         if (terminal === g_terminal) {


### PR DESCRIPTION
This makes the plot pane setting apply instantly without needing to restart the Julia process. It's also much more robust against other packages trying to inject their own displays above ours.
Also simplifies a bunch of `display`/`displayable` definitions.