### PR TITLE
interrupt evaluation from progress monitor

### DIFF
--- a/scripts/packages/VSCodeServer/src/eval.jl
+++ b/scripts/packages/VSCodeServer/src/eval.jl
@@ -68,6 +68,8 @@ function repl_runcode_request(conn, params::ReplRunCodeRequestParams)
         show_code = params.showCodeInREPL
         show_result = params.showResultInREPL
 
+        JSONRPC.send_notification(conn_endpoint[], "repl/starteval", nothing)
+
         rendered_result = nothing
         Logging.with_logger(VSCodeLogger()) do
             hideprompt() do


### PR DESCRIPTION
Alternative to https://github.com/julia-vscode/julia-vscode/pull/1733 -- this shows an indeterminate progress indicator when evaluating anything inline. Also shows a `Cancel` button, which throws an interrupt at Julia (can't guarantee that'll end up in the actual `@progress` loop, but whatever).