### PR TITLE
pushfirst/popfirst LOAD_PATH

### DIFF
--- a/scripts/debugger/run_debugger.jl
+++ b/scripts/debugger/run_debugger.jl
@@ -1,7 +1,7 @@
 # ENV["JULIA_DEBUG"] = "all"
 
-Base.push!(LOAD_PATH, joinpath(@__DIR__, "..", "packages"))
+pushfirst!(LOAD_PATH, joinpath(@__DIR__, "..", "packages"))
 import VSCodeDebugger
-pop!(LOAD_PATH)
+popfirst!(LOAD_PATH)
 
 VSCodeDebugger.startdebugger()

--- a/scripts/terminalserver/terminalserver.jl
+++ b/scripts/terminalserver/terminalserver.jl
@@ -1,9 +1,8 @@
 # this script basially only handles `ARGS`
 
-
-Base.push!(LOAD_PATH, joinpath(@__DIR__, "..", "packages"))
+pushfirst!(LOAD_PATH, joinpath(@__DIR__, "..", "packages"))
 using VSCodeServer
-pop!(LOAD_PATH)
+popfirst!(LOAD_PATH)
 
 let
     args = [popfirst!(Base.ARGS) for _ in 1:5]


### PR DESCRIPTION
Otherwise we can end up loading the wrong version of VSCodeServer, depending on how `LOAD_PATH` was set.