### PR TITLE
add inline-eval'ed code to repl history

### DIFF
--- a/package.json
+++ b/package.json
@@ -705,7 +705,7 @@
                 "julia.execution.codeInREPL": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Print executed code in REPL.",
+                    "description": "Print executed code in REPL and append it to the REPL history.",
                     "scope": "window"
                 },
                 "julia.packageServer": {


### PR DESCRIPTION
if `codeInREPL` is set.

Fixes https://github.com/julia-vscode/julia-vscode/issues/1752.

I thought about putting this behind another setting, but it feels fairly intuitive to reuse `codeInREPL` for this.