### PR TITLE
improve LS startup interaction with inline eval

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -234,9 +234,8 @@ async function startLanguageServer() {
         // Push the disposable to the context's subscriptions so that the  client can be deactivated on extension deactivation
         g_context.subscriptions.push(languageClient.start())
         startupNotification.command = 'language-julia.showLanguageServerOutput'
-        languageClient.onReady().then(() => {
-            setLanguageClient(languageClient)
-        }).finally(() => {
+        setLanguageClient(languageClient)
+        languageClient.onReady().finally(() => {
             disposable.dispose()
             startupNotification.dispose()
         })

--- a/src/interactive/modules.ts
+++ b/src/interactive/modules.ts
@@ -53,6 +53,7 @@ export async function getModuleForEditor(document: vscode.TextDocument, position
     if (manuallySetModule) { return manuallySetModule }
 
     if (!g_languageClient) { return 'Main' }
+    await g_languageClient.onReady()
     try {
         const params: VersionedTextDocumentPositionParams = {
             textDocument: vslc.TextDocumentIdentifier.create(document.uri.toString()),

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -319,12 +319,13 @@ async function getBlockRange(params): Promise<vscode.Position[]> {
     const zeroPos = new vscode.Position(0, 0)
     const zeroReturn = [zeroPos, zeroPos, params.position]
 
-    const err = 'Error: Julia Language server is not running.\n\nPlease wait a few seconds and try again once the `Starting Julia Language Server...` message in the status bar is gone.'
-
     if (g_languageClient === null) {
-        vscode.window.showErrorMessage(err)
+        vscode.window.showErrorMessage('No LS running or start. Check your settings.')
         return zeroReturn
     }
+
+    await g_languageClient.onReady()
+
     let ret_val: vscode.Position[]
     try {
         ret_val = await g_languageClient.sendRequest('julia/getCurrentBlockRange', params)

--- a/src/jlpkgenv.ts
+++ b/src/jlpkgenv.ts
@@ -72,6 +72,10 @@ export async function switchEnvToPath(envpath: string, notifyLS: boolean) {
     }
 
     if (notifyLS) {
+        if (!g_languageClient) {
+            return
+        }
+        await g_languageClient.onReady()
         g_languageClient.sendNotification('julia/activateenvironment', envpath)
     }
 }


### PR DESCRIPTION
This triggers the `onSetLanguageClient` event right away, not when the LS is ready, which allows consumers to `await` the ready state instead of having to return early. So with this patch you can use inline evaluation straight after starting VSCode without an error message; it will be evaluated after both the LS and the REPL process are ready.