### PR TITLE
refine progress bar

### DIFF
--- a/scripts/packages/VSCodeServer/src/progress.jl
+++ b/scripts/packages/VSCodeServer/src/progress.jl
@@ -7,6 +7,7 @@ function Logging.handle_message(j::VSCodeLogger, level, message, _module,
     end isa Some
 
     if isprogress
+        sleep(.01) # issue #1769
         return nothing
     end
 


### PR DESCRIPTION
may fix #1769. The 0.01s sleep is a bit arbitrary number/a bit of a hack, a better or cleaner option may be to do the progress bar update in another thread?

test with, eg.
```julia
using ProgressLogging
using LinearAlgebra

function f1(nx)
    @withprogress name = "test" for i=1:nx
        m = rand(200, 200)
        ev = eigen(m)
        (i <= 10 || mod(i,20) == 0) && println("now: $i")
        @logprogress i / nx
    end
end

f1(1000)
```