### PR TITLE
Note that julia.environmentPath needs a VS Code reload to take effect

### DIFF
--- a/package.json
+++ b/package.json
@@ -598,7 +598,7 @@
                         "null"
                     ],
                     "default": null,
-                    "description": "Path to a julia environment.",
+                    "description": "Path to a julia environment. VS Code needs to be reloaded for changes to take effect.",
                     "scope": "window"
                 },
                 "julia.useCustomSysimage": {


### PR DESCRIPTION
I was trying to get the REPL to start in a specific directory, so I was trying out different settings for `julia.environmentPath`. But I was just restarting the REPL, so it looked like `julia.environmentPath` was not having any effect. Thanks to @aviatesk on Slack I now realize what's going on (I incorrectly assumed that the environment settings applied just to the REPL), but it might be good to mention something like this.