### PR TITLE
fix bt cropping for inline results

### DIFF
--- a/scripts/packages/VSCodeServer/src/eval.jl
+++ b/scripts/packages/VSCodeServer/src/eval.jl
@@ -263,11 +263,8 @@ function Base.display_error(io::IO, err::EvalError)
 end
 
 function crop_backtrace(bt)
-    i = find_frame_index(bt, @__FILE__, inlineeval)
-    # NOTE:
-    # `4` corresponds to the number of function calls between `inlineeval` to the user code (, which was invoked by `include_string`),
-    # i.e. `inlineeval`, `Base.invokelatest`, `Base.invokelatest` (the method instance with keyword args handled), and `include_string`
-    return bt[1:(i === nothing ? end : i - 4)]
+    i = find_first_topelevel_scope(bt)
+    return bt[1:(i === nothing ? end : i)]
 end
 
 # more cleaner way ?

--- a/scripts/packages/VSCodeServer/src/misc.jl
+++ b/scripts/packages/VSCodeServer/src/misc.jl
@@ -18,7 +18,7 @@ function find_first_topelevel_scope(bt::Vector{<:Union{Base.InterpreterIP,Ptr{Cv
             linfo = frame.linfo
             if linfo isa Core.CodeInfo
                 linetable = linfo.linetable
-                if isa(linetable, Vector{Core.LineInfoNode}) && length(linetable) ≥ 1 && first(linetable).method === Symbol("top-level scope")
+                if isa(linetable, Vector) && length(linetable) ≥ 1 && first(linetable).method === Symbol("top-level scope")
                     return true
                 end
             end

--- a/scripts/packages/VSCodeServer/src/misc.jl
+++ b/scripts/packages/VSCodeServer/src/misc.jl
@@ -11,8 +11,21 @@ function find_frame_index(bt::Vector{<:Union{Base.InterpreterIP,Ptr{Cvoid}}}, fi
     end
     return
 end
-
-
+function find_first_topelevel_scope(bt::Vector{<:Union{Base.InterpreterIP,Ptr{Cvoid}}})
+    for (i, ip) in enumerate(bt)
+        st = Base.StackTraces.lookup(ip)
+        ind = findfirst(st) do frame
+            if frame.linfo isa Base.CodeInfo
+                if frame.linfo.linetable[1].method == Symbol("top-level scope")
+                    return true
+                end
+            end
+            return false
+        end
+        ind === nothing || return i
+    end
+    return
+end
 # path utilitiles
 # ---------------
 

--- a/scripts/packages/VSCodeServer/src/misc.jl
+++ b/scripts/packages/VSCodeServer/src/misc.jl
@@ -1,16 +1,6 @@
 # error handling
 # --------------
 
-find_frame_index(st::Vector{Base.StackTraces.StackFrame}, file, func) =
-    return findfirst(frame -> frame.file === Symbol(file) && frame.func === Symbol(func), st)
-function find_frame_index(bt::Vector{<:Union{Base.InterpreterIP,Ptr{Cvoid}}}, file, func)
-    for (i, ip) in enumerate(bt)
-        st = Base.StackTraces.lookup(ip)
-        ind = find_frame_index(st, file, func)
-        ind === nothing || return i
-    end
-    return
-end
 function find_first_topelevel_scope(bt::Vector{<:Union{Base.InterpreterIP,Ptr{Cvoid}}})
     for (i, ip) in enumerate(bt)
         st = Base.StackTraces.lookup(ip)

--- a/scripts/packages/VSCodeServer/src/misc.jl
+++ b/scripts/packages/VSCodeServer/src/misc.jl
@@ -18,7 +18,7 @@ function find_first_topelevel_scope(bt::Vector{<:Union{Base.InterpreterIP,Ptr{Cv
             linfo = frame.linfo
             if linfo isa Core.CodeInfo
                 linetable = linfo.linetable
-                if isa(linetable, Core.LineInfoNode) && length(linetable) ≥ 1 && first(linetable).method === Symbol("top-level scope")
+                if isa(linetable, Vector{Core.LineInfoNode}) && length(linetable) ≥ 1 && first(linetable).method === Symbol("top-level scope")
                     return true
                 end
             end

--- a/scripts/packages/VSCodeServer/src/misc.jl
+++ b/scripts/packages/VSCodeServer/src/misc.jl
@@ -8,8 +8,11 @@ function find_first_topelevel_scope(bt::Vector{<:Union{Base.InterpreterIP,Ptr{Cv
             linfo = frame.linfo
             if linfo isa Core.CodeInfo
                 linetable = linfo.linetable
-                if isa(linetable, Vector) && length(linetable) ≥ 1 && first(linetable).method === Symbol("top-level scope")
-                    return true
+                if isa(linetable, Vector) && length(linetable) ≥ 1
+                    lin = first(linetable)
+                    if isa(lin, Core.LineInfoNode) && lin.method === Symbol("top-level scope")
+                        return true
+                    end
                 end
             end
             return false
@@ -18,6 +21,7 @@ function find_first_topelevel_scope(bt::Vector{<:Union{Base.InterpreterIP,Ptr{Cv
     end
     return
 end
+
 # path utilitiles
 # ---------------
 

--- a/scripts/packages/VSCodeServer/src/misc.jl
+++ b/scripts/packages/VSCodeServer/src/misc.jl
@@ -15,8 +15,10 @@ function find_first_topelevel_scope(bt::Vector{<:Union{Base.InterpreterIP,Ptr{Cv
     for (i, ip) in enumerate(bt)
         st = Base.StackTraces.lookup(ip)
         ind = findfirst(st) do frame
-            if frame.linfo isa Base.CodeInfo
-                if frame.linfo.linetable[1].method == Symbol("top-level scope")
+            linfo = frame.linfo
+            if linfo isa Core.CodeInfo
+                linetable = linfo.linetable
+                if isa(linetable, Core.LineInfoNode) && length(linetable) ≥ 1 && first(linetable).method === Symbol("top-level scope")
                     return true
                 end
             end


### PR DESCRIPTION
Turns out I broke this in the last release.
![image](https://user-images.githubusercontent.com/6735977/101385407-0db67300-38bc-11eb-85e4-e733b75292b7.png)
