### PR TITLE
Fix ReadMe Getting Started list numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ This [VS Code](https://code.visualstudio.com) extension provides support for the
 ### Installing Julia/VS Code/VS Code Julia extension
 1. Install Julia for your platform: https://julialang.org/downloads/
 2. Install VS Code for your platform: https://code.visualstudio.com/download   
-At the end of this step you should be able to start VS Code.
+    At the end of this step you should be able to start VS Code.
 3. Install the Julia VS Code extension:  
-3.1 Start VS Code.    
-3.2 Inside VS Code, go to the extensions view either by
-executing the ``View: Show Extensions`` command (click View->Command Palette...)
-or by clicking on the extension icon on the left side of the VS Code
-window.      
-3.3 In the extensions view, simply search for the term ``julia`` in the marketplace
-search box, then select the extension named ``Julia`` and click the install button.
-You might have to restart VS Code after this step.
+    1. Start VS Code.    
+    2. Inside VS Code, go to the extensions view either by
+        executing the ``View: Show Extensions`` command (click View->Command Palette...)
+        or by clicking on the extension icon on the left side of the VS Code
+        window.      
+    3. In the extensions view, simply search for the term ``julia`` in the marketplace
+        search box, then select the extension named ``Julia`` and click the install button.
+        You might have to restart VS Code after this step.
 
 ### Configure the Julia extension
 


### PR DESCRIPTION
Currently the "Getting Started" instructions do not look right when I open the extension in VS code. I think this is because the list of instructions is not indented correctly. This PR fixes that.

For the record here is what it currently looks like for me:
<img width="610" alt="Screen Shot 2020-12-10 at 1 41 53 pm" src="https://user-images.githubusercontent.com/4486578/101714504-d0392c00-3aed-11eb-80f4-97578f8083df.png">
where you can see the numbering is thrown off by the lack of indentation. 