### PR TITLE
Cell move commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -392,16 +392,6 @@
                 "when": "editorTextFocus && editorLangId == julia"
             },
             {
-                "command": "language-julia.moveCellUp",
-                "key": "ctrl+alt+[",
-                "when": "editorTextFocus && editorLangId == julia"
-            },
-            {
-                "command": "language-julia.moveCellDown",
-                "key": "ctrl+alt+]",
-                "when": "editorTextFocus && editorLangId == julia"
-            },
-            {
                 "command": "language-julia.clearCurrentInlineResult",
                 "key": "Ctrl+I Ctrl+D",
                 "when": "editorTextFocus && !editorHasSelection && !findWidgetVisible && !markerNavigationVisible && !parameterHintsVisible && !inSnippetMode && !isInEmbeddedEditor && !suggestWidgetVisible && !onTypeRenameInputVisible && !renameInputVisible && editorLangId == julia && juliaHasInlineResult"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
         "onCommand:language-julia.executeCell",
         "onCommand:language-julia.executeJuliaBlockInREPL",
         "onCommand:language-julia.selectBlock",
+        "onCommand:language-julia.moveCellUp",
+        "onCommand:language-julia.moveCellDown",
         "onCommand:language-julia.debug.getActiveJuliaEnvironment",
         "onCommand:language-julia.debugEditorContents",
         "onCommand:language-julia.runEditorContents",
@@ -212,6 +214,14 @@
                 "title": "Julia: Execute Code Cell And Move"
             },
             {
+                "command": "language-julia.moveCellUp",
+                "title": "Julia: Move to Previous Cell"
+            },
+            {
+                "command": "language-julia.moveCellDown",
+                "title": "Julia: Move to Next Cell"
+            },
+            {
                 "command": "language-julia.selectBlock",
                 "title": "Julia: Select Code Block"
             },
@@ -379,6 +389,16 @@
             {
                 "command": "language-julia.executeCellAndMove",
                 "key": "shift+Enter",
+                "when": "editorTextFocus && editorLangId == julia"
+            },
+            {
+                "command": "language-julia.moveCellUp",
+                "key": "ctrl+alt+[",
+                "when": "editorTextFocus && editorLangId == julia"
+            },
+            {
+                "command": "language-julia.moveCellDown",
+                "key": "ctrl+alt+]",
                 "when": "editorTextFocus && editorLangId == julia"
             },
             {


### PR DESCRIPTION
This adds commands to move to next and previous cell (part of #1278).
I assigned the shortcuts `ctrl+alt+[` and `ctrl+alt+]` to match the vscode python extension, although the behavior matches Juno (moving to previous cell moves to its last line, rather than the first).
Another option is alt+arrows, like Juno, but vscode uses those for "move line".