### PR TITLE
fixes: #1753

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -151,12 +151,12 @@ async function startLanguageServer() {
     const serverArgsDebug = ['--startup-file=no', '--history-file=no', '--depwarn=no', `--project=${envForLSPath}`, 'main.jl', jlEnvPath, '--debug=yes', telemetry.getCrashReportingPipename(), oldDepotPath, g_context.globalStoragePath]
     const spawnOptions = {
         cwd: path.join(g_context.extensionPath, 'scripts', 'languageserver'),
-        env: {
-            JULIA_DEPOT_PATH: path.join(g_context.extensionPath, 'scripts', 'languageserver', 'julia_pkgdir'),
+        env: Object.assign(process.env, {
+            JULIA_DEPOT_PATH: path.join(g_context.extensionPath, 'scripts', 'languageserver', 'julia_pkgdir') + ':' + oldDepotPath,
             JULIA_LOAD_PATH: process.platform === 'win32' ? ';' : ':',
             HOME: process.env.HOME ? process.env.HOME : os.homedir(),
             JULIA_LANGUAGESERVER: '1'
-        }
+        })
     }
 
     const jlexepath = await juliaexepath.getJuliaExePath()

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -65,10 +65,10 @@ async function startREPL(preserveFocus: boolean, showTerminal: boolean = true) {
             return jlarg2
         }
 
-        const env = {
+        const env = Object.assign(process.env, {
             JULIA_EDITOR: get_editor(),
             JULIA_NUM_THREADS: inferJuliaNumThreads()
-        }
+        })
 
         const pkgServer: string = vscode.workspace.getConfiguration('julia').get('packageServer')
         if (pkgServer.length !== 0) {


### PR DESCRIPTION
Intel MKL linked julia requires MKL related path variables present, not preserving the original environment will lead to silent, hard to debug, crashes. In the PR
the original environment is augemnted with julia vs-code environment, allowing Intel MKL compiled julia be used as a back end.

Im addition this PR may fix other pending issues related to JULIA_DEPOT_PATH, by preserving the old_depot_path, and adding a closing ':' token to allow julia to use its default
DEPOT_PATH mechanism.