### PR TITLE
Color Customization for Inline Result Bubbles

### DIFF
--- a/package.json
+++ b/package.json
@@ -712,6 +712,12 @@
                         "Shows inline execution results in REPL and inline bubbles"
                     ]
                 },
+                "julia.execution.inlineResults.colors": {
+                    "type": "object",
+                    "default": {},
+                    "markdownDescription": "Customizes the colors of inline results when they are displayed in the editor. \n* Available keys for this setting are : \n\t* `foreground`: foreground text color\n\t* `foreground-light`: foreground text color in light themes \n\t* `foreground-dark`: foreground text color in dark themes\n\t* `background`: background color\n\t* `background-light`: background color in light themes\n\t* `background-dark`: background color in dark themes\n\t* `accent`: accent color for normal execution results\n\t* `accent-error`: accent color for error execution results \n* Accepted values are: \n\t* valid CSS color strings\n\t* VS Code [Theme Colors](https://code.visualstudio.com/api/references/theme-color), prefixed by `vscode.` (i.e. `vscode.editor.foreground`)",
+                    "scope": "window"
+                },
                 "julia.execution.codeInREPL": {
                     "type": "boolean",
                     "default": false,

--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -90,7 +90,7 @@ export class Result {
         const colorConfig = section.get<object>('execution.inlineResults.colors')
 
         let colorFor = function (candidates: string[], defaultCallBack: () => string | vscode.ThemeColor): string | vscode.ThemeColor {
-            if (candidates.length) {
+            if (candidates.length > 0) {
                 if (colorConfig && colorConfig[candidates[0]]) {
                     let color: string = colorConfig[candidates[0]]
                     return color.startsWith('vscode.') ? new vscode.ThemeColor(color.replace(/^(vscode\.)/, '')) : color

--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -113,8 +113,10 @@ export class Result {
                 color: colorFor(['foreground'], () => new vscode.ThemeColor('editor.foreground')),
                 backgroundColor: colorFor(['background'], () => '#ffffff22'),
                 margin: '0 0 0 10px',
+                border: "2px solid",
+                borderColor: accentColor,
                 // HACK: CSS injection to get custom styling in:
-                textDecoration: `none; white-space: pre; border-left: 2px ${accentColor} solid; border-radius: 2px`
+                textDecoration: `none; white-space: pre; border-top: 0px; border-right: 0px; border-bottom: 0px; border-radius: 2px`
             },
             dark: {
                 before: {

--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -89,29 +89,29 @@ export class Result {
         const section = vscode.workspace.getConfiguration('julia')
         const colorConfig = section.get<object>('execution.inlineResults.colors')
 
-        let colorFor = function (candidates: string[], defaultCallBack: () => string | vscode.ThemeColor): string | vscode.ThemeColor {
+        let colorFor = function (candidates: string[], defaultTo: string | vscode.ThemeColor): string | vscode.ThemeColor {
             if (candidates.length > 0) {
                 if (colorConfig && colorConfig[candidates[0]]) {
                     let color: string = colorConfig[candidates[0]]
                     return color.startsWith('vscode.') ? new vscode.ThemeColor(color.replace(/^(vscode\.)/, '')) : color
                 } else {
-                    return colorFor(candidates.slice(1), defaultCallBack)
+                    return colorFor(candidates.slice(1), defaultTo)
                 }
             } else {
-                return defaultCallBack()
+                return defaultTo
             }
         }
 
         const accentColor = this.content.isError
-            ? colorFor(['accent-error'], () => '#d11111')
-            : colorFor(['accent'], () => '#159eed')
+            ? colorFor(['accent-error'], '#d11111')
+            : colorFor(['accent'], '#159eed')
 
         return {
             before: {
                 contentIconPath: undefined,
                 contentText: undefined,
-                color: colorFor(['foreground'], () => new vscode.ThemeColor('editor.foreground')),
-                backgroundColor: colorFor(['background'], () => '#ffffff22'),
+                color: colorFor(['foreground'], new vscode.ThemeColor('editor.foreground')),
+                backgroundColor: colorFor(['background'], '#ffffff22'),
                 margin: '0 0 0 10px',
                 border: "2px solid",
                 borderColor: accentColor,
@@ -120,14 +120,14 @@ export class Result {
             },
             dark: {
                 before: {
-                    color: colorFor(['foreground-dark', 'foreground'], () => new vscode.ThemeColor('editor.foreground')),
-                    backgroundColor: colorFor(['background-dark', 'background'], () => '#ffffff22')
+                    color: colorFor(['foreground-dark', 'foreground'], new vscode.ThemeColor('editor.foreground')),
+                    backgroundColor: colorFor(['background-dark', 'background'], '#ffffff22')
                 }
             },
             light: {
                 before: {
-                    color: colorFor(['foreground-light', 'foreground'], () => new vscode.ThemeColor('editor.foreground')),
-                    backgroundColor: colorFor(['background-light', 'background'], () => '#00000011')
+                    color: colorFor(['foreground-light', 'foreground'], new vscode.ThemeColor('editor.foreground')),
+                    backgroundColor: colorFor(['background-light', 'background'], '#00000011')
                 }
             },
             rangeBehavior: vscode.DecorationRangeBehavior.OpenClosed,

--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -86,25 +86,46 @@ export class Result {
 
     createResultDecoration(): vscode.DecorationRenderOptions {
 
-        const borderColor = this.content.isError ? '#d11111' : '#159eed'
+        const section = vscode.workspace.getConfiguration('julia')
+        const colorConfig = section.get<object>("execution.inlineResults.colors")
+
+        let colorFor = function (candidates: string[], defaultCallBack: () => string | vscode.ThemeColor): string | vscode.ThemeColor {
+            if (candidates.length) {
+                if (colorConfig && colorConfig[candidates[0]]) {
+                    let color: string = colorConfig[candidates[0]]
+                    return color.startsWith('vscode.') ? new vscode.ThemeColor(color.replace(/^(vscode\.)/, "")) : color
+                } else {
+                    return colorFor(candidates.slice(1), defaultCallBack)
+                }
+            } else {
+                return defaultCallBack()
+            }
+        }
+
+        const accentColor = this.content.isError
+            ? colorFor(['accent-error'], () => '#d11111')
+            : colorFor(['accent'], () => '#159eed')
+
         return {
             before: {
                 contentIconPath: undefined,
                 contentText: undefined,
-                color: new vscode.ThemeColor('editor.foreground'),
-                backgroundColor: '#ffffff22',
+                color: colorFor(['foreground'], () => new vscode.ThemeColor('editor.foreground')),
+                backgroundColor: colorFor(['background'], () => '#ffffff22'),
                 margin: '0 0 0 10px',
                 // HACK: CSS injection to get custom styling in:
-                textDecoration: `none; white-space: pre; border-left: 2px ${borderColor} solid; border-radius: 2px`
+                textDecoration: `none; white-space: pre; border-left: 2px ${accentColor} solid; border-radius: 2px`
             },
             dark: {
                 before: {
-                    backgroundColor: '#ffffff22'
+                    color: colorFor(['foreground-dark', 'foreground'], () => new vscode.ThemeColor('editor.foreground')),
+                    backgroundColor: colorFor(['background-dark', 'background'], () => '#ffffff22')
                 }
             },
             light: {
                 before: {
-                    backgroundColor: '#00000011'
+                    color: colorFor(['foreground-light', 'foreground'], () => new vscode.ThemeColor('editor.foreground')),
+                    backgroundColor: colorFor(['background-light', 'background'], () => '#00000011')
                 }
             },
             rangeBehavior: vscode.DecorationRangeBehavior.OpenClosed,

--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -87,13 +87,13 @@ export class Result {
     createResultDecoration(): vscode.DecorationRenderOptions {
 
         const section = vscode.workspace.getConfiguration('julia')
-        const colorConfig = section.get<object>("execution.inlineResults.colors")
+        const colorConfig = section.get<object>('execution.inlineResults.colors')
 
         let colorFor = function (candidates: string[], defaultCallBack: () => string | vscode.ThemeColor): string | vscode.ThemeColor {
             if (candidates.length) {
                 if (colorConfig && colorConfig[candidates[0]]) {
                     let color: string = colorConfig[candidates[0]]
-                    return color.startsWith('vscode.') ? new vscode.ThemeColor(color.replace(/^(vscode\.)/, "")) : color
+                    return color.startsWith('vscode.') ? new vscode.ThemeColor(color.replace(/^(vscode\.)/, '')) : color
                 } else {
                     return colorFor(candidates.slice(1), defaultCallBack)
                 }

--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -113,10 +113,10 @@ export class Result {
                 color: colorFor(['foreground'], new vscode.ThemeColor('editor.foreground')),
                 backgroundColor: colorFor(['background'], '#ffffff22'),
                 margin: '0 0 0 10px',
-                border: "2px solid",
+                border: '2px solid',
                 borderColor: accentColor,
                 // HACK: CSS injection to get custom styling in:
-                textDecoration: `none; white-space: pre; border-top: 0px; border-right: 0px; border-bottom: 0px; border-radius: 2px`
+                textDecoration: 'none; white-space: pre; border-top: 0px; border-right: 0px; border-bottom: 0px; border-radius: 2px'
             },
             dark: {
                 before: {

--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -89,10 +89,10 @@ export class Result {
         const section = vscode.workspace.getConfiguration('julia')
         const colorConfig = section.get<object>('execution.inlineResults.colors')
 
-        let colorFor = function (candidates: string[], defaultTo: string | vscode.ThemeColor): string | vscode.ThemeColor {
+        const colorFor = function (candidates: string[], defaultTo: string | vscode.ThemeColor): string | vscode.ThemeColor {
             if (candidates.length > 0) {
                 if (colorConfig && colorConfig[candidates[0]]) {
-                    let color: string = colorConfig[candidates[0]]
+                    const color: string = colorConfig[candidates[0]]
                     return color.startsWith('vscode.') ? new vscode.ThemeColor(color.replace(/^(vscode\.)/, '')) : color
                 } else {
                     return colorFor(candidates.slice(1), defaultTo)


### PR DESCRIPTION
This will help with accessibility and reasoning about code structure.

To consider :
- Naming of configuration strings, which will be hard to deprecate.
- Whether to allow users to bind colors to [theme colors](https://code.visualstudio.com/api/references/theme-color). The `vscode.` prefix is necessary because programmatically verifying theme colors is unsupported. Prefixing seems mostly consistent with [other areas](https://code.visualstudio.com/api/extension-guides/webview#theming-webview-content) of the API.

Other notes : 
- Currently proposes that we refer to the left border as "accent", since at some point we may want to somehow support an all-around border -- these seem to be more central in high contrast color themes. 
- In settings, I wanted this to follow logically after `Julia > Execution : Result Type`, but couldn't find a way alphabetically.

Thanks to @pfitzseb for pointing me to the necessary resources.

![Screen Shot 2021-01-06 at 11 01 51 AM](https://user-images.githubusercontent.com/51499038/103721023-0647ce00-5010-11eb-92b9-f1b6dd77c2bb.png)