### PR TITLE
better word separators for Julia

### DIFF
--- a/package.json
+++ b/package.json
@@ -734,7 +734,8 @@
         },
         "configurationDefaults": {
             "[julia]": {
-                "editor.quickSuggestions": true
+                "editor.quickSuggestions": true,
+                "editor.wordSeparators": "`~#$%^&*()-=+[{]}\\|;:'\",.<>/?"
             }
         },
         "taskDefinitions": [


### PR DESCRIPTION
`@` and `!` are part of identifiers in Julia, so they shouldn't be in the list of word separators. Fixes https://github.com/julia-vscode/julia-vscode/issues/1860.