### PR TITLE
Fix a race condition

### DIFF
--- a/src/interactive/modules.ts
+++ b/src/interactive/modules.ts
@@ -52,17 +52,19 @@ export async function getModuleForEditor(document: vscode.TextDocument, position
     const manuallySetModule = manuallySetDocuments[document.fileName]
     if (manuallySetModule) { return manuallySetModule }
 
-    if (!g_languageClient) { return 'Main' }
-    await g_languageClient.onReady()
+    const languageClient = g_languageClient
+
+    if (!languageClient) { return 'Main' }
+    await languageClient.onReady()
     try {
         const params: VersionedTextDocumentPositionParams = {
             textDocument: vslc.TextDocumentIdentifier.create(document.uri.toString()),
             version: document.version,
             position: position
         }
-        return await g_languageClient.sendRequest<string>('julia/getModuleAt', params)
+        return await languageClient.sendRequest<string>('julia/getModuleAt', params)
     } catch (err) {
-        if (g_languageClient) {
+        if (languageClient) {
             telemetry.handleNewCrashReportFromException(err, 'Extension')
         }
         return 'Main'


### PR DESCRIPTION
This might fix [this](https://portal.azure.com/#blade/AppInsightsExtension/DetailsV2Blade/ComponentId/%7B%22SubscriptionId%22%3A%226803c4ed-bcb4-41d4-bceb-7faf5e7a3469%22%2C%22ResourceGroup%22%3A%22Default%22%2C%22Name%22%3A%22julia-vscode-insider%22%2C%22LinkedApplicationType%22%3A0%2C%22ResourceId%22%3A%22%2Fsubscriptions%2F6803c4ed-bcb4-41d4-bceb-7faf5e7a3469%2FresourceGroups%2FDefault%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2Fjulia-vscode-insider%22%2C%22ResourceType%22%3A%22microsoft.insights%2Fcomponents%22%2C%22IsAzureFirst%22%3Afalse%7D/DataModel/%7B%22eventId%22%3A%22b00403d9-58ff-11eb-b315-7be397f49349%22%2C%22timestamp%22%3A%222021-01-17T20%3A07%3A55.645Z%22%2C%22cacheId%22%3A%22de8c4cec-9f05-4825-85de-40c5e928d6ed%22%2C%22eventTable%22%3A%22exceptions%22%7D).

My theory here is that the value of `g_languageClient` is changed somewhere in the call to `onReady`, so that one can end up in a situation `g_languageClient` refers to different things throughout this function. Trying to solve this by making a local copy at the beginning.