### PR TITLE
Add support for tagging package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
         "onCommand:language-julia.cdHere",
         "onCommand:language-julia.activateHere",
         "onCommand:language-julia.activateFromDir",
+        "onCommand:language-julia.tagNewPackageVersion",
         "onLanguage:julia",
         "onLanguage:juliamarkdown",
         "workspaceContains:deps/build.jl",
@@ -124,6 +125,10 @@
             {
                 "command": "language-julia.openPackageDirectory",
                 "title": "Julia: Open Package Directory in New Window"
+            },
+            {
+                "command": "language-julia.tagNewPackageVersion",
+                "title": "Julia: Tag new package version (experimental)"
             },
             {
                 "command": "language-julia.changeCurrentEnvironment",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "preview": false,
     "publisher": "julialang",
     "engines": {
-        "vscode": "^1.47.0"
+        "vscode": "^1.52.0"
     },
     "license": "SEE LICENSE IN LICENSE",
     "bugs": {

--- a/scripts/environments/pkgdev/Manifest.toml
+++ b/scripts/environments/pkgdev/Manifest.toml
@@ -1,0 +1,228 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Artifacts]]
+deps = ["Pkg"]
+git-tree-sha1 = "c30985d8821e0cd73870b17b0ed0ce6dc44cb744"
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.3.0"
+
+[[AutoHashEquals]]
+git-tree-sha1 = "45bb6705d93be619b81451bb2006b7ee5d4e4453"
+uuid = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
+version = "0.2.0"
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[CSTParser]]
+deps = ["Tokenize"]
+git-tree-sha1 = "e5113dea282811e2548bf2fb665b0c3293b7500c"
+uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
+version = "3.0.0"
+
+[[DataAPI]]
+git-tree-sha1 = "ad84f52c0b8f05aa20839484dbaf01690b41ff84"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.4.0"
+
+[[DataValueInterfaces]]
+git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
+uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
+version = "1.0.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[DocumentFormat]]
+deps = ["CSTParser", "FilePathsBase", "Tokenize"]
+git-tree-sha1 = "702597e975cd21c3c1b7fc4cf091e84d83ba5f94"
+uuid = "ffa9a821-9c82-50df-894e-fbcef3ed31cd"
+version = "3.2.1"
+
+[[FilePathsBase]]
+deps = ["Dates", "Mmap", "Printf", "Test", "UUIDs"]
+git-tree-sha1 = "2c04f566b1d57cc67e75cb058c2b4080d055156c"
+uuid = "48062228-2e41-5def-b9a4-89aafe57970f"
+version = "0.9.7"
+
+[[GitHub]]
+deps = ["Base64", "Dates", "HTTP", "JSON", "MbedTLS", "Sockets", "SodiumSeal"]
+git-tree-sha1 = "a4f61fc1b1724e6eec1d9333eac2d4b01d8fcc8f"
+uuid = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
+version = "5.4.0"
+
+[[HTTP]]
+deps = ["Base64", "Dates", "IniFile", "MbedTLS", "Sockets", "URIs"]
+git-tree-sha1 = "63055ee44b5c2b95ec1921edcf856c60124ff0c3"
+uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+version = "0.9.2"
+
+[[IniFile]]
+deps = ["Test"]
+git-tree-sha1 = "098e4d2c533924c921f9f9847274f2ad89e018b8"
+uuid = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
+version = "0.5.0"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[IteratorInterfaceExtensions]]
+git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
+uuid = "82899510-4779-5014-852e-03e436cf321d"
+version = "1.0.0"
+
+[[JLLWrappers]]
+git-tree-sha1 = "a431f5f2ca3f4feef3bd7a5e94b8b8d4f2f647a0"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.2.0"
+
+[[JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.1"
+
+[[LibGit2]]
+deps = ["Printf"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[MbedTLS]]
+deps = ["Dates", "MbedTLS_jll", "Random", "Sockets"]
+git-tree-sha1 = "1c38e51c3d08ef2278062ebceade0e46cefc96fe"
+uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
+version = "1.0.3"
+
+[[MbedTLS_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "0eef589dd1c26a3ac9d753fe1a8bcad63f956fa6"
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.16.8+1"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[Mustache]]
+deps = ["Printf", "Tables"]
+git-tree-sha1 = "36995ef0d532fe08119d70b2365b7b03d4e00f48"
+uuid = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
+version = "1.0.10"
+
+[[Parsers]]
+deps = ["Dates"]
+git-tree-sha1 = "50c9a9ed8c714945e01cd53a21007ed3865ed714"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "1.0.15"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[PkgButlerEngine]]
+deps = ["Mustache", "Pkg"]
+git-tree-sha1 = "2933a828f7d520db4ccbf6b992cfa9c6bcae7ed3"
+uuid = "5c9c0fc8-7103-448b-bb0a-c427020e3b0b"
+version = "1.9.0"
+
+[[PkgDev]]
+deps = ["Base64", "DocumentFormat", "FilePathsBase", "GitHub", "JSON", "LibGit2", "Pkg", "PkgButlerEngine", "RegistryTools", "URIParser", "UUIDs"]
+git-tree-sha1 = "e713ef88b25768ff77ba5006561a18f872a89e1e"
+uuid = "149e707d-584d-56d3-88ec-740c18e106ff"
+version = "1.6.0"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[RegistryTools]]
+deps = ["AutoHashEquals", "LibGit2", "Pkg", "UUIDs"]
+git-tree-sha1 = "60522125b10a3b71b07677302c3aedd0b4363835"
+uuid = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
+version = "1.5.3"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SodiumSeal]]
+deps = ["Base64", "Libdl", "libsodium_jll"]
+git-tree-sha1 = "80cef67d2953e33935b41c6ab0a178b9987b1c99"
+uuid = "2133526b-2bfb-4018-ac12-889fb3908a75"
+version = "0.1.1"
+
+[[TableTraits]]
+deps = ["IteratorInterfaceExtensions"]
+git-tree-sha1 = "b1ad568ba658d8cbb3b892ed5380a6f3e781a81e"
+uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+version = "1.0.0"
+
+[[Tables]]
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "TableTraits", "Test"]
+git-tree-sha1 = "240d19b8762006ff04b967bdd833269ad642d550"
+uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+version = "1.2.2"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[Tokenize]]
+git-tree-sha1 = "d7fd9a39c6c6b40d3fee07056cde300ed2cc48b0"
+uuid = "0796e94c-ce3b-5d07-9a54-7f471281c624"
+version = "0.5.10"
+
+[[URIParser]]
+deps = ["Unicode"]
+git-tree-sha1 = "53a9f49546b8d2dd2e688d216421d050c9a31d0d"
+uuid = "30578b45-9adc-5946-b283-645ec420af67"
+version = "0.4.1"
+
+[[URIs]]
+git-tree-sha1 = "7855809b88d7b16e9b029afd17880930626f54a2"
+uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
+version = "1.2.0"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[libsodium_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "7127f5f40332ccfa43ee07dcd0c4d81a27d9bb23"
+uuid = "a9144af2-ca23-56d9-984f-0d03f7b5ccf8"
+version = "1.0.18+1"

--- a/scripts/environments/pkgdev/Project.toml
+++ b/scripts/environments/pkgdev/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+PkgDev = "149e707d-584d-56d3-88ec-740c18e106ff"

--- a/scripts/packagedev/tagnewpackageversion.jl
+++ b/scripts/packagedev/tagnewpackageversion.jl
@@ -1,0 +1,30 @@
+using Pkg
+
+Pkg.instantiate()
+
+using PkgDev
+
+try
+    version_arg = ARGS[3]
+    new_version = nothing
+
+    if version_arg=="Next"
+        new_version = nothing
+    elseif version_arg=="Major"
+        new_version = :major
+    elseif version_arg=="Minor"
+        new_version = :minor
+    elseif version_arg=="Patch"
+        new_version = :patch
+    else
+        new_version = Base.VersionNumber(version_arg)
+    end
+
+    PkgDev.tag(PkgDev.FilePathsBase.cwd(), new_version, credentials=ARGS[1], github_username=ARGS[2])
+
+catch err
+    Base.display_error(err, catch_backtrace())
+end
+
+println("FINISHED")
+readline()

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,7 @@ import * as repl from './interactive/repl'
 import * as jlpkgenv from './jlpkgenv'
 import * as juliaexepath from './juliaexepath'
 import * as openpackagedirectory from './openpackagedirectory'
+import { JuliaPackageDevFeature } from './packagedevtools'
 import * as packagepath from './packagepath'
 import * as smallcommands from './smallcommands'
 import * as tasks from './tasks'
@@ -67,6 +68,7 @@ export async function activate(context: vscode.ExtensionContext) {
         jlpkgenv.activate(context)
 
         context.subscriptions.push(new JuliaDebugFeature(context))
+        context.subscriptions.push(new JuliaPackageDevFeature(context))
 
         g_startupNotification = vscode.window.createStatusBarItem()
         context.subscriptions.push(g_startupNotification)

--- a/src/packagedevtools.ts
+++ b/src/packagedevtools.ts
@@ -1,0 +1,50 @@
+import * as path from 'path'
+import * as vscode from 'vscode'
+import { getJuliaExePath } from './juliaexepath'
+import * as telemetry from './telemetry'
+
+export class JuliaPackageDevFeature {
+    constructor(private context: vscode.ExtensionContext) {
+        this.context.subscriptions.push(vscode.commands.registerCommand('language-julia.tagNewPackageVersion', () => this.tagNewPackageVersion()))
+    }
+
+    private async tagNewPackageVersion() {
+        telemetry.traceEvent('command-tagnewpackageversion')
+
+        let resultVersion = await vscode.window.showQuickPick(['Next', 'Major', 'Minor', 'Patch', 'Custom'], { placeHolder: 'Please select the version to be tagged.' })
+
+        if (resultVersion === 'Custom') {
+            resultVersion = await vscode.window.showInputBox({ prompt: 'Please enter the version number you want to tag.' })
+        }
+
+        if (resultVersion !== undefined) {
+            const bar = await vscode.authentication.getSession('github', ['repo'], { createIfNone: true })
+            const accessToken = bar.accessToken
+            const account = bar.account.label
+
+            const exepath = await getJuliaExePath()
+
+            const newTerm = vscode.window.createTerminal(
+                {
+                    name: 'Julia: Tag a new package version',
+                    shellPath: exepath,
+                    shellArgs: [
+                        path.join(this.context.extensionPath, 'scripts', 'packagedev', 'tagnewpackageversion.jl'),
+                        accessToken,
+                        account,
+                        resultVersion
+                    ],
+                    cwd: vscode.workspace.workspaceFolders[0].uri.fsPath,
+                    env: {
+                        JULIA_PROJECT: path.join(this.context.extensionPath, 'scripts', 'environments', 'pkgdev')
+                    },
+
+                }
+            )
+
+            newTerm.show(true)
+        }
+    }
+
+    public dispose() { }
+}


### PR DESCRIPTION
This makes the `tag` functionality from PkgDev.jl available through the extension.

I'm pretty sure there are still some corner cases that this doesn't handle properly, and we could probably also improve on the UI, but on the other hand it really, really simplifies tagging a new version :) And one major benefit of using this from VS Code rather than directly as a package is that we can get the authentication info from VS Code, so that is a lot less brittle than the normal way in PkgDev of trying to get the credentials from the git credential manager.

Not sure, should we maybe just merge and leave it with the `experimental` label and then fix things as they come up?