### PR TITLE
Add option for live test file

### DIFF
--- a/package.json
+++ b/package.json
@@ -801,6 +801,12 @@
                     "default": "",
                     "description": "Julia package server. Set's the `JULIA_PKG_SERVER` environment variable *before* starting a Julia process. Leave this empty to use the systemwide default. Requires a restart of the Julia process.",
                     "scope": "machine-overridable"
+                },
+                "julia.liveTestFile": {
+                    "type": "string",
+                    "default": "test/runtests.jl",
+                    "description": "A workspace relative path to a Julia file that contains the tests that should be run for live testing.",
+                    "scope": "window"
                 }
             }
         },

--- a/scripts/tasks/task_liveunittesting.jl
+++ b/scripts/tasks/task_liveunittesting.jl
@@ -2,4 +2,4 @@ pushfirst!(LOAD_PATH, joinpath(@__DIR__, "..", "packages"))
 import VSCodeLiveUnitTesting
 popfirst!(LOAD_PATH)
 
-VSCodeLiveUnitTesting.live_unit_test(ARGS[1])
+VSCodeLiveUnitTesting.live_unit_test(ARGS[1], ARGS[2])

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -51,7 +51,7 @@ class JuliaTaskProvider {
                 testTaskWithCoverage.presentationOptions = { echo: false, focus: false, panel: vscode.TaskPanelKind.Dedicated, clear: true }
                 result.push(testTaskWithCoverage)
 
-                const livetestTask = new vscode.Task({ type: 'julia', command: 'livetest' }, folder, `Run live unit tests (experimental)`, 'julia', new vscode.ProcessExecution(jlexepath, ['--color=yes', `--project=${pkgenvpath}`, path.join(this.context.extensionPath, 'scripts', 'tasks', 'task_liveunittesting.jl'), folder.name], { env: { JULIA_NUM_THREADS: inferJuliaNumThreads() } }), '')
+                const livetestTask = new vscode.Task({ type: 'julia', command: 'livetest' }, folder, `Run tests live (experimental)`, 'julia', new vscode.ProcessExecution(jlexepath, ['--color=yes', `--project=${pkgenvpath}`, path.join(this.context.extensionPath, 'scripts', 'tasks', 'task_liveunittesting.jl'), folder.name, vscode.workspace.getConfiguration('julia').get('liveTestFile')], { env: { JULIA_NUM_THREADS: inferJuliaNumThreads() } }), '')
                 livetestTask.group = vscode.TaskGroup.Test
                 livetestTask.presentationOptions = { echo: false, focus: false, panel: vscode.TaskPanelKind.Dedicated, clear: true }
                 result.push(livetestTask)


### PR DESCRIPTION
If one has a test suite that genuinely takes a long time to run, then this options allows one to specify a different test file that has some unit tests that might run quicker specifically for live testing.