### PR TITLE
better plotpane image scaling

### DIFF
--- a/src/interactive/plots.ts
+++ b/src/interactive/plots.ts
@@ -153,10 +153,10 @@ export function displayPlot(params: { kind: string, data: string }) {
     const payload = params.data
 
     if (kind === 'image/svg+xml') {
-        const has_xmlns_attribute = payload.includes("xmlns=");
-        var plotPaneContent: string;
+        const has_xmlns_attribute = payload.includes('xmlns=');
+        let plotPaneContent: string;
         if (has_xmlns_attribute) {
-            // the xmlns attribute has to be present for data:image/svg+xml to work
+            // the xmlns attribute has to be present for data:image/svg+xml to work (https://stackoverflow.com/questions/18467982)
             // encodeURIComponent is needed to replace all special characters from the SVG string
             // which could break the HTML
             plotPaneContent = wrap_imagelike(`data:image/svg+xml,${encodeURIComponent(payload)}`);


### PR DESCRIPTION
With CairoMakie I'm usually annoyed that SVG's are not scaled and therefore shown way too big / cut off. Also, png images are scaled to fit but only horizontally, so if the plot pane is rather wide but not tall, images are cut off at the bottom.

This tries to fix both of those problems.

SVG's are put into an image tag if they appear to be valid for that purpose (have the xmlns tag). This image tag is then scaled such that the image either vertically or horizontally fits into the plot pane if the image is bigger than either dimension.

If the image is shorter in both dimensions than the available space, it is not scaled but shown at its true size (via `object-fit: scale-down`).

Here are two examples showing how a big svg is scaled:

```julia
let
    svg = String(read(download("https://jkrumbiegel.github.io/assets/2020-11-15-makielayout/example_1.svg")))
    display(MIME"image/svg+xml"(), svg)
end
```

<img width="545" alt="grafik" src="https://user-images.githubusercontent.com/22495855/105643176-9b5f1980-5e8e-11eb-9841-484cebe0d424.png">

<img width="1127" alt="grafik" src="https://user-images.githubusercontent.com/22495855/105643186-a6b24500-5e8e-11eb-894f-3fbd0d69736c.png">
