### PR TITLE
Fix for #1895 Benchmark task MethodError

### DIFF
--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -71,7 +71,7 @@ class JuliaTaskProvider {
             }
 
             if (await fs.exists(path.join(rootPath, 'benchmark', 'benchmarks.jl'))) {
-                const benchmarkTask = new vscode.Task({ type: 'julia', command: 'benchmark' }, folder, `Run benchmark`, 'julia', new vscode.ProcessExecution(jlexepath, ['--color=yes', `--project=${pkgenvpath}`, '-e', 'using PkgBenchmark; benchmarkpkg(Base.ARGS[1], promptsave=false, promptoverwrite=false)', folder.name]), '')
+                const benchmarkTask = new vscode.Task({ type: 'julia', command: 'benchmark' }, folder, `Run benchmark`, 'julia', new vscode.ProcessExecution(jlexepath, ['--color=yes', `--project=${pkgenvpath}`, '-e', 'using PkgBenchmark; benchmarkpkg(Base.ARGS[1], resultfile="benchmark/results.json")', folder.name]), '')
                 benchmarkTask.presentationOptions = { echo: false, focus: false, panel: vscode.TaskPanelKind.Dedicated, clear: true }
                 result.push(benchmarkTask)
             }


### PR DESCRIPTION
Hopefully this should fix #1895. 

I'm not too sure what to put for the name and directory of the results file, or if there is some way of having the user pass this into the task as an argument. At the moment I've set it to save it in the benchmark subdirectory as that seems to make sense to me, but if anyone knows what the old behaviour was it might be worth changing it to match that.