### PR TITLE
Cancelable debounced getModuleAt with retries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -838,6 +838,14 @@
                 "tunnel": "0.0.4",
                 "typed-rest-client": "1.2.0",
                 "underscore": "1.8.3"
+            },
+            "dependencies": {
+                "underscore": {
+                    "version": "1.8.3",
+                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+                    "dev": true
+                }
             }
         },
         "babel-runtime": {
@@ -5943,6 +5951,14 @@
             "requires": {
                 "tunnel": "0.0.4",
                 "underscore": "1.8.3"
+            },
+            "dependencies": {
+                "underscore": {
+                    "version": "1.8.3",
+                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+                    "dev": true
+                }
             }
         },
         "typedarray": {
@@ -5973,10 +5989,9 @@
             }
         },
         "underscore": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-            "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-            "dev": true
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.0.tgz",
+            "integrity": "sha512-21rQzss/XPMjolTiIezSu3JAjgagXKROtNrYFEOWK109qY1Uv2tVjPTZ1ci2HgvQDA16gHYSthQIJfB+XId/rQ=="
         },
         "union-value": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -970,6 +970,7 @@
         "markdown-it": "^12.0.4",
         "markdown-it-footnote": "^3.0.2",
         "promised-temp": "^v0.1.0",
+        "underscore": "^1.12.0",
         "uuidv4": "^6.2.6",
         "vscode-debugadapter": "^1.44.0",
         "vscode-jsonrpc": "^6.0.0",

--- a/src/interactive/modules.ts
+++ b/src/interactive/modules.ts
@@ -63,20 +63,16 @@ export async function getModuleForEditor(document: vscode.TextDocument, position
             version: document.version,
             position: position
         }
-        if (cancelable) {
-            let mod = await debouncedGetModuleRequest(languageClient, params)
-            let retry = 1
-            while (mod !== '#retry' && retry <= 3) {
-                retry += 1
-                mod = await debouncedGetModuleRequest(languageClient, params)
-            }
-            if (mod === '#retry') {
-                throw `Could not get module for ${params}`
-            }
-            return mod
-        } else {
-            return await languageClient.sendRequest<string>('julia/getModuleAt', params)
+        let mod = await debouncedGetModuleRequest(languageClient, params)
+        let retry = 1
+        while (mod !== '#retry' && retry <= 3) {
+            retry += 1
+            mod = await debouncedGetModuleRequest(languageClient, params)
         }
+        if (mod === '#retry') {
+            throw `Could not get module for ${params}`
+        }
+        return mod
     } catch (err) {
         if (err.message === 'Language client is not ready yet') {
             vscode.window.showErrorMessage(err)

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -338,7 +338,7 @@ async function executeFile(uri?: vscode.Uri | string) {
         code = editor.document.getText()
 
         const pos = editor.document.validatePosition(new vscode.Position(0, 1)) // xref: https://github.com/julia-vscode/julia-vscode/issues/1500
-        module = await modules.getModuleForEditor(editor.document, pos)
+        module = await modules.getModuleForEditor(editor.document, pos, false)
     }
 
     await g_connection.sendRequest(
@@ -468,7 +468,7 @@ async function executeCell(shouldMove: boolean = false) {
     const cellrange = currentCellRange(ed)
     const code = doc.getText(cellrange)
 
-    const module: string = await modules.getModuleForEditor(ed.document, cellrange.start)
+    const module: string = await modules.getModuleForEditor(ed.document, cellrange.start, false)
 
     await startREPL(true, false)
 
@@ -497,7 +497,7 @@ async function evaluateBlockOrSelection(shouldMove: boolean = false) {
         let range: vscode.Range = null
         let nextBlock: vscode.Position = null
         const startpos: vscode.Position = editor.document.validatePosition(new vscode.Position(selection.start.line, selection.start.character))
-        const module: string = await modules.getModuleForEditor(editor.document, startpos)
+        const module: string = await modules.getModuleForEditor(editor.document, startpos, false)
 
         if (selection.isEmpty) {
             const currentBlock = await getBlockRange(getVersionedParamsAtPosition(editor.document, startpos))


### PR DESCRIPTION
Alternative to https://github.com/julia-vscode/julia-vscode/pull/1898.

This makes the `getModuleAt` requests that update the module selector cancelable and debounced (200ms), which should drastically cut down on the number of requests we make. `getModuleAt` in the LS will also never hard-fail; if the documents are out of sync, we'll instead return `'#retry'`, which causes the client to retry up to three times.