### PR TITLE
Allow persistance of relative env paths

### DIFF
--- a/src/debugger/debugFeature.ts
+++ b/src/debugger/debugFeature.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode'
-import { getEnvPath } from '../jlpkgenv'
+import * as jlpkgenv from '../jlpkgenv'
 import { getJuliaExePath } from '../juliaexepath'
 import { JuliaDebugSession } from './juliaDebug'
 
@@ -12,7 +12,7 @@ export class JuliaDebugFeature {
             vscode.debug.registerDebugConfigurationProvider('julia', provider),
             vscode.debug.registerDebugAdapterDescriptorFactory('julia', factory),
             vscode.commands.registerCommand('language-julia.debug.getActiveJuliaEnvironment', async config => {
-                const pkgenvpath = await getEnvPath()
+                const pkgenvpath = await jlpkgenv.getAbsEnvPath()
                 return pkgenvpath
             }),
             vscode.commands.registerCommand('language-julia.runEditorContents', (resource: vscode.Uri | undefined) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -101,7 +101,7 @@ export async function activate(context: vscode.ExtensionContext) {
         const api = {
             version: 2,
             async getEnvironment() {
-                return await jlpkgenv.getEnvPath()
+                return await jlpkgenv.getAbsEnvPath()
             },
             async getJuliaPath() {
                 return await juliaexepath.getJuliaExePath()
@@ -166,7 +166,7 @@ async function startLanguageServer() {
 
     let jlEnvPath = ''
     try {
-        jlEnvPath = await jlpkgenv.getEnvPath()
+        jlEnvPath = await jlpkgenv.getAbsEnvPath()
     }
     catch (e) {
         vscode.window.showErrorMessage('Could not start the julia language server. Make sure the configuration setting julia.executablePath points to the julia binary.')

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -78,7 +78,7 @@ async function startREPL(preserveFocus: boolean, showTerminal: boolean = true) {
 
         const juliaIsConnectedPromise = startREPLMsgServer(pipename)
         const exepath = await juliaexepath.getJuliaExePath()
-        const pkgenvpath = await jlpkgenv.getEnvPath()
+        const pkgenvpath = await jlpkgenv.getAbsEnvPath()
         if (pkgenvpath === null) {
             const jlarg1 = ['-i', '--banner=no'].concat(vscode.workspace.getConfiguration('julia').get('additionalArgs'))
             g_terminal = vscode.window.createTerminal(

--- a/src/jlpkgenv.ts
+++ b/src/jlpkgenv.ts
@@ -172,23 +172,28 @@ async function getDefaultEnvPath() {
     return g_path_of_default_environment
 }
 
-export async function getEnvPath() {
+async function getEnvPath() {
     if (g_path_of_current_environment === null) {
         const section = vscode.workspace.getConfiguration('julia')
         const envPathConfig = section.get<string>('environmentPath')
         if (envPathConfig) {
-            if (path.isAbsolute(envPathConfig)) {
-                g_path_of_current_environment = envPathConfig
-            }
-            else {
-                g_path_of_current_environment = path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, envPathConfig)
-            }
+            g_path_of_current_environment = envPathConfig
         }
         else {
             g_path_of_current_environment = await getDefaultEnvPath()
         }
     }
     return g_path_of_current_environment
+}
+
+export async function getAbsEnvPath() {
+    const envPath = await getEnvPath()
+    if (path.isAbsolute(envPath)) {
+        return envPath
+    }
+    else {
+        return path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, envPath)
+    }
 }
 
 export async function getEnvName() {

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -38,7 +38,7 @@ class JuliaTaskProvider {
             const result: vscode.Task[] = []
 
             const jlexepath = await juliaexepath.getJuliaExePath()
-            const pkgenvpath = await jlpkgenv.getEnvPath()
+            const pkgenvpath = await jlpkgenv.getAbsEnvPath()
 
             if (await fs.exists(path.join(rootPath, 'test', 'runtests.jl'))) {
                 const testTask = new vscode.Task({ type: 'julia', command: 'test' }, folder, `Run tests`, 'julia', new vscode.ProcessExecution(jlexepath, ['--color=yes', `--project=${pkgenvpath}`, '-e', `using Pkg; Pkg.test("${folder.name}")`], { env: { JULIA_NUM_THREADS: inferJuliaNumThreads() } }), '')


### PR DESCRIPTION
This is a follow-up to https://github.com/julia-vscode/julia-vscode/pull/1903.

My previous attempt meant that if one has a relative path in a local settings file, then it would immediately changed to an absolute path in the settings file when the extension started. That seems undesirable: we want the ability to store relative paths in the settings, but then we want to have absolute paths passed to every place where that value is used. This PR should enable this.