### PR TITLE
more env improvements

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -160,6 +160,7 @@ function changeConfig(event: vscode.ConfigurationChangeEvent) {
 
 async function startLanguageServer() {
     g_startupNotification.text = 'Starting Julia Language Server…'
+    g_startupNotification.show()
 
     let jlEnvPath = ''
     try {
@@ -167,10 +168,10 @@ async function startLanguageServer() {
     } catch (e) {
         vscode.window.showErrorMessage('Could not start the Julia language server. Make sure the configuration setting julia.executablePath points to the Julia binary.')
         vscode.window.showErrorMessage(e)
+        g_startupNotification.hide()
         return
     }
 
-    g_startupNotification.show()
 
     const languageServerDepotPath = path.join(g_context.globalStoragePath, 'lsdepot', 'v1')
     await fs.createDirectory(languageServerDepotPath)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -160,19 +160,18 @@ function changeConfig(event: vscode.ConfigurationChangeEvent) {
 
 async function startLanguageServer() {
     g_startupNotification.text = 'Starting Julia Language Server…'
-    g_startupNotification.show()
-
-    // let debugOptions = { execArgv: ["--nolazy", "--debug=6004"] };
 
     let jlEnvPath = ''
     try {
         jlEnvPath = await jlpkgenv.getAbsEnvPath()
-    }
-    catch (e) {
-        vscode.window.showErrorMessage('Could not start the julia language server. Make sure the configuration setting julia.executablePath points to the julia binary.')
+    } catch (e) {
+        vscode.window.showErrorMessage('Could not start the Julia language server. Make sure the configuration setting julia.executablePath points to the Julia binary.')
         vscode.window.showErrorMessage(e)
         return
     }
+
+    g_startupNotification.show()
+
     const languageServerDepotPath = path.join(g_context.globalStoragePath, 'lsdepot', 'v1')
     await fs.createDirectory(languageServerDepotPath)
     const oldDepotPath = process.env.JULIA_DEPOT_PATH ? process.env.JULIA_DEPOT_PATH : ''
@@ -280,12 +279,7 @@ async function startLanguageServer() {
         })
     }
     catch (e) {
-        vscode.window.showErrorMessage(
-            'Could not start the julia language server. Make sure the configuration setting `julia.executablePath` points to the julia binary.',
-            {
-
-            }
-        )
+        vscode.window.showErrorMessage('Could not start the Julia language server. Make sure the configuration setting julia.executablePath points to the Julia binary.')
         setLanguageClient()
         disposable.dispose()
         g_startupNotification.hide()

--- a/src/jlpkgenv.ts
+++ b/src/jlpkgenv.ts
@@ -177,23 +177,27 @@ async function getEnvPath() {
         const section = vscode.workspace.getConfiguration('julia')
         const envPathConfig = section.get<string>('environmentPath')
         if (envPathConfig) {
-            g_path_of_current_environment = envPathConfig
+            if (await fs.exists(absEnvPath(envPathConfig))) {
+                g_path_of_current_environment = envPathConfig
+                return g_path_of_current_environment
+            }
         }
-        else {
-            g_path_of_current_environment = await getDefaultEnvPath()
-        }
+        g_path_of_current_environment = await getDefaultEnvPath()
     }
     return g_path_of_current_environment
 }
 
+function absEnvPath(p: string) {
+    if (path.isAbsolute(p)) {
+        return p
+    } else {
+        return path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, p)
+    }
+}
+
 export async function getAbsEnvPath() {
     const envPath = await getEnvPath()
-    if (path.isAbsolute(envPath)) {
-        return envPath
-    }
-    else {
-        return path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, envPath)
-    }
+    return absEnvPath(envPath)
 }
 
 export async function getEnvName() {


### PR DESCRIPTION
This verifies the user supplied env path before returning it in `getAbsEnvPath`. Falls back to the default env path if verification fails. Also properly hides the startup notification if we fail early in `startLanguageServer`.