### PR TITLE
fix find_toplevel_scope in the REPL

### DIFF
--- a/scripts/packages/VSCodeServer/src/misc.jl
+++ b/scripts/packages/VSCodeServer/src/misc.jl
@@ -14,8 +14,9 @@ function find_first_topelevel_scope(bt::Vector{<:Union{Base.InterpreterIP,Ptr{Cv
                         return true
                     end
                 end
+            else
+                return frame.func === Symbol("top-level scope")
             end
-            return false
         end
         ind === nothing || return i
     end


### PR DESCRIPTION
for shorter backtraces