### PR TITLE
treerender: dispatch on AbstractDict (instead of Dict) --> fix

### DIFF
--- a/scripts/packages/VSCodeServer/src/trees.jl
+++ b/scripts/packages/VSCodeServer/src/trees.jl
@@ -92,7 +92,7 @@ function treerender(x)
     end
 end
 
-function treerender(x::Dict{K,V}) where {K,V}
+function treerender(x::AbstractDict{K,V}) where {K,V}
     treerender(LazyTree(string(nameof(typeof(x)), "{$(K), $(V)} with $(pluralize(length(keys(x)), "element", "elements"))"), wsicon(x), length(keys(x)) == 0, function ()
         if length(keys(x)) > MAX_PARTITION_LENGTH
             partition_by_keys(x, sz=MAX_PARTITION_LENGTH)


### PR DESCRIPTION
Since version 1.1.10 the nice tree rendering of special dictionaries (like OrderedDict) in the workspace was gone.
This fix changes the appropriate method dispatch back to AbstractDict.