### PR TITLE
Treerender proposal for a sorts of dictionaries and arrays

### DIFF
--- a/scripts/packages/VSCodeServer/src/trees.jl
+++ b/scripts/packages/VSCodeServer/src/trees.jl
@@ -92,7 +92,7 @@ function treerender(x)
     end
 end
 
-function treerender(x::Dict{K,V}) where {K,V}
+function treerender(x::AbstractDict{K,V}) where {K,V}
     treerender(LazyTree(string(nameof(typeof(x)), "{$(K), $(V)} with $(pluralize(length(keys(x)), "element", "elements"))"), wsicon(x), length(keys(x)) == 0, function ()
         if length(keys(x)) > MAX_PARTITION_LENGTH
             partition_by_keys(x, sz=MAX_PARTITION_LENGTH)


### PR DESCRIPTION
Solves the conflict of interests arising in #1926 and discussed in https://github.com/julia-vscode/julia-vscode/pull/1926#issuecomment-777417836.

All sorts of dictionaries and arrays are rendered primarily displaying their key/index => values. But additionally the properties of the underlying objects are browsable via a top list entry called #properties (using any-icon and the type display style, but that can be changed easily). I recommend leaving the properties entry on top to make it more acceptable for use cases where browsing the properties is more likely (e.g. ODESolutions) and because it could be seen as some sort of meta information.

<img width="450" alt="tree-dict-array-proposal" src="https://user-images.githubusercontent.com/68918058/107661586-b355dc00-6c89-11eb-983f-4b368d780901.png">
