### PR TITLE
Make optional the File Explorer context menu entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to the Julia extension will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Added
+* The global Julia entries in the File Explorer right-click menu can now be toggled on or off.
 
 ## [1.1.10] - 2021-01-28
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -301,15 +301,18 @@
                 },
                 {
                     "command": "language-julia.cdHere",
-                    "group": "julia"
+                    "group": "julia",
+                    "when": "julia.showInExplorerContextMenu && explorerResourceIsFolder"
                 },
                 {
                     "command": "language-julia.activateHere",
-                    "group": "julia"
+                    "group": "julia",
+                    "when": "julia.showInExplorerContextMenu"
                 },
                 {
                     "command": "language-julia.activateFromDir",
-                    "group": "julia"
+                    "group": "julia",
+                    "when": "julia.showInExplorerContextMenu"
                 }
             ],
             "editor/title": [
@@ -624,6 +627,12 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Check that all declared arguments are used within the function body."
+                },
+                "julia.showInExplorerContextMenu": {
+                    "type": "boolean",
+                    "default": "false",
+                    "description": "Show Julia environment commands in the Explorer context menu.",
+                    "scope": "resource"
                 },
                 "julia.enableCrashReporter": {
                     "type": [


### PR DESCRIPTION
The globally enabled entries in the Explorer right-click menu are a bit intrusive for users who are not working with Julia exclusively or nearly so. This quick patch introduces an option to enable or disable the entries, also in accordance with the newly released [VSCode Extension Guidelines](https://code.visualstudio.com/api/references/extension-guidelines#context-menus).

Currently, the menu entries are disabled by default. An argument can be made that they should remain enabled by default, for ease of use or for the sake of continuity across extension versions.

***

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.
