### PR TITLE
only show explorer context menu entries when REPL is running

### DIFF
--- a/package.json
+++ b/package.json
@@ -301,15 +301,18 @@
                 },
                 {
                     "command": "language-julia.cdHere",
-                    "group": "julia"
+                    "group": "julia",
+                    "when": "hasJuliaREPL"
                 },
                 {
                     "command": "language-julia.activateHere",
-                    "group": "julia"
+                    "group": "julia",
+                    "when": "hasJuliaREPL"
                 },
                 {
                     "command": "language-julia.activateFromDir",
-                    "group": "julia"
+                    "group": "julia",
+                    "when": "hasJuliaREPL"
                 }
             ],
             "editor/title": [

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -753,10 +753,12 @@ export function activate(context: vscode.ExtensionContext) {
             connection.onNotification(notifyTypeShowProfilerResultFile, showProfileResultFile)
             connection.onNotification(notifyTypeProgress, updateProgress)
             setContext('isJuliaEvaluating', false)
+            setContext('hasJuliaREPL', true)
         }),
         onExit(() => {
             results.removeAll()
             setContext('isJuliaEvaluating', false)
+            setContext('hasJuliaREPL', false)
         }),
         onStartEval(() => {
             updateProgress({


### PR DESCRIPTION
Alternative to https://github.com/julia-vscode/julia-vscode/pull/1929.

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.
