### PR TITLE
unparametrize wrapper

### DIFF
--- a/scripts/packages/VSCodeServer/src/eval.jl
+++ b/scripts/packages/VSCodeServer/src/eval.jl
@@ -2,8 +2,8 @@ const INLINE_RESULT_LENGTH = 100
 const MAX_RESULT_LENGTH = 10_000
 
 # Workaround for https://github.com/julia-vscode/julia-vscode/issues/1940
-struct Wrapper{T}
-    content::T
+struct Wrapper
+    content
 end
 wrap(x) = Wrapper(x)
 unwrap(x) = x.content


### PR DESCRIPTION
Fixes fun behaviour like
```
julia> Base.unwrap_unionall(Array)
TypeError(:new, "", UnionAll, Array{T,N})
```
for some reason.

Also hopefully fixes https://github.com/julia-vscode/julia-vscode/issues/1954.

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.
