### PR TITLE
Debugger no longer experimental?

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ in JSON, so you need to use ``\\`` as the path separator character on Windows.
 
 ## Features
 
-The extension currently provides
+The extension currently provides:
 
 * syntax highlighting
 * [snippets: latex and user-shared snippets](https://github.com/julia-vscode/julia-vscode/wiki/Snippets)
@@ -52,7 +52,7 @@ The extension currently provides
 * [a linter](https://github.com/julia-vscode/julia-vscode/wiki/Information#linter)
 * [code navigation](https://github.com/julia-vscode/julia-vscode/wiki/Navigation)
 * tasks for running tests, builds, benchmarks and build documentation
-* an experimental debugger
+* a debugger
 * a plot gallery
 * a grid viewer for tabular data
 * integrated support for Weave.jl


### PR DESCRIPTION
I didn't notice "experimental" in the docs, only in the README, and just thought it might be outdated with version 1.0 out (and seeing debug issue closed). If not ignore or close. All software may have bugs or missing features, but seeing "experimental" may put people off.

In general I would like to know where VSCode extension has feature parity with Juno (and well anything else used for Julia) or is better.

Such as for the debugger, linter, plotting etc. All considered at least non-experimental? I kind of liked the way in Juno to highlight code to run and getting checkboxes. Is it on the agenda or already there somewhere with non-default option?

I do not really care what implements the debugger if it just works. Is there one built-in go to option, this one (or as an option?):

https://github.com/judy-vscode/Adapter

https://discourse.julialang.org/t/tips-for-debugging-in-julia-vs-code-while-using-large-packages/43371/7

Fixes #.

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.
