### PR TITLE
Add a crash report handler

### DIFF
--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -533,6 +533,8 @@ async function evaluateBlockOrSelection(shouldMove: boolean = false) {
     }
     catch (err) {
         telemetry.handleNewCrashReportFromException(err, 'Extension')
+        throw (err)
+
     }
 }
 


### PR DESCRIPTION
That command crashed on my own computer. I thought instead of firing on my own debugger, I might as well add a crash report handler for everyone :)

Having said that, I really wish we had some easy way to just wrap everything in the extension in such a try catch block with crash reporting...

For every PR, please check the following:
- [X] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [X] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.
