### PR TITLE
Fix for Weave preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Fixed
 * SVGs with embedded single quotes are now displayed properly again.
+* Weave preview works again.
 
 ## [1.1.10] - 2021-01-28
 ### Fixed

--- a/src/weave.ts
+++ b/src/weave.ts
@@ -27,7 +27,9 @@ async function weave_core(column, selected_format: string = undefined) {
 
         await fs.writeTextFile(source_filename, source_text, 'utf8')
 
-        output_filename = path.join(temporary_dirname, 'output-file.html')
+        // note that there is a bug in Weave.jl right now that does not support the option
+        // out_path properly. The output file will therefore always have the format [input-file].html
+        output_filename = path.join(temporary_dirname, 'source-file.html')
     }
     else {
         source_filename = vscode.window.activeTextEditor.document.fileName


### PR DESCRIPTION
    Weave.jl does not properly respect the out_path option and instead uses
    it to determine the output directory. There should probably be a fix
    in Weave.jl at some point.

Fixes #1683.

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.
