### PR TITLE
Execute code block/cell support for .jmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -437,6 +437,11 @@
                 "when": "editorTextFocus && editorLangId == julia"
             },
             {
+                "command": "language-julia.executeCodeBlockOrSelectionAndMove",
+                "key": "alt+Enter",
+                "when": "editorTextFocus && editorLangId == juliamarkdown"
+            },
+            {
                 "command": "language-julia.interrupt",
                 "key": "Ctrl+C",
                 "when": "terminalFocus && isJuliaREPL && isJuliaEvaluating"
@@ -445,6 +450,11 @@
                 "command": "language-julia.executeCellAndMove",
                 "key": "shift+Enter",
                 "when": "editorTextFocus && editorLangId == julia"
+            },
+            {
+                "command": "language-julia.executeCellAndMove",
+                "key": "shift+Enter",
+                "when": "editorTextFocus && editorLangId == juliamarkdown"
             },
             {
                 "command": "language-julia.clearCurrentInlineResult",


### PR DESCRIPTION
I got annoyed with the lack of shift+enter/alt+enter support in .jmd files, so I created this. Right now, alt-enter in juliamarkdown mode just sends the entire current block to the REPL. Shift-enter (execute cell) does check if the cell is a Julia-block, starting with ` ```julia / ```{julia` and so does nothing in a markdown section. I could include the same check for the alt-enter command if needed.

Fixes #1807.

A more general note: do you have a direction to go with the .jmd files? Right now the experience is not really polished, and I could make some more fixes. But if you are going in a completely different direction than that is a bit useless (I read somewhere in an issue that you wanted to integrate .jmd and the Notebook interface in VS Code?)

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.
