### PR TITLE
update-run-commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "preview": false,
     "publisher": "julialang",
     "engines": {
-        "vscode": "^1.52.0"
+        "vscode": "^1.54.0"
     },
     "license": "SEE LICENSE IN LICENSE",
     "bugs": {
@@ -346,16 +346,6 @@
                     "command": "language-julia.plotpane-delete-all"
                 },
                 {
-                    "command": "language-julia.executeFile",
-                    "when": "resourceLangId == julia",
-                    "group": "1_run@10"
-                },
-                {
-                    "command": "language-julia.debugEditorContents",
-                    "when": "resourceLangId == julia",
-                    "group": "1_run@20"
-                },
-                {
                     "command": "language-julia.clearAllInlineResultsInEditor",
                     "when": "editorLangId == julia"
                 },
@@ -370,6 +360,23 @@
                 {
                     "command": "language-julia.activateFromDir",
                     "group": "julia"
+                }
+            ],
+            "editor/title/run": [
+                {
+                    "command": "language-julia.executeFile",
+                    "when": "resourceLangId == julia",
+                    "group": "Julia@10"
+                },
+                {
+                    "command": "language-julia.runEditorContents",
+                    "when": "resourceLangId == julia",
+                    "group": "Julia@20"
+                },
+                {
+                    "command": "language-julia.debugEditorContents",
+                    "when": "resourceLangId == julia",
+                    "group": "Julia@30"
                 }
             ],
             "commandPalette": [

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
             },
             {
                 "command": "language-julia.executeCodeBlockOrSelection",
-                "title": "Julia: Execute Code"
+                "title": "Julia: Execute Code in REPL"
             },
             {
                 "command": "language-julia.executeJuliaCodeInREPL",
@@ -152,11 +152,11 @@
             },
             {
                 "command": "language-julia.executeCodeBlockOrSelectionAndMove",
-                "title": "Julia: Execute Code And Move"
+                "title": "Julia: Execute Code in REPL and Move"
             },
             {
                 "command": "language-julia.executeFile",
-                "title": "Julia: Execute File",
+                "title": "Julia: Execute File in REPL",
                 "icon": "$(play)"
             },
             {
@@ -230,11 +230,11 @@
             },
             {
                 "command": "language-julia.executeCell",
-                "title": "Julia: Execute Code Cell"
+                "title": "Julia: Execute Code Cell in REPL"
             },
             {
                 "command": "language-julia.executeCellAndMove",
-                "title": "Julia: Execute Code Cell And Move"
+                "title": "Julia: Execute Code Cell in REPL and Move"
             },
             {
                 "command": "language-julia.moveCellUp",


### PR DESCRIPTION
Fixes #1992.

This first of all adopts the new recommended location for these commands from the VS Code side of things.

It then also amends the description of our run commands to always include "REPL" for those commands that send code to the REPL.

Finally, it adds the "Run in new process" command back in. I think that is ok now, since all run commands will be in a submenu in any case, so we'll have that situation just based on the two commands we have already, so we might as well have a third option there. 

UI now looks like this after one clicks on the run button:

![image](https://user-images.githubusercontent.com/1036561/110181179-171e8100-7dc0-11eb-9e47-d30f0ee01dcf.png)


For every PR, please check the following:
- [X] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [X] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.
