### PR TITLE
Debugging large memory usage: Add optional memory usage logging for language server process

### DIFF
--- a/scripts/languageserver/main.jl
+++ b/scripts/languageserver/main.jl
@@ -31,6 +31,8 @@ function Base.showerror(io::IO, ex::LSPrecompileFailure)
     print(io, ex.msg)
 end
 
+server = nothing # in the global scope so that memory allocation can be probed
+
 try
     if length(Base.ARGS) != 5
         error("Invalid number of arguments passed to julia language server.")


### PR DESCRIPTION
I'm keen to see if the memory footprint of the language server process can be reduced, as I want to use vscode on memory limited machines where memory is precious, so I added this to get some log info out about internal memory usage.

This adds periodic memory usage logging via `varinfo` on `Main`, `LanguageServer` and `SymbolServer`, that are run every 30 seconds async and saved to a `logs` dir in the vscode extension root.

It just stores the output of this for each module every 30 seconds
```
InteractiveUtils.varinfo(m, all=true, sortby=:size, imported=true)
```

This may just be a debugging tool, and not something for merging, so I didn't fill out the full changelog and docs.

I'm new to this codebase, so apologies if this is misguided.

Related: https://github.com/julia-vscode/julia-vscode/issues/1443


The results are curious.. 
With the only julia process running on my MacOS machine being the language server process, this is after a few minutes where the process has grown to just over 1GB (which is on the smaller side. Usually the process sits around 4GB)

It seems that < 20 MiB  of the  ~1 GiB is associated with the LanguageServer objects, so it seems that even in this non-runaway state there may be a memory leak going on?

### Main
```
| name                |        size | summary                       |
|:------------------- | -----------:|:----------------------------- |
| Base                |             | Module                        |
| Core                |             | Module                        |
| Main                |             | Module                        |
| SymbolServer        |  15.638 MiB | Module                        |
| LanguageServer      | 828.161 KiB | Module                        |
| Sockets             | 323.238 KiB | Module                        |
| InteractiveUtils    | 270.836 KiB | Module                        |
| ##meta#51           |   1.464 KiB | IdDict{Any, Any} with 1 entry |
| LSPrecompileFailure |   188 bytes | DataType                      |
| #1#4                |   172 bytes | DataType                      |
| #2#5                |   172 bytes | DataType                      |
| #3#6                |   172 bytes | DataType                      |
| #7#8                |   172 bytes | DataType                      |
| #9#10               |   172 bytes | DataType                      |
| #global_err_handler |   172 bytes | DataType                      |
| #memlog             |   172 bytes | DataType                      |
| eval                |     0 bytes | typeof(eval)                  |
| global_err_handler  |     0 bytes | typeof(global_err_handler)    |
| include             |     0 bytes | typeof(include)               |
| memlog              |     0 bytes | typeof(memlog)                |
```

### LanguageServer (top few)
```
| name                                                  |        size | summary                                                                                                                                                                                                                                                                                        |
|:----------------------------------------------------- | -----------:|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| LanguageServer                                        | 828.161 KiB | Module                                                                                                                                                                                                                                                                                         |
| JSONRPC                                               | 205.620 KiB | Module                                                                                                                                                                                                                                                                                         |
| URIParser                                             | 201.522 KiB | Module                                                                                                                                                                                                                                                                                         |
| ##meta#51                                             |  14.397 KiB | IdDict{Any, Any} with 9 entries                                                                                                                                                                                                                                                                |
| snippet_completions                                   |   2.250 KiB | Dict{String, String} with 31 entries                                                                                                                                                                                                                                                           |
| ServerCapabilities                                    |   1.090 KiB | DataType                                                                                                                                                                                                                                                                                       |
| LSActions                                             |   1.040 KiB | Dict{String, LanguageServer.ServerAction} with 4 entries                                                                                                                                                                                                                                       |
| TextDocumentClientCapabilities                        |   708 bytes | DataType                                                                                                                                                                                                                                                                                       |
| serverCapabilities                                    |   675 bytes | LanguageServer.ServerCapabilities  
```

### SymbolServer (top few)

```
| name                                 |        size | summary                                                  |
|:------------------------------------ | -----------:|:-------------------------------------------------------- |
| SymbolServer                         |  15.638 MiB | Module                                                   |
| _global_method_cache                 |  14.465 MiB | IdDict{Any, Vector{Any}} with 10405 entries              |
| _global_symbol_cache_by_mod          | 542.430 KiB | IdDict{Module, Base.IdSet{Symbol}} with 55 entries       |
| Sockets                              | 323.238 KiB | Module                                                   |
| CacheStore                           |  32.311 KiB | Module                                                   |
| UUIDs                                |  19.541 KiB | Module                                                   |
| ##meta#51                            |  14.637 KiB | IdDict{Any, Any} with 12 entries                         |
| stdlibs                              |   1.070 KiB | Dict{Symbol, SymbolServer.ModuleStore} with 3 entries    |
| Server                               |   284 bytes | DataType                                                 |
```