### PR TITLE
Fix debugger commands

### DIFF
--- a/src/debugger/debugFeature.ts
+++ b/src/debugger/debugFeature.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode'
 import * as jlpkgenv from '../jlpkgenv'
 import { getJuliaExePath } from '../juliaexepath'
-import { registerCommand } from '../utils'
 import { JuliaDebugSession } from './juliaDebug'
 
 export class JuliaDebugFeature {
@@ -12,11 +11,10 @@ export class JuliaDebugFeature {
         this.context.subscriptions.push(
             vscode.debug.registerDebugConfigurationProvider('julia', provider),
             vscode.debug.registerDebugAdapterDescriptorFactory('julia', factory),
-            registerCommand('language-julia.debug.getActiveJuliaEnvironment', async config => {
-                const pkgenvpath = await jlpkgenv.getAbsEnvPath()
-                return pkgenvpath
+            vscode.commands.registerCommand('language-julia.debug.getActiveJuliaEnvironment', async config => {
+                return await jlpkgenv.getAbsEnvPath()
             }),
-            registerCommand('language-julia.runEditorContents', async (resource: vscode.Uri | undefined) => {
+            vscode.commands.registerCommand('language-julia.runEditorContents', async (resource: vscode.Uri | undefined) => {
                 resource = getActiveUri(resource)
                 if (!resource) {
                     vscode.window.showInformationMessage('No active editor found.')
@@ -38,7 +36,7 @@ export class JuliaDebugFeature {
                     vscode.window.showErrorMessage('Could not run editor content in new process.')
                 }
             }),
-            registerCommand('language-julia.debugEditorContents', async (resource: vscode.Uri | undefined) => {
+            vscode.commands.registerCommand('language-julia.debugEditorContents', async (resource: vscode.Uri | undefined) => {
                 resource = getActiveUri(resource)
                 if (!resource) {
                     vscode.window.showInformationMessage('No active editor found.')


### PR DESCRIPTION
Fixes #2003.

The only relevant change is `registerCommand` -> `vscode.commands.registerCommand`. I have no clue why this changes anything, even after trying a _bunch_ of different approaches to debug this...

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.
