### PR TITLE
start-kernel-when-execute

### DIFF
--- a/src/notebook/notebookFeature.ts
+++ b/src/notebook/notebookFeature.ts
@@ -17,7 +17,7 @@ export class JuliaNotebookKernelProvider implements vscode.NotebookKernelProvide
     }
 
     async resolveKernel?(kernel: JuliaKernel, document: vscode.NotebookDocument, webview: vscode.NotebookCommunication, token: vscode.CancellationToken): Promise<void> {
-        await kernel.start()
+
     }
 
 }

--- a/src/notebook/notebookKernel.ts
+++ b/src/notebook/notebookKernel.ts
@@ -41,7 +41,8 @@ export class JuliaKernel implements vscode.NotebookKernel {
         this._localDisposables.forEach(d => d.dispose())
     }
 
-    executeCell(document: vscode.NotebookDocument, cell: vscode.NotebookCell): void {
+    async executeCell(document: vscode.NotebookDocument, cell: vscode.NotebookCell): Promise<void> {
+        await this.start()
         const executionOrder = ++this._current_request_id
 
         this.executionRequests.set(executionOrder, { cell: cell, executionOrder: executionOrder })


### PR DESCRIPTION
@donjayamanne I think this takes care of the proper startup behavior for the kernel. With this it also works that if one kills the kernel by killing the corresponding terminal, a new kernel will be started at the next cell execution.