### PR TITLE
Add ability for users to create a Julia Notebook (defaults to Julia langauge)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ import { ProfilerResultsProvider } from './interactive/profiler'
 import * as repl from './interactive/repl'
 import * as jlpkgenv from './jlpkgenv'
 import * as juliaexepath from './juliaexepath'
+import { registerWithJupyter } from './notebook/jupyterExtension'
 import { JuliaNotebookFeature } from './notebook/notebookFeature'
 import * as openpackagedirectory from './openpackagedirectory'
 import { JuliaPackageDevFeature } from './packagedevtools'
@@ -58,7 +59,8 @@ export async function activate(context: vscode.ExtensionContext) {
         })
 
         // Active features from other files
-        juliaexepath.activate(context)
+		juliaexepath.activate(context)
+		registerWithJupyter();
         await juliaexepath.getJuliaExePath() // We run this function now and await to make sure we don't run in twice simultaneously later
         repl.activate(context)
         weave.activate(context)

--- a/src/notebook/jupyterExtension.ts
+++ b/src/notebook/jupyterExtension.ts
@@ -1,0 +1,20 @@
+import { extensions } from 'vscode'
+
+interface IJupyterExtensionApi {
+    registerNewNotebookContent(options: { defaultCellLanguage: string }): void;
+}
+
+export async function registerWithJupyter() {
+    const jupyter = extensions.getExtension<IJupyterExtensionApi>(
+        'ms-toolsai.jupyter'
+    )
+    if (!jupyter) {
+        return
+    }
+    if (!jupyter.isActive) {
+        await jupyter.activate()
+    }
+    jupyter.exports.registerNewNotebookContent({
+        defaultCellLanguage: 'julia',
+    })
+}

--- a/src/notebook/notebookFeature.ts
+++ b/src/notebook/notebookFeature.ts
@@ -1,5 +1,5 @@
-import * as vscode from 'vscode'
-import { JuliaKernel } from './notebookKernel'
+import * as vscode from 'vscode';
+import { JuliaKernel } from './notebookKernel';
 
 export class JuliaNotebookKernelProvider implements vscode.NotebookKernelProvider<JuliaKernel> {
     constructor(public extensionPath: string) {
@@ -8,11 +8,8 @@ export class JuliaNotebookKernelProvider implements vscode.NotebookKernelProvide
     // onDidChangeKernels?: vscode.Event<vscode.NotebookDocument>;
 
     async provideKernels(document: vscode.NotebookDocument, token: vscode.CancellationToken): Promise<JuliaKernel[]> {
-        if (document.metadata.custom?.metadata?.kernelspec?.language === 'julia') {
+        if (document.viewType === 'jupyter-notebook') {
             return [new JuliaKernel(document, this.extensionPath, true)]
-        }
-        else {
-            return []
         }
     }
 


### PR DESCRIPTION
This is a  feature (extensibility point we added for .NET Interacgive notebooks extension).

See below git (it doesn't make Jupyter a dependency, merely adds a command if the user has it installed).
Not sure you want this, but i figured it could be handy.
![julia](https://user-images.githubusercontent.com/1948812/111009544-c3c0ab80-8348-11eb-87c1-b24a7fa0c456.gif)
