### PR TITLE
Fix JULIA_EDITOR

### DIFF
--- a/package.json
+++ b/package.json
@@ -672,6 +672,14 @@
                     "scope": "machine-overridable",
                     "description": "Number of threads to use for Julia processes."
                 },
+                "julia.editor": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": null,
+                    "markdownDescription": "Command to open files from the REPL (via setting the `JULIA_EDITOR` environment variable). Defaults to `code`/`code-insiders` if unset."
+                },
                 "julia.format.indent": {
                     "type": "integer",
                     "default": 4,

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -40,6 +40,11 @@ function is_remote_env(): boolean {
 }
 
 function get_editor(): string {
+    const editor: string | null = vscode.workspace.getConfiguration('julia').get('editor')
+
+    if (editor) {
+        return editor
+    }
     if (is_remote_env()) {
         if (vscode.env.appName === 'Code - OSS') {
             return 'code-server'

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -40,18 +40,14 @@ function is_remote_env(): boolean {
 }
 
 function get_editor(): string {
-    if (is_remote_env() || process.platform === 'darwin') {
-        // code-server:
+    if (is_remote_env()) {
         if (vscode.env.appName === 'Code - OSS') {
-            return `"${path.join(vscode.env.appRoot, '..', '..', 'bin', 'code-server')}"`
+            return 'code-server'
         } else {
-            const cmd = vscode.env.appName.includes('Insiders') && process.platform !== 'darwin' ? 'code-insiders' : 'code'
-            return `"${path.join(vscode.env.appRoot, 'bin', cmd)}"`
+            return `"${process.execPath}"`
         }
     }
-    else {
-        return `"${process.execPath}"`
-    }
+    return vscode.env.appName.includes('Insiders') ? 'code-insiders' : 'code'
 }
 
 async function startREPL(preserveFocus: boolean, showTerminal: boolean = true) {


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/2057. 
This basically makes `get_editor` a bit dumber, but more robust and user overrideable.

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.
