### PR TITLE
Make package tagging Julia 1.6 only and improve update script

### DIFF
--- a/scripts/packagedev/tagnewpackageversion.jl
+++ b/scripts/packagedev/tagnewpackageversion.jl
@@ -1,3 +1,9 @@
+if VERSION < v"1.6"
+    println("The package tagging functionality is only supported on Julia 1.6 and newer. You are running Julia $VERSION, please update your Julia version to use the package tagging feature.")
+    readline()
+    exit()
+end
+
 using Pkg
 
 Pkg.instantiate()
@@ -8,13 +14,13 @@ try
     version_arg = ARGS[3]
     new_version = nothing
 
-    if version_arg=="Next"
+    if version_arg == "Next"
         new_version = nothing
-    elseif version_arg=="Major"
+    elseif version_arg == "Major"
         new_version = :major
-    elseif version_arg=="Minor"
+    elseif version_arg == "Minor"
         new_version = :minor
-    elseif version_arg=="Patch"
+    elseif version_arg == "Patch"
         new_version = :patch
     else
         new_version = Base.VersionNumber(version_arg)

--- a/src/scripts/updateDeps.ts
+++ b/src/scripts/updateDeps.ts
@@ -26,6 +26,7 @@ async function our_download(url: string, destination: string) {
 
 async function main() {
     const juliaPath = path.join(homedir(), 'AppData', 'Local', 'Julia-1.3.1', 'bin', 'julia.exe')
+    const julia_1_6_Path = path.join(homedir(), 'AppData', 'Local', 'Programs', 'Julia-1.6.1', 'bin', 'julia.exe')
 
     await our_download('https://cdn.jsdelivr.net/npm/vega-lite@2', 'libs/vega-lite-2/vega-lite.min.js')
     await our_download('https://cdn.jsdelivr.net/npm/vega-lite@3', 'libs/vega-lite-3/vega-lite.min.js')
@@ -61,6 +62,8 @@ async function main() {
     await cp.exec(`${juliaPath} --project=. -e "using Pkg; Pkg.resolve()"`, { cwd: path.join(process.cwd(), 'scripts/testenvironments/vscodedebugger') })
     await cp.exec(`${juliaPath} --project=. -e "using Pkg; Pkg.resolve()"`, { cwd: path.join(process.cwd(), 'scripts/testenvironments/vscodeserver') })
     await cp.exec(`${juliaPath} --project=. -e "using Pkg; Pkg.resolve()"`, { cwd: path.join(process.cwd(), 'scripts/testenvironments/chromeprofileformat') })
+
+    await cp.exec(`${julia_1_6_Path} --project=. -e "using Pkg; Pkg.update()"`, { cwd: path.join(process.cwd(), 'scripts/environments/pkgdev') })
 
     await cp.exec('npm update', { cwd: process.cwd() })
 }


### PR DESCRIPTION
The tagging functionality is currently broken on Julia 1.6. I fixed things in PkgDev.jl, but things are now Julia 1.6 only.

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.
