### PR TITLE
add terminal link handler for julia specific link syntax

### DIFF
--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -422,7 +422,7 @@ function isResultInLineRange(editor: vscode.TextEditor, result: Result, range: v
 
 // goto frame utilties
 
-async function openFile(path: string, line: number = undefined) {
+export async function openFile(path: string, line: number = undefined) {
     line = line || 1
     const start = new vscode.Position(line - 1, 0)
     const end = new vscode.Position(line - 1, 0)

--- a/src/juliaexepath.ts
+++ b/src/juliaexepath.ts
@@ -1,3 +1,4 @@
+import { realpath } from 'async-file'
 import { exec } from 'child-process-promise'
 import * as child_process from 'child_process'
 import * as os from 'os'
@@ -97,20 +98,29 @@ export async function getJuliaExePath() {
             }
         }
         else {
+            let fullPath: string | undefined = undefined
             if (getExecutablePath().includes(path.sep)) {
-                setNewJuliaExePath(getExecutablePath().replace(/^~/, os.homedir()))
+                fullPath = getExecutablePath().replace(/^~/, os.homedir())
             } else {
                 // resolve full path
-                let fullPath: string | undefined = undefined
                 try {
                     fullPath = await which(getExecutablePath())
                 }
                 catch (err) {
+                    console.debug('which failed to get the julia exe path')
+                    console.debug(err)
                 }
 
-                if (fullPath) {
-                    setNewJuliaExePath(fullPath)
+            }
+            if (fullPath) {
+                try {
+                    fullPath = await realpath(fullPath)
                 }
+                catch (err) {
+                    console.debug('realpath failed to resolve the julia exe path')
+                    console.debug(err)
+                }
+                setNewJuliaExePath(fullPath)
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/885, at least for the logging/stacktrace special case of
```
   @ Base ./rational.jl:61
```
Works with relative (resolved inside of Base) and absolute paths.

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.
