### PR TITLE
Fix links in docpane

### DIFF
--- a/src/docbrowser/documentation.ts
+++ b/src/docbrowser/documentation.ts
@@ -5,7 +5,7 @@ import { withLanguageClient } from '../extension'
 import { constructCommandString, getVersionedParamsAtPosition, registerCommand } from '../utils'
 
 function openArgs(href: string) {
-    const matches = href.match(/^((\w+\:\/\/)?.+?)(?:\:(\d+))?$/)
+    const matches = href.match(/^((\w+\:\/\/)?.+?)(?:[\:#](\d+))?$/)
     let uri
     let line
     if (matches[1] && matches[3] && matches[2] === undefined) {
@@ -25,6 +25,16 @@ const md = new markdownit().use(
 ).use(
     require('markdown-it-footnote')
 )
+
+// add custom validator to allow for file:// links
+const BAD_PROTO_RE = /^(vbscript|javascript|data):/
+const GOOD_DATA_RE = /^data:image\/(gif|png|jpeg|webp);/
+md.validateLink = (url) => {
+    // url should be normalized at this point, and existing entities are decoded
+    var str = url.trim().toLowerCase()
+
+    return BAD_PROTO_RE.test(str) ? (GOOD_DATA_RE.test(str) ? true : false) : true
+}
 
 md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
     const aIndex = tokens[idx].attrIndex('href')
@@ -185,6 +195,9 @@ class DocumentationViewProvider implements vscode.WebviewViewProvider {
         </script>
 
         <style>
+        body {
+            word-break: break-all;
+        }
         body:active {
             outline: 1px solid var(--vscode-focusBorder);
         }


### PR DESCRIPTION
We moved to `file://` links in LanguageServer.jl some time ago, which markdown-it filters out by default. This changes their URL validation to allow that.

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.
