### PR TITLE
plot navigator fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,6 +157,10 @@
                 "title": "Julia: Show Documentation Pane"
             },
             {
+                "command": "language-julia.show-plot-navigator",
+                "title": "Julia: Show Plot Navigator"
+            },
+            {
                 "command": "language-julia.browse-back-documentation",
                 "title": "Julia: Browse Back Documentation",
                 "icon": "$(arrow-left)"
@@ -743,6 +747,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Display plots within VS Code. Might require a restart of the Julia process."
+                },
+                "julia.usePlotNavigator": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether to automatically show the plot navigator when plotting."
                 },
                 "julia.useProgressFrontend": {
                     "type": "boolean",

--- a/src/docbrowser/documentation.ts
+++ b/src/docbrowser/documentation.ts
@@ -104,12 +104,11 @@ class DocumentationViewProvider implements vscode.WebviewViewProvider {
     }
 
     async showDocumentationPane() {
-        // this forces the webview to be resolved:
-        await vscode.commands.executeCommand('julia-documentation.focus')
-        // should always be true, but better safe than sorry
-        if (this.view) {
-            this.view.show?.(true)
+        if (this.view?.show === undefined) {
+            // this forces the webview to be resolved, but changes focus:
+            await vscode.commands.executeCommand('julia-documentation.focus')
         }
+        this.view.show(true)
     }
 
     async showDocumentationFromWord(word: string) {


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/2172.

Focus is now mostly retained (except for the first time the navigator is displayed). Also added a setting to disable automatically showing the navigator.

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.
