### PR TITLE
improve disconnect handling

### DIFF
--- a/scripts/error_handler.jl
+++ b/scripts/error_handler.jl
@@ -1,8 +1,20 @@
 using Sockets
 import InteractiveUtils
 
+is_disconnected_exception(err) = false
+is_disconnected_exception(err::InvalidStateException) = err.state === :closed
+is_disconnected_exception(err::Base.IOError) = true
+is_disconnected_exception(err::CompositeException) = all(is_disconnected_exception, err.exceptions)
+
 function global_err_handler(e, bt, vscode_pipe_name, cloudRole)
-    @warn "Some Julia code in the VS Code extension crashed with" exception=(e, bt)
+    if is_disconnected_exception(e)
+        @debug "Disconnect. Nothing to worry about."
+        return
+    end
+
+    @error "Some Julia code in the VS Code extension crashed"
+    Base.display_error(e, bt)
+
 
     try
         st = stacktrace(bt)
@@ -59,7 +71,6 @@ function global_err_handler(e, bt, vscode_pipe_name, cloudRole)
         finally
             close(pipe_to_vscode)
         end
-        Base.display_error(e, bt)
     finally
         exit(1)
     end

--- a/scripts/packages/VSCodeServer/src/VSCodeServer.jl
+++ b/scripts/packages/VSCodeServer/src/VSCodeServer.jl
@@ -80,8 +80,6 @@ function dispatch_msg(conn_endpoint, msg_dispatcher, msg, is_dev)
     end
 end
 
-is_disconnected_exception(err) = err isa InvalidStateException && err.state === :closed || err isa Base.IOError
-
 function serve(args...; is_dev=false, crashreporting_pipename::Union{AbstractString,Nothing}=nothing)
     if !HAS_REPL_TRANSFORM[] && isdefined(Base, :active_repl)
         hook_repl(Base.active_repl)
@@ -124,10 +122,7 @@ function serve(args...; is_dev=false, crashreporting_pipename::Union{AbstractStr
             end
         end
     catch err
-        if !isopen(conn) && (
-             err isa CompositeException && all(is_disconnected_exception, err.exceptions) ||
-             is_disconnected_exception(err)
-           )
+        if !isopen(conn) && is_disconnected_exception(err)
             # expected error
             @debug "remote closed the connection"
         else

--- a/scripts/packages/VSCodeServer/src/debugger.jl
+++ b/scripts/packages/VSCodeServer/src/debugger.jl
@@ -6,9 +6,13 @@ function repl_startdebugger_request(conn, params::NamedTuple{(:debugPipename,),T
             socket = Sockets.connect(debug_pipename)
             try
                 DebugAdapter.startdebug(socket, function (err, bt)
-                    printstyled(stderr, "Error while running the debugger", color=:red, bold=true)
-                    printstyled(stderr, " (consider adding a breakpoint for uncaught exceptions):\n", color=:red)
-                    Base.display_error(stderr, err, bt)
+                    if is_disconnected_exception(err)
+                        @debug "connection closed"
+                    else
+                        printstyled(stderr, "Error while running the debugger", color=:red, bold=true)
+                        printstyled(stderr, " (consider adding a breakpoint for uncaught exceptions):\n", color=:red)
+                        Base.display_error(stderr, err, bt)
+                    end
                 end)
             finally
                 close(socket)


### PR DESCRIPTION
This stops connection errors from being propagated to crash reporting or the user, since these are mostly expected. If they are the cause of something going seriously wrong then we won't get anything useful out of them anyways.

Together with https://github.com/julia-vscode/DebugAdapter.jl/pull/39 this fixes the debugging experience.

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.
