### PR TITLE
When using Julia kernel change code cells to Julia

### DIFF
--- a/src/notebook/notebookFeature.ts
+++ b/src/notebook/notebookFeature.ts
@@ -9,6 +9,11 @@ export class JuliaNotebookFeature {
         this.controller = vscode.notebooks.createNotebookController('julia', 'jupyter-notebook', 'Julia Kernel')
         this.controller.supportedLanguages = ['julia']
         this.controller.supportsExecutionOrder = true
+        this.controller.onDidChangeSelectedNotebooks((e) =>{
+            if (e.selected && e.notebook) {
+                e.notebook.getCells().filter(cell => cell.kind === vscode.NotebookCellKind.Code).map(cell => vscode.languages.setTextDocumentLanguage(cell.document, 'julia'))
+            }
+        })
         this.controller.executeHandler = this.executeCells.bind(this)
     }
 


### PR DESCRIPTION
@davidanthoff This is required.
If you open a notebook today, some kernels can & will change the language of the cells. 
E.g. if you open a notebook and user changes the language to HTML for some reason or accidentally uses .NET kernel or the like, then the language of the cells can change.
If after running the cells the user realized the kernel is incorrect & change it from Python or .NEt to Julia, now the cells are not Jualia, we'll need to update them.