### PR TITLE
Integrate notebook with workspace view

### DIFF
--- a/scripts/packages/VSCodeServer/src/serve_notebook.jl
+++ b/scripts/packages/VSCodeServer/src/serve_notebook.jl
@@ -79,6 +79,9 @@ function serve_notebook(pipename; crashreporting_pipename::Union{AbstractString,
 
         msg_dispatcher = JSONRPC.MsgDispatcher()
         msg_dispatcher[notebook_runcell_notification_type] = notebook_runcell_notification
+        msg_dispatcher[repl_getvariables_request_type] = repl_getvariables_request
+        msg_dispatcher[repl_getlazy_request_type] = repl_getlazy_request
+        msg_dispatcher[repl_showingrid_notification_type] = repl_showingrid_notification
 
         while true
             msg = JSONRPC.get_next_message(conn_endpoint[])

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import { JuliaDebugFeature } from './debugger/debugFeature'
 import * as documentation from './docbrowser/documentation'
 import { ProfilerResultsProvider } from './interactive/profiler'
 import * as repl from './interactive/repl'
+import { WorkspaceFeature } from './interactive/workspace'
 import * as jlpkgenv from './jlpkgenv'
 import * as juliaexepath from './juliaexepath'
 import { JuliaNotebookFeature } from './notebook/notebookFeature'
@@ -71,7 +72,9 @@ export async function activate(context: vscode.ExtensionContext) {
         openpackagedirectory.activate(context)
         jlpkgenv.activate(context)
 
-        context.subscriptions.push(new JuliaNotebookFeature(context))
+        const workspaceFeature = new WorkspaceFeature(context)
+        context.subscriptions.push(workspaceFeature)
+        context.subscriptions.push(new JuliaNotebookFeature(context, workspaceFeature))
         context.subscriptions.push(new JuliaDebugFeature(context, compiledProvider))
         context.subscriptions.push(new JuliaPackageDevFeature(context))
 

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -19,7 +19,6 @@ import * as plots from './plots'
 import { showProfileResult, showProfileResultFile } from './profiler'
 import * as results from './results'
 import { Frame, openFile } from './results'
-import * as workspace from './workspace'
 
 let g_context: vscode.ExtensionContext = null
 let g_languageClient: vslc.LanguageClient = null
@@ -233,7 +232,7 @@ interface DebugLaunchParams {
     filename: string
 }
 
-const notifyTypeDisplay = new rpc.NotificationType<{ kind: string, data: any }>('display')
+export const notifyTypeDisplay = new rpc.NotificationType<{ kind: string, data: any }>('display')
 const notifyTypeDebuggerEnter = new rpc.NotificationType<DebugLaunchParams>('debugger/enter')
 const notifyTypeDebuggerRun = new rpc.NotificationType<DebugLaunchParams>('debugger/run')
 const notifyTypeReplStartDebugger = new rpc.NotificationType<{ debugPipename: string }>('repl/startdebugger')
@@ -943,6 +942,5 @@ export function activate(context: vscode.ExtensionContext, compiledProvider) {
 
     results.activate(context)
     plots.activate(context)
-    workspace.activate(context)
     modules.activate(context)
 }

--- a/src/notebook/notebookFeature.ts
+++ b/src/notebook/notebookFeature.ts
@@ -1,15 +1,17 @@
+/* eslint-disable semi */
 import * as vscode from 'vscode';
+import { WorkspaceFeature } from '../interactive/workspace';
 import { JuliaKernel } from './notebookKernel';
 
 export class JuliaNotebookFeature {
     private readonly controller: vscode.NotebookController;
     private readonly kernels: Map<vscode.NotebookDocument, JuliaKernel> = new Map<vscode.NotebookDocument, JuliaKernel>()
 
-    constructor(private context: vscode.ExtensionContext) {
+    constructor(private context: vscode.ExtensionContext, private workspaceFeature: WorkspaceFeature) {
         this.controller = vscode.notebooks.createNotebookController('julia', 'jupyter-notebook', 'Julia Kernel')
         this.controller.supportedLanguages = ['julia']
         this.controller.supportsExecutionOrder = true
-        this.controller.onDidChangeSelectedNotebooks((e) =>{
+        this.controller.onDidChangeSelectedNotebooks((e) => {
             if (e.selected && e.notebook) {
                 e.notebook.getCells().filter(cell => cell.kind === vscode.NotebookCellKind.Code).map(cell => vscode.languages.setTextDocumentLanguage(cell.document, 'julia'))
             }
@@ -20,12 +22,14 @@ export class JuliaNotebookFeature {
     private async executeCells(cells: vscode.NotebookCell[], notebook: vscode.NotebookDocument, controller: vscode.NotebookController): Promise<void> {
         // First check whether we already have a kernel running for the current notebook document
         if (!this.kernels.has(notebook)) {
-            this.kernels.set(notebook, new JuliaKernel(this.context.extensionPath, this.controller, notebook))
+            const kernel = new JuliaKernel(this.context.extensionPath, this.controller, notebook)
+            await this.workspaceFeature.addNotebookKernel(kernel)
+            this.kernels.set(notebook, kernel)
         }
 
         const currentKernel = this.kernels.get(notebook)
 
-        cells.forEach(async cell => await currentKernel.executeCell(cell))
+        cells.forEach(cell => currentKernel.executeCell(cell))
     }
 
     public dispose() {


### PR DESCRIPTION
This integrates the notebook kernels into our workspace view.

I'm going to merge this PR right away into the `notebook` branch, but this touches a couple of things that @pfitzseb is more familiar with than I am, so if you want to take a fairly isolated look how I changed the workspace implementation, then hopefully this PR makes that a bit easier to review.