### PR TITLE
Fix REPL stacktrace links for Windows platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the Julia extension will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+* Fixed REPL stacktraces file path links for Windows. Paths with tilda symbol now expand to the correct HOMEPATH. Paths with spaces are handled correctly ([#2261](https://github.com/julia-vscode/julia-vscode/pull/2261))
+
 ### Changed
 * `Julia: Connect external REPL` now gives feedback when connected ([#2182](https://github.com/julia-vscode/julia-vscode/pull/2182))
 

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -804,7 +804,7 @@ async function linkHandler(link: any) {
         const exepath = await juliaexepath.getJuliaExePath()
         file = path.join(exepath, '..', '..', 'share', 'julia', 'base', file)
     } else if (file.startsWith('~')) {
-        file = path.join(process.env.HOME, file.slice(1))
+        file = path.join(process.platform === 'win32' ? process.env.HOMEPATH : process.env.HOME, file.slice(1))
     }
     try {
         await openFile(file, line)
@@ -820,7 +820,7 @@ function linkProvider(context: vscode.TerminalLinkContext, token: vscode.Cancell
         return []
     }
 
-    const match = line.match(/(@\s+(?:[^\s]+\s+)?)(.+?):(\d+)/)
+    const match = line.match(/(@\s+(?:[^\s/\\]+\s+)?)(.+?):(\d+)/)
     if (match) {
         return [
             {


### PR DESCRIPTION
This PR fixes two issues for Windows platform related to creating links to files in the new stacktrace introduced in Julia >= 1.6:

1. Fix expanding of tilda symbol to the home path using the correct environment variable for Windows platform `HOMEPATH`.
2. Improve handling of paths containing spaces by improving the relevant regular expression.

**Handling of paths with spaces:**
![vs-code](https://user-images.githubusercontent.com/41748383/123897051-76099680-d96b-11eb-9e1a-af320f0394bc.png)
