### PR TITLE
flush conn channel in display calls

### DIFF
--- a/scripts/packages/VSCodeServer/src/display.jl
+++ b/scripts/packages/VSCodeServer/src/display.jl
@@ -35,6 +35,7 @@ end
 
 function sendDisplayMsg(kind, data)
     JSONRPC.send_notification(conn_endpoint[], "display", Dict{String,String}("kind" => kind, "data" => data))
+    JSONRPC.flush(conn_endpoint[])
 end
 
 function display(d::InlineDisplay, m::MIME, x)


### PR DESCRIPTION
to make display more responsive. We're doing the same for progress messages.