### PR TITLE
Explicitly set logger to stderr in LS startup script

### DIFF
--- a/scripts/languageserver/main.jl
+++ b/scripts/languageserver/main.jl
@@ -2,6 +2,9 @@ if VERSION < v"1.0.0"
     error("VS Code julia language server only works with julia 1.0.0+")
 end
 
+using Logging
+global_logger(ConsoleLogger(stderr))
+
 @info "Starting the Julia Language Server"
 
 using InteractiveUtils, Sockets


### PR DESCRIPTION
This fixes the LS on 1.7.

The proper fix is https://github.com/JuliaLang/julia/pull/41653, but we should probably get this in regardless?