### PR TITLE
Clear cell output when cell is queued for exec

### DIFF
--- a/src/notebook/notebookKernel.ts
+++ b/src/notebook/notebookKernel.ts
@@ -67,10 +67,7 @@ export class JuliaKernel {
 
         // Now create execution object that actually will run the code
         const execution = this.controller.createNotebookCellExecution(cell)
-        execution.executionOrder = executionOrder
-
-        await execution.clearOutput()
-
+        execution.token.onCancellationRequested(e=>execution.end(undefined))
         this._scheduledExecutionRequests.push(execution)
 
         this._processExecutionRequests.notify()
@@ -86,9 +83,11 @@ export class JuliaKernel {
                 this._currentExecutionRequest = this._scheduledExecutionRequests.shift()
 
                 if (this._currentExecutionRequest.token.isCancellationRequested) {
-                    this._currentExecutionRequest.end(undefined)
                 }
                 else {
+                    const executionOrder = ++this._current_request_id
+                    this._currentExecutionRequest.executionOrder = executionOrder
+
                     const runStartTime = Date.now()
                     this._currentExecutionRequest.start(runStartTime)
 

--- a/src/notebook/notebookKernel.ts
+++ b/src/notebook/notebookKernel.ts
@@ -59,8 +59,13 @@ export class JuliaKernel {
     }
 
     public async queueCell(cell: vscode.NotebookCell): Promise<void> {
-        const executionOrder = ++this._current_request_id
+        // First clear output
+        const clearOutputExecution = this.controller.createNotebookCellExecution(cell)
+        clearOutputExecution.start()
+        await clearOutputExecution.clearOutput()
+        clearOutputExecution.end(undefined)
 
+        // Now create execution object that actually will run the code
         const execution = this.controller.createNotebookCellExecution(cell)
         execution.executionOrder = executionOrder
 

--- a/src/notebook/notebookKernel.ts
+++ b/src/notebook/notebookKernel.ts
@@ -64,8 +64,7 @@ export class JuliaKernel {
         const execution = this.controller.createNotebookCellExecution(cell)
         execution.executionOrder = executionOrder
 
-        // TODO For some reason this doesn't work here
-        // await execution.clearOutput()
+        await execution.clearOutput()
 
         this._scheduledExecutionRequests.push(execution)
 
@@ -87,9 +86,6 @@ export class JuliaKernel {
                 else {
                     const runStartTime = Date.now()
                     this._currentExecutionRequest.start(runStartTime)
-
-                    // TODO Ideally we would clear output at scheduling already, but for now do it here
-                    await this._currentExecutionRequest.clearOutput()
 
                     const result = await this._msgConnection.sendRequest(
                         requestTypeRunCell,


### PR DESCRIPTION
@DonJayamanne, this errors because apparently one can only delete cell output during execution of a cell. I think we would really want to delete cell output when the cell gets queued, though, like in other Jupyter clients. Is there some way to do that?