### PR TITLE
Hide notebook feature behind a feature flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1048,6 +1048,12 @@
                     ],
                     "description": "Functions or modules that are set to compiled mode when setting the defaults.",
                     "scope": "window"
+                },
+                "julia.notebookController": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable the experimental native Jupyter notebook integration.",
+                    "scope": "application"
                 }
             }
         },

--- a/src/notebook/notebookFeature.ts
+++ b/src/notebook/notebookFeature.ts
@@ -32,8 +32,13 @@ export class JuliaNotebookFeature {
     private readonly disposables: vscode.Disposable[] = [];
 
     constructor(private context: vscode.ExtensionContext, private workspaceFeature: WorkspaceFeature) {
-        this.init()
-        vscode.workspace.onDidOpenNotebookDocument(this.onDidOpenNotebookDocument, this, this.disposables)
+        const section = vscode.workspace.getConfiguration('julia')
+        const enabled = section ? section.get<boolean>('notebookController', false) : false
+        if (enabled) {
+            this.init()
+
+            vscode.workspace.onDidOpenNotebookDocument(this.onDidOpenNotebookDocument, this, this.disposables)
+        }
     }
 
     private async init() {


### PR DESCRIPTION
So until we find a solution for https://github.com/julia-vscode/julia-vscode/issues/2256, the native notebook experience will write notebook files that don't save kernel information. In my mind this is a bit of a showstopper, anything where we write files that have a "bug" I think we should hide behind an experimental flag. I think users would get rightfully upset if we shipped something that writes incorrect files and then they have to deal with these down the road.

So, that is what this PR does. I would suggest we merge this and leave it in until upstream provides the necessary APIs to properly write correct Jupyter notebooks. And with this PR merged, we _can_ ship a version 1.3 to the release channel, though.

CC @DonJayamanne and @claudiaregio, if you have some other idea how we could solve this in the very short term, please let me know! I think we are shooting at a release sometime in the first half of next week.