### PR TITLE
Provide better labels for notebook controller

### DIFF
--- a/src/notebook/notebookFeature.ts
+++ b/src/notebook/notebookFeature.ts
@@ -63,6 +63,8 @@ export class JuliaNotebookFeature {
             const controller = vscode.notebooks.createNotebookController(kernelId, JupyterNotebookViewType, displayName)
             controller.supportedLanguages = ['julia']
             controller.supportsExecutionOrder = true
+            controller.description = 'Julia VS Code extension'
+            controller.detail = juliaVersion.path
             controller.onDidChangeSelectedNotebooks((e) => {
                 if (e.selected && e.notebook) {
                     e.notebook.getCells().filter(cell => cell.kind === vscode.NotebookCellKind.Code).map(cell => vscode.languages.setTextDocumentLanguage(cell.document, 'julia'))


### PR DESCRIPTION
This makes the kernel selection UI look like this:

![image](https://user-images.githubusercontent.com/1036561/126853780-bb8b5a4c-e3ce-4388-b492-67cc77221145.png)

So it shows our extension name, so that users understand where that kernel is coming from, and it also shows the Julia path that is used for that kernel.

@DonJayamanne and @claudiaregio, maybe the Jupyter extension could also set the `controller.description` field to something like `Jupyter extension`, then it would be even clearer where these kernels come from?