### PR TITLE
Add a debug launch for the LSP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /dist/
 /out/
 /scripts/languageserver/julia_pkgdir/lib/
+/globalstorage

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,6 +33,31 @@
                 "${workspaceFolder}/out/test/**/*.js"
             ],
             "preLaunchTask": "npm: test-compile"
+        },
+        {
+            "name": "Run LSP",
+            "type": "julia",
+            "request": "launch",
+            "program": "${workspaceFolder}/scripts/languageserver/main.jl",
+            "stopOnEntry": false,
+            "cwd": "${workspaceFolder}/scripts/languageserver",
+            "args": [
+                "", // Environment
+                "--debug=yes",
+                "", // Telemetry pipename
+                "", // Old depot path,
+                "${workspaceFolder}/globalstorage", // Storage path
+                "download" // useSymserverDownloads
+            ]
+        }
+    ],
+    "compounds": [
+        {
+            "name": "Run Extension and LSP",
+            "configurations": [
+                "Run Extension",
+                "Run LSP"
+            ]
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -35,7 +35,7 @@
             "preLaunchTask": "npm: test-compile"
         },
         {
-            "name": "Run LSP",
+            "name": "Run LS",
             "type": "julia",
             "request": "launch",
             "program": "${workspaceFolder}/scripts/languageserver/main.jl",
@@ -47,16 +47,36 @@
                 "", // Telemetry pipename
                 "", // Old depot path,
                 "${workspaceFolder}/globalstorage", // Storage path
-                "download" // useSymserverDownloads
+                "download", // useSymserverDownloads
+                "--detached=yes"
             ]
+        },
+        {
+            "name": "Run Extension with detached LS",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceRoot}"
+            ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": [
+                "${workspaceRoot}/dist/**/*.js"
+            ],
+            "preLaunchTask": "npm: webpack",
+            "env": {
+                "DEBUG_MODE": "true",
+                "DETACHED_LS": "true"
+            }
         }
     ],
     "compounds": [
         {
             "name": "Run Extension and LSP",
             "configurations": [
-                "Run Extension",
-                "Run LSP"
+                "Run Extension with detached LS",
+                "Run LS"
             ]
         }
     ]

--- a/scripts/languageserver/main.jl
+++ b/scripts/languageserver/main.jl
@@ -24,14 +24,28 @@ try
         error("Invalid number of arguments passed to julia language server.")
     end
 
-    conn = stdout
-    (outRead, outWrite) = redirect_stdout()
-
-    if Base.ARGS[2] == "--debug=yes"
-        ENV["JULIA_DEBUG"] = "all"
-    elseif Base.ARGS[2] != "--debug=no"
+    debug_mode = if Base.ARGS[2] == "--debug=yes"
+        true
+    elseif Base.ARGS[2] == "--debug=no"
+        false
+    else
         error("Invalid argument passed.")
     end
+
+    if debug_mode
+        ENV["JULIA_DEBUG"] = "all"
+    end
+
+    if debug_mode
+        serv = listen(7777)
+        global conn_in = accept(serv)
+        global conn_out = conn_in
+    else
+        global conn_in = stdin
+        global conn_out = stdout
+        (outRead, outWrite) = redirect_stdout()
+    end
+
 
     try
         using LanguageServer, SymbolServer
@@ -52,8 +66,8 @@ try
     @info "Symbol server store is at '$symserver_store_path'."
 
     server = LanguageServerInstance(
-        stdin,
-        conn,
+        conn_in,
+        conn_out,
         Base.ARGS[1],
         Base.ARGS[4],
         (err, bt)->global_err_handler(err, bt, Base.ARGS[3], "Language Server"),

--- a/scripts/languageserver/main.jl
+++ b/scripts/languageserver/main.jl
@@ -20,7 +20,7 @@ function Base.showerror(io::IO, ex::LSPrecompileFailure)
 end
 
 try
-    if length(Base.ARGS) != 6
+    if length(Base.ARGS) != 7
         error("Invalid number of arguments passed to julia language server.")
     end
 
@@ -32,11 +32,19 @@ try
         error("Invalid argument passed.")
     end
 
+    detached_mode = if Base.ARGS[7] == "--detached=yes"
+        true
+    elseif Base.ARGS[7] == "--detached=no"
+        false
+    else
+        error("Invalid argumentpassed.")
+    end
+
     if debug_mode
         ENV["JULIA_DEBUG"] = "all"
     end
 
-    if debug_mode
+    if detached_mode
         serv = listen(7777)
         global conn_in = accept(serv)
         global conn_out = conn_in
@@ -70,7 +78,7 @@ try
         conn_out,
         Base.ARGS[1],
         Base.ARGS[4],
-        (err, bt)->global_err_handler(err, bt, Base.ARGS[3], "Language Server"),
+        (err, bt) -> global_err_handler(err, bt, Base.ARGS[3], "Language Server"),
         symserver_store_path,
         ARGS[6] == "download"
     )

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@
 import { SeverityLevel } from 'applicationinsights/out/Declarations/Contracts'
 import * as fs from 'async-file'
 import { unwatchFile, watchFile } from 'async-file'
+import * as net from 'net'
 import * as os from 'os'
 import * as path from 'path'
 import * as vscode from 'vscode'
@@ -196,7 +197,6 @@ async function startLanguageServer() {
     const oldDepotPath = process.env.JULIA_DEPOT_PATH ? process.env.JULIA_DEPOT_PATH : ''
     const envForLSPath = path.join(g_context.extensionPath, 'scripts', 'environments', 'languageserver')
     const serverArgsRun: string[] = ['--startup-file=no', '--history-file=no', '--depwarn=no', `--project=${envForLSPath}`, 'main.jl', jlEnvPath, '--debug=no', telemetry.getCrashReportingPipename(), oldDepotPath, storagePath, useSymserverDownloads]
-    const serverArgsDebug: string[] = ['--startup-file=no', '--history-file=no', '--depwarn=no', `--project=${envForLSPath}`, 'main.jl', jlEnvPath, '--debug=yes', telemetry.getCrashReportingPipename(), oldDepotPath, storagePath, useSymserverDownloads]
     const spawnOptions = {
         cwd: path.join(g_context.extensionPath, 'scripts', 'languageserver'),
         env: {
@@ -209,10 +209,13 @@ async function startLanguageServer() {
 
     const jlexepath = await juliaexepath.getJuliaExePath()
 
-    const serverOptions: ServerOptions = {
-        run: { command: jlexepath, args: serverArgsRun, options: spawnOptions },
-        debug: { command: jlexepath, args: serverArgsDebug, options: spawnOptions }
-    }
+    const serverOptions: ServerOptions = Boolean(process.env.DEBUG_MODE) ?
+        async () => {
+            // TODO Add some loop here that retries in case the LSP is not yet ready
+            const conn = net.connect(7777)
+            return { reader: conn, writer: conn, detached: true }
+        } :
+        { command: jlexepath, args: serverArgsRun, options: spawnOptions }
 
     const clientOptions: LanguageClientOptions = {
         documentSelector: ['julia', 'juliamarkdown'],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -196,7 +196,8 @@ async function startLanguageServer() {
     await fs.createDirectory(languageServerDepotPath)
     const oldDepotPath = process.env.JULIA_DEPOT_PATH ? process.env.JULIA_DEPOT_PATH : ''
     const envForLSPath = path.join(g_context.extensionPath, 'scripts', 'environments', 'languageserver')
-    const serverArgsRun: string[] = ['--startup-file=no', '--history-file=no', '--depwarn=no', `--project=${envForLSPath}`, 'main.jl', jlEnvPath, '--debug=no', telemetry.getCrashReportingPipename(), oldDepotPath, storagePath, useSymserverDownloads]
+    const serverArgsRun: string[] = ['--startup-file=no', '--history-file=no', '--depwarn=no', `--project=${envForLSPath}`, 'main.jl', jlEnvPath, '--debug=no', telemetry.getCrashReportingPipename(), oldDepotPath, storagePath, useSymserverDownloads, '--detached=no']
+    const serverArgsDebug: string[] = ['--startup-file=no', '--history-file=no', '--depwarn=no', `--project=${envForLSPath}`, 'main.jl', jlEnvPath, '--debug=yes', telemetry.getCrashReportingPipename(), oldDepotPath, storagePath, useSymserverDownloads, '--detached=no']
     const spawnOptions = {
         cwd: path.join(g_context.extensionPath, 'scripts', 'languageserver'),
         env: {
@@ -209,13 +210,16 @@ async function startLanguageServer() {
 
     const jlexepath = await juliaexepath.getJuliaExePath()
 
-    const serverOptions: ServerOptions = Boolean(process.env.DEBUG_MODE) ?
+    const serverOptions: ServerOptions = Boolean(process.env.DETACHED_LS) ?
         async () => {
             // TODO Add some loop here that retries in case the LSP is not yet ready
             const conn = net.connect(7777)
             return { reader: conn, writer: conn, detached: true }
         } :
-        { command: jlexepath, args: serverArgsRun, options: spawnOptions }
+        {
+            run: { command: jlexepath, args: serverArgsRun, options: spawnOptions },
+            debug: { command: jlexepath, args: serverArgsDebug, options: spawnOptions }
+        }
 
     const clientOptions: LanguageClientOptions = {
         documentSelector: ['julia', 'juliamarkdown'],


### PR DESCRIPTION
With this the LSP process starts in debug mode when we debug the extension. Breakpoints in request handlers? Check!

Probably still a bit iffy, and the fact that the debugger doesn't handle `@async` will probably be a problem, but crudly it works and is probably already helpful.

@ZacLN just pinging you here to make sure you see this, I think this might make working on the LS a lot easier.