### PR TITLE
Implement a new kernel selection strategy

### DIFF
--- a/src/juliaexepath.ts
+++ b/src/juliaexepath.ts
@@ -4,7 +4,7 @@ import * as child_process from 'child_process'
 import * as os from 'os'
 import * as path from 'path'
 import * as process from 'process'
-import { valid } from 'semver'
+import { parse } from 'semver'
 import * as vscode from 'vscode'
 import * as which from 'which'
 import { onDidChangeConfig } from './extension'
@@ -14,7 +14,7 @@ import { resolvePath } from './utils'
 let actualJuliaExePath: JuliaExecutable = null
 
 async function setNewJuliaExePath(newPath: string) {
-    actualJuliaExePath = new JuliaExecutable('', newPath)
+    actualJuliaExePath = new JuliaExecutable('', newPath, undefined, undefined, true)
 
     const env = {
         JULIA_LANGUAGESERVER: '1'
@@ -86,11 +86,11 @@ function getSearchPaths(): string[] {
     return pathsToSearch
 }
 export class JuliaExecutable {
-    constructor(public version: string, public path: string) {
+    constructor(public version: string, public path: string, public arch: string | undefined, public channel: string | undefined, public officialChannel: boolean) {
     }
 
     public getVersion() {
-        return valid(this.version)
+        return parse(this.version)
     }
 }
 let cachedJuliaExePaths: Promise<JuliaExecutable[]> | undefined
@@ -121,7 +121,7 @@ export async function getJuliaExePaths(): Promise<JuliaExecutable[]> {
                     if (actualJuliaExePath.path === filePath && !actualJuliaExePath.version) {
                         actualJuliaExePath.version = version
                     }
-                    executables.push(new JuliaExecutable(version, path.join(bindir, path.basename(filePath))))
+                    executables.push(new JuliaExecutable(version, path.join(bindir, path.basename(filePath)), undefined, undefined, true))
                 } catch (ex) {
                     return
                 }


### PR DESCRIPTION
Replaces https://github.com/julia-vscode/julia-vscode/pull/2276.

@DonJayamanne I thought about this a bit more, and this is a quite different strategy now :)

The starting point is that I think we should actually register a controller for every Julia version that is installed, not just one per minor version. The "one per minor version" is something IJulia.jl does, but I don't really see any good reason for that in our case, I think we should just give users access to any Julia version they have installed.

From that it follows that we can't name our controllers `julia-1.6` because those names are not unique, we now want the ability to have a controller for 1.6.1 and 1.6.2 etc. I also now want to expose x64 and x86 controllers and a couple more things that will come once I integrate things with https://github.com/julialang/juliaup. To accommodate all of that, I'm ging up on trying to use the same names for controllers that IJulia.jl uses, instead we'll use something richer. For now `julia-1.6.1`, but this will turn into `julia-1.6.1~x64` down the road.

The next change is to the whole `updateNotebookAffinity` story. I now base that _purely_ on the `metadata.language_info.version` field from the Jupyter notebook file. I now _completely_ ignore the content in the `metadata.kernelspec` element. I think select controller based on the version is at the end of the day finer grained and lets us do more useful defaults. I also make sure that we only ever mark one controller per notebook as `NotebookControllerAffinity.Preferred`, so in my ideal world VS Code (or the Jupyter extension) would actually _not_ prompt to select a kernel if only one controller is marked as preferred, instead it would just select that controller automatically without any user interaction.

The final part is that in `updateNotebookWithSelectedKernel` I now write a `metadata.kernelspec` that matches what Jupyter Lab does, so here I use a name that is just `julia-1.6` again. Given that I don't use that anymore in the read phase at all, we can treat this entire element as purely informational or useful for other clients, and so the idea now is to just write it in a form that helps them.

Does that all make sense to you?

One other question: I think you mentioned at some point that there is also some state somewhere in VS Code where kernel choice is stored somewhere outside of the notebook file? I almost feel it would be better if that was not the case, because (I think) the implementation in this PR should actually always lead to just one preferred controller that should then be used, and so I think ideally that logic would just run every time a notebook is opened, and no recourse to some hidden state somewhere else would come into play.

CC @@claudiaregio.