### PR TITLE
wip: inline evaluation: handle jump to unsaved editors

### DIFF
--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -432,6 +432,8 @@ export async function openFile(path: string, line: number = undefined) {
     if (path.indexOf('Untitled') === 0) {
         // can't open an untitled file like this:
         // uri = vscode.Uri.parse('untitled:' + path)
+        // watch: https://github.com/microsoft/vscode/issues/117985
+        return vscode.window.showWarningMessage('can\'t open unsaved editor.')
     } else {
         uri = vscode.Uri.file(path)
     }


### PR DESCRIPTION
Just found VSCode API doesn't support this.

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.
