### PR TITLE
Rewrite Julia executable search code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -168,15 +168,6 @@
                 "katex": "^0.13.9"
             }
         },
-        "@types/child-process-promise": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@types/child-process-promise/-/child-process-promise-2.2.2.tgz",
-            "integrity": "sha512-4eGTIhKW0jb9DlS81Fgo/UyZ12DMhDhz3Ec8tdHW53l4ubteynNIuy7Z1HNnyHn1jTzXa/o9iX0WoAdiSoDs+Q==",
-            "dev": true,
-            "requires": {
-                "@types/node": "*"
-            }
-        },
         "@types/decompress": {
             "version": "4.2.4",
             "resolved": "https://registry.npmjs.org/@types/decompress/-/decompress-4.2.4.tgz",
@@ -636,14 +627,6 @@
             "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
             "dev": true
         },
-        "async-child-process": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/async-child-process/-/async-child-process-1.1.1.tgz",
-            "integrity": "sha1-J9ClmLVzhwf5iYwEi9IxNAWDdHs=",
-            "requires": {
-                "babel-runtime": "^6.11.6"
-            }
-        },
         "async-file": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/async-file/-/async-file-2.0.2.tgz",
@@ -689,15 +672,6 @@
             "requires": {
                 "tunnel": "0.0.6",
                 "typed-rest-client": "^1.8.4"
-            }
-        },
-        "babel-runtime": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-            "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-            "requires": {
-                "core-js": "^2.4.0",
-                "regenerator-runtime": "^0.11.0"
             }
         },
         "balanced-match": {
@@ -943,16 +917,6 @@
                 "domutils": "^2.7.0"
             }
         },
-        "child-process-promise": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/child-process-promise/-/child-process-promise-2.2.1.tgz",
-            "integrity": "sha1-RzChHvYQ+tRQuPIjx50x172tgHQ=",
-            "requires": {
-                "cross-spawn": "^4.0.2",
-                "node-version": "^1.0.0",
-                "promise-polyfill": "^6.0.1"
-            }
-        },
         "chokidar": {
             "version": "3.5.1",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
@@ -1073,35 +1037,11 @@
                 "emitter-listener": "^1.1.1"
             }
         },
-        "core-js": {
-            "version": "2.6.12",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-            "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-        },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
             "dev": true
-        },
-        "cross-spawn": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-            "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-            "requires": {
-                "lru-cache": "^4.0.1",
-                "which": "^1.2.9"
-            },
-            "dependencies": {
-                "which": {
-                    "version": "1.3.1",
-                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-                    "requires": {
-                        "isexe": "^2.0.0"
-                    }
-                }
-            }
         },
         "css-select": {
             "version": "4.1.3",
@@ -2401,15 +2341,6 @@
             "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
             "dev": true
         },
-        "lru-cache": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-            "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-            "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
-            }
-        },
         "make-dir": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -2641,11 +2572,6 @@
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
             "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
             "dev": true
-        },
-        "node-version": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/node-version/-/node-version-1.2.0.tgz",
-            "integrity": "sha512-ma6oU4Sk0qOoKEAymVoTvk8EdXEobdS7m/mAGhDJ8Rouugho48crHBORAmy5BoOcv8wraPM6xumapQp5hl4iIQ=="
         },
         "normalize-path": {
             "version": "3.0.0",
@@ -2975,11 +2901,6 @@
             "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
             "dev": true
         },
-        "promise-polyfill": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-6.1.0.tgz",
-            "integrity": "sha1-36lpQ+qcEh/KTem1hoyznTRy4Fc="
-        },
         "promised-temp": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/promised-temp/-/promised-temp-0.1.0.tgz",
@@ -3006,16 +2927,16 @@
                 }
             }
         },
+        "promisify-child-process": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/promisify-child-process/-/promisify-child-process-4.1.1.tgz",
+            "integrity": "sha512-/sRjHZwoXf1rJ+8s4oWjYjGRVKNK1DUnqfRC1Zek18pl0cN6k3yJ1cCbqd0tWNe4h0Gr+SY4vR42N33+T82WkA=="
+        },
         "proto-list": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
             "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
             "dev": true
-        },
-        "pseudomap": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
         },
         "punycode": {
             "version": "2.1.1",
@@ -3093,11 +3014,6 @@
             "requires": {
                 "resolve": "^1.9.0"
             }
-        },
-        "regenerator-runtime": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
         },
         "regexpp": {
             "version": "3.2.0",
@@ -3352,6 +3268,11 @@
             "version": "1.3.7",
             "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
             "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
+        },
+        "string-argv": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+            "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg=="
         },
         "string-width": {
             "version": "4.2.2",
@@ -4172,11 +4093,6 @@
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
             "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
             "dev": true
-        },
-        "yallist": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         },
         "yargs": {
             "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -1219,14 +1219,14 @@
     "dependencies": {
         "@traptitech/markdown-it-katex": "^3.4.3",
         "applicationinsights": "^1.8.10",
-        "async-child-process": "^v1.1.1",
         "async-file": "^v2.0.2",
         "await-notify": "^1.0.1",
-        "child-process-promise": "^v2.2.1",
         "markdown-it": "^12.1.0",
         "markdown-it-footnote": "^3.0.3",
         "promised-temp": "^v0.1.0",
+        "promisify-child-process": "^4.1.1",
         "semver": "^7.3.5",
+        "string-argv": "^0.3.1",
         "uuidv4": "^6.2.11",
         "vscode-debugadapter": "^1.48.0",
         "vscode-jsonrpc": "^6.0.0",
@@ -1234,7 +1234,6 @@
         "which": "^2.0.2"
     },
     "devDependencies": {
-        "@types/child-process-promise": "^2.2.2",
         "@types/download": "^8.0.1",
         "@types/markdown-it": "^12.0.3",
         "@types/mocha": "^8.2.3",

--- a/src/debugger/debugFeature.ts
+++ b/src/debugger/debugFeature.ts
@@ -1,13 +1,13 @@
 import * as vscode from 'vscode'
 import * as jlpkgenv from '../jlpkgenv'
-import { getJuliaExePath } from '../juliaexepath'
+import { JuliaExecutablesFeature } from '../juliaexepath'
 import { registerCommand } from '../utils'
 import { JuliaDebugSession } from './juliaDebug'
 
 export class JuliaDebugFeature {
-    constructor(private context: vscode.ExtensionContext, compiledProvider) {
+    constructor(private context: vscode.ExtensionContext, compiledProvider, juliaExecutablesFeature: JuliaExecutablesFeature) {
         const provider = new JuliaDebugConfigurationProvider(compiledProvider)
-        const factory = new InlineDebugAdapterFactory(this.context)
+        const factory = new InlineDebugAdapterFactory(this.context, juliaExecutablesFeature)
 
         compiledProvider.onDidChangeTreeData(() => {
             if (vscode.debug.activeDebugSession && vscode.debug.activeDebugSession.type === 'julia') {
@@ -143,11 +143,11 @@ export class JuliaDebugConfigurationProvider implements vscode.DebugConfiguratio
 
 class InlineDebugAdapterFactory implements vscode.DebugAdapterDescriptorFactory {
 
-    constructor(private context: vscode.ExtensionContext) { }
+    constructor(private context: vscode.ExtensionContext, private juliaExecutablesFeature: JuliaExecutablesFeature) { }
 
     createDebugAdapterDescriptor(_session: vscode.DebugSession): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
         return (async () => {
-            return new vscode.DebugAdapterInlineImplementation(<any>new JuliaDebugSession(this.context, await getJuliaExePath()))
+            return new vscode.DebugAdapterInlineImplementation(<any>new JuliaDebugSession(this.context, await this.juliaExecutablesFeature.getActiveJuliaExecutableAsync()))
         })()
     }
 }

--- a/src/debugger/juliaDebug.ts
+++ b/src/debugger/juliaDebug.ts
@@ -7,6 +7,7 @@ import { InitializedEvent, Logger, logger, LoggingDebugSession, StoppedEvent, Te
 import { DebugProtocol } from 'vscode-debugprotocol'
 import { createMessageConnection, Disposable, MessageConnection, StreamMessageReader, StreamMessageWriter } from 'vscode-jsonrpc/node'
 import { replStartDebugger } from '../interactive/repl'
+import { JuliaExecutable } from '../juliaexepath'
 import { getCrashReportingPipename } from '../telemetry'
 import { generatePipeName, inferJuliaNumThreads } from '../utils'
 import { notifyTypeDebug, notifyTypeExec, notifyTypeOurFinished, notifyTypeRun, notifyTypeSetCompiledItems, notifyTypeSetCompiledMode, notifyTypeStopped, requestTypeBreakpointLocations, requestTypeContinue, requestTypeDisconnect, requestTypeEvaluate, requestTypeExceptionInfo, requestTypeNext, requestTypeRestartFrame, requestTypeScopes, requestTypeSetBreakpoints, requestTypeSetExceptionBreakpoints, requestTypeSetFunctionBreakpoints, requestTypeSetVariable, requestTypeSource, requestTypeStackTrace, requestTypeStepIn, requestTypeStepInTargets, requestTypeStepOut, requestTypeTerminate, requestTypeThreads, requestTypeVariables } from './debugProtocol'
@@ -55,7 +56,7 @@ export class JuliaDebugSession extends LoggingDebugSession {
      * Creates a new debug adapter that is used for one debug session.
      * We configure the default implementation of a debug adapter here.
      */
-    public constructor(private context: vscode.ExtensionContext, private juliaPath: string) {
+    public constructor(private context: vscode.ExtensionContext, private juliaExecutable: JuliaExecutable) {
         super('julia-debug.txt')
 
         // this debugger uses zero-based lines and columns
@@ -231,8 +232,9 @@ export class JuliaDebugSession extends LoggingDebugSession {
 
         this._debuggeeTerminal = vscode.window.createTerminal({
             name: args.noDebug ? 'Julia Session' : 'Julia Debugger',
-            shellPath: this.juliaPath,
+            shellPath: this.juliaExecutable.file,
             shellArgs: [
+                ...this.juliaExecutable.args,
                 '--color=yes',
                 '--startup-file=no',
                 '--history-file=no',

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -11,7 +11,7 @@ import * as vslc from 'vscode-languageclient/node'
 import { onSetLanguageClient } from '../extension'
 import * as jlpkgenv from '../jlpkgenv'
 import { switchEnvToPath } from '../jlpkgenv'
-import * as juliaexepath from '../juliaexepath'
+import { JuliaExecutablesFeature } from '../juliaexepath'
 import * as telemetry from '../telemetry'
 import { generatePipeName, getVersionedParamsAtPosition, inferJuliaNumThreads, registerCommand, setContext } from '../utils'
 import { VersionedTextDocumentPositionParams } from './misc'
@@ -28,6 +28,8 @@ let g_compiledProvider = null
 let g_terminal: vscode.Terminal = null
 
 export let g_connection: rpc.MessageConnection = undefined
+
+let g_juliaExecutablesFeature: JuliaExecutablesFeature
 
 function startREPLCommand() {
     telemetry.traceEvent('command-startrepl')
@@ -92,7 +94,7 @@ async function startREPL(preserveFocus: boolean, showTerminal: boolean = true) {
 
         const juliaIsConnectedPromise = startREPLMsgServer(pipename)
 
-        const exepath = await juliaexepath.getJuliaExePath()
+        const juliaExecutable = await g_juliaExecutablesFeature.getActiveJuliaExecutableAsync()
 
         let jlarg1: string[]
         const pkgenvpath = await jlpkgenv.getAbsEnvPath()
@@ -123,7 +125,7 @@ async function startREPL(preserveFocus: boolean, showTerminal: boolean = true) {
             const tmuxArgs = [
                 <string>config.get('persistentSession.shellExecutionArgument'),
                 // create a new tmux session, set remain-on-exit to true, and attach; if the session already exists we just attach to the existing session
-                `tmux new -d -s ${sessionName} ${exepath} ${jlarg1.concat(getArgs()).join(' ')} && tmux set -q remain-on-exit && tmux attach -t ${sessionName} ||
+                `tmux new -d -s ${sessionName} ${juliaExecutable.file} ${[...juliaExecutable.args, ...jlarg1, ...getArgs()].join(' ')} && tmux set -q remain-on-exit && tmux attach -t ${sessionName} ||
                 tmux send-keys -t ${sessionName}.left ^A ^K ^H '${connectJuliaCode}' ENTER && tmux attach -t ${sessionName}`
             ]
 
@@ -136,8 +138,8 @@ async function startREPL(preserveFocus: boolean, showTerminal: boolean = true) {
         } else {
             g_terminal = vscode.window.createTerminal({
                 name: 'Julia REPL',
-                shellPath: exepath,
-                shellArgs: jlarg1.concat(getArgs()),
+                shellPath: juliaExecutable.file,
+                shellArgs: [...juliaExecutable.args, ...jlarg1, ...getArgs()],
                 env: env
             })
         }
@@ -802,8 +804,8 @@ async function linkHandler(link: any) {
 
     if (file.startsWith('.')) {
         // Base file
-        const exepath = await juliaexepath.getJuliaExePath()
-        file = path.join(exepath, '..', '..', 'share', 'julia', 'base', file)
+        const exepath = await g_juliaExecutablesFeature.getActiveJuliaExecutableAsync()
+        file = path.join(await exepath.getBaseRootFolderPathAsync(), file)
     } else if (file.startsWith('~')) {
         file = path.join(homedir(), file.slice(1))
     }
@@ -843,8 +845,9 @@ export async function replStartDebugger(pipename: string) {
     g_connection.sendNotification(notifyTypeReplStartDebugger, { debugPipename: pipename })
 }
 
-export function activate(context: vscode.ExtensionContext, compiledProvider) {
+export function activate(context: vscode.ExtensionContext, compiledProvider, juliaExecutablesFeature: JuliaExecutablesFeature) {
     g_context = context
+    g_juliaExecutablesFeature = juliaExecutablesFeature
 
     g_compiledProvider = compiledProvider
 

--- a/src/jlpkgenv.ts
+++ b/src/jlpkgenv.ts
@@ -1,11 +1,11 @@
 import * as fs from 'async-file'
-import { exec } from 'child-process-promise'
 import * as os from 'os'
 import * as path from 'path'
+import { execFile } from 'promisify-child-process'
 import * as vscode from 'vscode'
 import * as vslc from 'vscode-languageclient/node'
 import { onSetLanguageClient } from './extension'
-import * as juliaexepath from './juliaexepath'
+import { JuliaExecutablesFeature } from './juliaexepath'
 import * as packagepath from './packagepath'
 import * as telemetry from './telemetry'
 import { registerCommand, resolvePath } from './utils'
@@ -17,6 +17,8 @@ let g_current_environment: vscode.StatusBarItem = null
 let g_path_of_current_environment: string = null
 let g_path_of_default_environment: string = null
 let g_resolved_path_of_environment: string = null
+
+let g_juliaExecutablesFeature: JuliaExecutablesFeature = null
 
 export async function getProjectFilePaths(envpath: string) {
     const dlext = process.platform === 'darwin' ? 'dylib' : process.platform === 'win32' ? 'dll' : 'so'
@@ -61,10 +63,20 @@ export async function switchEnvToPath(envpath: string, notifyLS: boolean) {
             vscode.workspace.workspaceFolders[0].uri.fsPath.charAt(0).toUpperCase() + vscode.workspace.workspaceFolders[0].uri.fsPath.slice(1) :
             vscode.workspace.workspaceFolders[0].uri.fsPath
 
-        const jlexepath = await juliaexepath.getJuliaExePath()
-        const res = await exec(`"${jlexepath}" --project=${g_resolved_path_of_environment} --startup-file=no --history-file=no -e "using Pkg; println(in(ARGS[1], VERSION>=VersionNumber(1,1,0) ? realpath.(filter(i->i!==nothing && isdir(i), getproperty.(values(Pkg.Types.Context().env.manifest), :path))) : realpath.(filter(i->i!=nothing && isdir(i), map(i->get(i[1], string(:path), nothing), values(Pkg.Types.Context().env.manifest)))) ))" "${case_adjusted}"`)
+        const juliaExecutable = await g_juliaExecutablesFeature.getActiveJuliaExecutableAsync()
+        const res = await execFile(
+            juliaExecutable.file,
+            [
+                ...juliaExecutable.args,
+                `--project=${g_resolved_path_of_environment}`,
+                '--startup-file=no',
+                '--history-file=no',
+                '-e "using Pkg; println(in(ARGS[1], VERSION>=VersionNumber(1,1,0) ? realpath.(filter(i->i!==nothing && isdir(i), getproperty.(values(Pkg.Types.Context().env.manifest), :path))) : realpath.(filter(i->i!=nothing && isdir(i), map(i->get(i[1], string(:path), nothing), values(Pkg.Types.Context().env.manifest)))) ))"',
+                `"${case_adjusted}"`
+            ]
+        )
 
-        if (res.stdout.trim() === 'false') {
+        if (res.stdout.toString().trim() === 'false') {
             vscode.window.showInformationMessage('You opened a Julia package that is not part of your current environment. Do you want to activate a different environment?', 'Change Julia environment')
                 .then(env_choice => {
                     if (env_choice === 'Change Julia environment') {
@@ -168,9 +180,15 @@ async function getDefaultEnvPath() {
             }
         }
 
-        const jlexepath = await juliaexepath.getJuliaExePath()
-        const res = await exec(`"${jlexepath}" --startup-file=no --history-file=no -e "using Pkg; println(dirname(Pkg.Types.Context().env.project_file))"`)
-        g_path_of_default_environment = res.stdout.trim()
+        const juliaExecutable = await g_juliaExecutablesFeature.getActiveJuliaExecutableAsync()
+        const res = await execFile(
+            juliaExecutable.file,
+            [
+                '--startup-file=no',
+                '--history-file=no',
+                '-e "using Pkg; println(dirname(Pkg.Types.Context().env.project_file))"'
+            ])
+        g_path_of_default_environment = res.stdout.toString().trim()
     }
     return g_path_of_default_environment
 }
@@ -208,7 +226,8 @@ export async function getEnvName() {
     return path.basename(envpath)
 }
 
-export async function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext, juliaExecutablesFeature: JuliaExecutablesFeature) {
+    g_juliaExecutablesFeature = juliaExecutablesFeature
     context.subscriptions.push(onSetLanguageClient(languageClient => {
         g_languageClient = languageClient
     }))

--- a/src/notebook/notebookKernel.ts
+++ b/src/notebook/notebookKernel.ts
@@ -237,8 +237,9 @@ export class JuliaKernel {
         const cwdPath = await this.getCwdPathForNotebook()
 
         this._kernelProcess = spawn(
-            this.juliaExecutable.path,
+            this.juliaExecutable.file,
             [
+                ...this.juliaExecutable.args,
                 '--color=yes',
                 `--project=${pkgenvpath}`,
                 '--startup-file=no',

--- a/src/packagedevtools.ts
+++ b/src/packagedevtools.ts
@@ -1,11 +1,11 @@
 import * as path from 'path'
 import * as vscode from 'vscode'
-import { getJuliaExePath } from './juliaexepath'
+import { JuliaExecutablesFeature } from './juliaexepath'
 import * as telemetry from './telemetry'
 import { registerCommand } from './utils'
 
 export class JuliaPackageDevFeature {
-    constructor(private context: vscode.ExtensionContext) {
+    constructor(private context: vscode.ExtensionContext, private juliaExecutablesFeature: JuliaExecutablesFeature) {
         this.context.subscriptions.push(registerCommand('language-julia.tagNewPackageVersion', () => this.tagNewPackageVersion()))
     }
 
@@ -23,13 +23,14 @@ export class JuliaPackageDevFeature {
             const accessToken = bar.accessToken
             const account = bar.account.label
 
-            const exepath = await getJuliaExePath()
+            const juliaExecutable = await this.juliaExecutablesFeature.getActiveJuliaExecutableAsync()
 
             const newTerm = vscode.window.createTerminal(
                 {
                     name: 'Julia: Tag a new package version',
-                    shellPath: exepath,
+                    shellPath: juliaExecutable.file,
                     shellArgs: [
+                        ...juliaExecutable.args,
                         path.join(this.context.extensionPath, 'scripts', 'packagedev', 'tagnewpackageversion.jl'),
                         accessToken,
                         account,

--- a/src/packagepath.ts
+++ b/src/packagepath.ts
@@ -1,33 +1,50 @@
-import { exec } from 'child-process-promise'
 import { join } from 'path'
+import { execFile } from 'promisify-child-process'
 import * as vscode from 'vscode'
 import { onDidChangeConfig } from './extension'
-import * as juliaexepath from './juliaexepath'
+import { JuliaExecutablesFeature } from './juliaexepath'
 
 let juliaPackagePath: string = null
 
 let juliaDepotPath: string[] = null
 
+let g_juliaExecutablesFeature: JuliaExecutablesFeature
+
 export async function getPkgPath() {
     if (juliaPackagePath === null) {
-        const jlexepath = await juliaexepath.getJuliaExePath()
+        const juliaExecutable = await g_juliaExecutablesFeature.getActiveJuliaExecutableAsync()
         // TODO: there's got to be a better way to do this.
-        const res = await exec(`"${jlexepath}" --startup-file=no --history-file=no -e "using Pkg;println(Pkg.depots()[1])"`)
-        juliaPackagePath = join(res.stdout.trim(), 'dev')
+        const res = await execFile(
+            juliaExecutable.file,
+            [
+                '--startup-file=no',
+                '--history-file=no',
+                '-e "using Pkg;println(Pkg.depots()[1])"'
+            ]
+        )
+        juliaPackagePath = join(res.stdout.toString().trim(), 'dev')
     }
     return juliaPackagePath
 }
 
 export async function getPkgDepotPath() {
     if (juliaDepotPath === null) {
-        const jlexepath = await juliaexepath.getJuliaExePath()
-        const res = await exec(`"${jlexepath}" --startup-file=no --history-file=no -e "using Pkg; println.(Pkg.depots())"`)
-        juliaDepotPath = res.stdout.trim().split('\n')
+        const juliaExecutable = await g_juliaExecutablesFeature.getActiveJuliaExecutableAsync()
+        const res = await execFile(
+            juliaExecutable.file,
+            [
+                '--startup-file=no',
+                '--history-file=no',
+                '-e "using Pkg; println.(Pkg.depots())"'
+            ]
+        )
+        juliaDepotPath = res.stdout.toString().trim().split('\n')
     }
     return juliaDepotPath
 }
 
-export function activate(context: vscode.ExtensionContext) {
+export function activate(context: vscode.ExtensionContext, juliaExecutablesFeature: JuliaExecutablesFeature) {
+    g_juliaExecutablesFeature = juliaExecutablesFeature
     context.subscriptions.push(
         onDidChangeConfig(event => {
             if (event.affectsConfiguration('julia.executablePath')) {

--- a/src/scripts/updateDeps.ts
+++ b/src/scripts/updateDeps.ts
@@ -1,8 +1,8 @@
-import * as cp from 'child-process-promise'
 import * as download from 'download'
 import { promises as fs } from 'fs'
 import * as path from 'path'
 import * as process from 'process'
+import * as cp from 'promisify-child-process'
 import * as semver from 'semver'
 
 async function our_download(url: string, destination: string) {
@@ -52,7 +52,7 @@ async function main() {
     for (const pkg of ['CodeTracking', 'CoverageTools', 'FilePathsBase', 'JuliaInterpreter', 'LoweredCodeUtils', 'OrderedCollections', 'PackageCompiler', 'Revise', 'Tokenize', 'URIParser']) {
         const tags = await cp.exec('git tag', { cwd: path.join(process.cwd(), `scripts/packages/${pkg}`) })
 
-        const newestTag = tags.stdout.split(/\r?\n/).map(i => { return { original: i, parsed: semver.valid(i) } }).filter(i => i.parsed !== null).sort((a, b) => semver.compare(b.parsed, a.parsed))[0]
+        const newestTag = tags.stdout.toString().split(/\r?\n/).map(i => { return { original: i, parsed: semver.valid(i) } }).filter(i => i.parsed !== null).sort((a, b) => semver.compare(b.parsed, a.parsed))[0]
 
         await cp.exec(`git checkout ${newestTag.original}`, { cwd: path.join(process.cwd(), `scripts/packages/${pkg}`) })
     }

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -2,12 +2,12 @@ import * as fs from 'async-file'
 import * as path from 'path'
 import * as vscode from 'vscode'
 import * as jlpkgenv from './jlpkgenv'
-import * as juliaexepath from './juliaexepath'
+import { JuliaExecutablesFeature } from './juliaexepath'
 import * as telemetry from './telemetry'
 import { inferJuliaNumThreads } from './utils'
 
 class JuliaTaskProvider {
-    constructor(private context: vscode.ExtensionContext) { }
+    constructor(private context: vscode.ExtensionContext, private juliaExecutablesFeature: JuliaExecutablesFeature) { }
 
     async provideTasks() {
         const emptyTasks: vscode.Task[] = []
@@ -37,30 +37,58 @@ class JuliaTaskProvider {
         try {
             const result: vscode.Task[] = []
 
-            const jlexepath = await juliaexepath.getJuliaExePath()
+            const juliaExecutable = await this.juliaExecutablesFeature.getActiveJuliaExecutableAsync()
             const pkgenvpath = await jlpkgenv.getAbsEnvPath()
 
             if (await fs.exists(path.join(rootPath, 'test', 'runtests.jl'))) {
-                const testTask = new vscode.Task({ type: 'julia', command: 'test' }, folder, `Run tests`, 'julia', new vscode.ProcessExecution(jlexepath, ['--color=yes', `--project=${pkgenvpath}`, '-e', `using Pkg; Pkg.test("${folder.name}")`], { env: { JULIA_NUM_THREADS: inferJuliaNumThreads() } }), '')
+                const testTask = new vscode.Task(
+                    {
+                        type: 'julia',
+                        command: 'test'
+                    },
+                    folder,
+                    `Run tests`,
+                    'julia',
+                    new vscode.ProcessExecution(
+                        juliaExecutable.file,
+                        [
+                            ...juliaExecutable.args,
+                            '--color=yes',
+                            `--project=${pkgenvpath}`,
+                            '-e',
+                            `using Pkg; Pkg.test("${folder.name}")`
+                        ],
+                        {
+                            env: { JULIA_NUM_THREADS: inferJuliaNumThreads() }
+                        }
+                    ),
+                    ''
+                )
                 testTask.group = vscode.TaskGroup.Test
                 testTask.presentationOptions = { echo: false, focus: false, panel: vscode.TaskPanelKind.Dedicated, clear: true }
                 result.push(testTask)
 
                 const testTaskWithCoverage = new vscode.Task(
-                    { type: 'julia', command: 'testcoverage' },
+                    {
+                        type: 'julia',
+                        command: 'testcoverage'
+                    },
                     folder,
                     `Run tests with coverage`,
                     'julia',
                     new vscode.ProcessExecution(
-                        jlexepath,
+                        juliaExecutable.file,
                         [
+                            ...juliaExecutable.args,
                             '--color=yes',
                             `--project=${pkgenvpath}`,
                             path.join(this.context.extensionPath, 'scripts', 'tasks', 'task_test.jl'),
                             folder.uri.fsPath,
                             vscode.workspace.getConfiguration('julia').get<boolean>('deleteJuliaCovFiles') ?? false ? 'true' : 'false'
                         ],
-                        { env: { JULIA_NUM_THREADS: inferJuliaNumThreads() } }
+                        {
+                            env: { JULIA_NUM_THREADS: inferJuliaNumThreads() }
+                        }
                     ),
                     ''
                 )
@@ -75,33 +103,97 @@ class JuliaTaskProvider {
 
             }
 
-            const buildJuliaSysimage = new vscode.Task({ type: 'julia', command: 'juliasysimagebuild' }, folder, `Build custom sysimage for current environment (experimental)`, 'julia', new vscode.ProcessExecution(jlexepath, ['--color=yes', `--project=${path.join(this.context.extensionPath, 'scripts', 'environments', 'sysimagecompile')}`, '--startup-file=no', '--history-file=no', path.join(this.context.extensionPath, 'scripts', 'tasks', 'task_compileenv.jl'), pkgenvpath]), '')
+            const buildJuliaSysimage = new vscode.Task(
+                {
+                    type: 'julia',
+                    command: 'juliasysimagebuild'
+                },
+                folder,
+                `Build custom sysimage for current environment (experimental)`,
+                'julia',
+                new vscode.ProcessExecution(
+                    juliaExecutable.file,
+                    [
+                        ...juliaExecutable.args,
+                        '--color=yes',
+                        `--project=${path.join(this.context.extensionPath, 'scripts', 'environments', 'sysimagecompile')}`,
+                        '--startup-file=no',
+                        '--history-file=no',
+                        path.join(this.context.extensionPath, 'scripts', 'tasks', 'task_compileenv.jl'),
+                        pkgenvpath
+                    ]
+                ),
+                ''
+            )
             buildJuliaSysimage.group = vscode.TaskGroup.Build
             buildJuliaSysimage.presentationOptions = { echo: false, focus: false, panel: vscode.TaskPanelKind.Dedicated, clear: true }
             result.push(buildJuliaSysimage)
 
             if (await fs.exists(path.join(rootPath, 'deps', 'build.jl'))) {
-                const buildTask = new vscode.Task({ type: 'julia', command: 'build' }, folder, `Run build`, 'julia', new vscode.ProcessExecution(jlexepath, ['--color=yes', `--project=${pkgenvpath}`, '-e', `using Pkg; Pkg.build("${folder.name}")`]), '')
+                const buildTask = new vscode.Task(
+                    {
+                        type: 'julia',
+                        command: 'build'
+                    },
+                    folder,
+                    `Run build`,
+                    'julia',
+                    new vscode.ProcessExecution(
+                        juliaExecutable.file,
+                        [
+                            ...juliaExecutable.args,
+                            '--color=yes',
+                            `--project=${pkgenvpath}`,
+                            '-e',
+                            `using Pkg; Pkg.build("${folder.name}")`
+                        ])
+                    ,
+                    ''
+                )
                 buildTask.group = vscode.TaskGroup.Build
                 buildTask.presentationOptions = { echo: false, focus: false, panel: vscode.TaskPanelKind.Dedicated, clear: true }
                 result.push(buildTask)
             }
 
             if (await fs.exists(path.join(rootPath, 'benchmark', 'benchmarks.jl'))) {
-                const benchmarkTask = new vscode.Task({ type: 'julia', command: 'benchmark' }, folder, `Run benchmark`, 'julia', new vscode.ProcessExecution(jlexepath, ['--color=yes', `--project=${pkgenvpath}`, '-e', 'using PkgBenchmark; benchmarkpkg(Base.ARGS[1], resultfile="benchmark/results.json")', folder.name]), '')
+                const benchmarkTask = new vscode.Task(
+                    {
+                        type: 'julia',
+                        command: 'benchmark'
+                    },
+                    folder,
+                    `Run benchmark`,
+                    'julia',
+                    new vscode.ProcessExecution(
+                        juliaExecutable.file,
+                        [
+                            ...juliaExecutable.args,
+                            '--color=yes',
+                            `--project=${pkgenvpath}`,
+                            '-e',
+                            'using PkgBenchmark; benchmarkpkg(Base.ARGS[1], resultfile="benchmark/results.json")',
+                            folder.name
+                        ]
+                    ),
+                    ''
+                )
                 benchmarkTask.presentationOptions = { echo: false, focus: false, panel: vscode.TaskPanelKind.Dedicated, clear: true }
                 result.push(benchmarkTask)
             }
 
             if (await fs.exists(path.join(rootPath, 'docs', 'make.jl'))) {
                 const buildTask = new vscode.Task(
-                    { type: 'julia', command: 'docbuild' },
+                    {
+                        type: 'julia',
+                        command: 'docbuild'
+                    },
                     folder,
                     `Build documentation`,
                     'julia',
                     new vscode.ProcessExecution(
-                        jlexepath,
+                        juliaExecutable.file,
                         [
+                            ...juliaExecutable.args,
                             `--project=${pkgenvpath}`,
                             '--color=yes',
                             path.join(this.context.extensionPath, 'scripts', 'tasks', 'task_docbuild.jl'),
@@ -129,6 +221,6 @@ class JuliaTaskProvider {
     }
 }
 
-export function activate(context: vscode.ExtensionContext) {
-    vscode.workspace.registerTaskProvider('julia', new JuliaTaskProvider(context))
+export function activate(context: vscode.ExtensionContext, juliaExecutablesFeature: JuliaExecutablesFeature) {
+    vscode.workspace.registerTaskProvider('julia', new JuliaTaskProvider(context, juliaExecutablesFeature))
 }


### PR DESCRIPTION
Fixes #2294. Alternative to #2340.

This got a bit out of control ;) But I think it is now in pretty good shape, hopefully. Couple comments:
- It interprets the config value as a command now, not a path. So things like `julia +1.2`, full paths, just `julia` etc. should all work.
- We no longer try to resolve the path (except for the link stuff) at all. Instead, we now use the command throughout to start everything. We probably need to test every feature that spawns Julia on every platform to be sure it all works... Or have this on insider sufficiently long :)
- Startup should be much faster because we now only run `julia -v` essentially, instead of running actual Julia code.
- Here is my logic for whitespaces in the configuration value: first, I just test if the entire value in the config points to a file. If yes, I take the entire content of the config field as `file` for `execFile`. If that is _not_ the case, I split the config value into args and the first one becomes the `file` part. I think that gets both the case of a value of say `C:\my folder\julia.exe` _and_ the case of `julia +1.2` right. What won't work is `C:\my folder\julia.exe +1.2`, for that case one would have to write `"C:\my folder\julia.exe" +1.2`. I think that makes sense?
- We were up to three different node packages that promisify `child_process`, I consolidated that to one that seemed best.
- I turned the whole Julia executable code into a class in the same way we've done it with other parts of the codebase as well when we made some significant changes, to get rid of global vars etc.

The entire thing is also much in preparation for an upcoming proper integration with `juliaup`, which should make the part where we search for notebook kernels even simpler.