### PR TITLE
Fix some strict typing bugs

### DIFF
--- a/src/debugger/debugFeature.ts
+++ b/src/debugger/debugFeature.ts
@@ -107,7 +107,7 @@ export class JuliaDebugConfigurationProvider implements vscode.DebugConfiguratio
             config.name = 'Launch Julia'
         }
 
-        if (!config.program && config.request !== 'attach') {
+        if (!config.program && config.request !== 'attach' && vscode.window.activeTextEditor) {
             config.program = vscode.window.activeTextEditor.document.fileName
         }
 

--- a/src/debugger/juliaDebug.ts
+++ b/src/debugger/juliaDebug.ts
@@ -268,14 +268,14 @@ export class JuliaDebugSession extends LoggingDebugSession {
         // await this._configurationDone.wait(1000);
         await this._configurationDone.wait()
 
-        this._launchedWithoutDebug = args.noDebug
+        this._launchedWithoutDebug = args.noDebug ?? false
 
         if (args.noDebug) {
             this._connection.sendNotification(notifyTypeRun, { program: args.program })
         }
         else {
             this._connection.sendNotification(notifyTypeDebug, {
-                stopOnEntry: args.stopOnEntry,
+                stopOnEntry: args.stopOnEntry ?? false,
                 program: args.program,
                 compiledModulesOrFunctions: args.compiledModulesOrFunctions,
                 compiledMode: args.compiledMode

--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -427,7 +427,7 @@ function isResultInLineRange(editor: vscode.TextEditor, result: Result, range: v
 // goto frame utilties
 
 export async function openFile(path: string, line: number | undefined = undefined) {
-    const newLine = line ?? 1
+    const newLine = line || 1
     const start = new vscode.Position(newLine - 1, 0)
     const end = new vscode.Position(newLine - 1, 0)
     const range = new vscode.Range(start, end)

--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -207,7 +207,11 @@ export function activate(context: vscode.ExtensionContext) {
         // public commands
         registerCommand('language-julia.clearAllInlineResults', removeAll),
         registerCommand('language-julia.clearAllInlineResultsInEditor', () => removeAll(vscode.window.activeTextEditor)),
-        registerCommand('language-julia.clearCurrentInlineResult', () => removeCurrent(vscode.window.activeTextEditor)),
+        registerCommand('language-julia.clearCurrentInlineResult', () => {
+            if (vscode.window.activeTextEditor) {
+                removeCurrent(vscode.window.activeTextEditor)
+            }
+        }),
 
         // internal commands
         registerCommand('language-julia.openFile', (locationArg: { path: string, line: number }) => {
@@ -422,10 +426,10 @@ function isResultInLineRange(editor: vscode.TextEditor, result: Result, range: v
 
 // goto frame utilties
 
-export async function openFile(path: string, line: number = undefined) {
-    line = line || 1
-    const start = new vscode.Position(line - 1, 0)
-    const end = new vscode.Position(line - 1, 0)
+export async function openFile(path: string, line: number | undefined = undefined) {
+    const newLine = line ?? 1
+    const start = new vscode.Position(newLine - 1, 0)
+    const end = new vscode.Position(newLine - 1, 0)
     const range = new vscode.Range(start, end)
 
     let uri: vscode.Uri

--- a/src/packagedevtools.ts
+++ b/src/packagedevtools.ts
@@ -12,38 +12,41 @@ export class JuliaPackageDevFeature {
     private async tagNewPackageVersion() {
         telemetry.traceEvent('command-tagnewpackageversion')
 
-        let resultVersion = await vscode.window.showQuickPick(['Next', 'Major', 'Minor', 'Patch', 'Custom'], { placeHolder: 'Please select the version to be tagged.' })
+        if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
 
-        if (resultVersion === 'Custom') {
-            resultVersion = await vscode.window.showInputBox({ prompt: 'Please enter the version number you want to tag.' })
-        }
+            let resultVersion = await vscode.window.showQuickPick(['Next', 'Major', 'Minor', 'Patch', 'Custom'], { placeHolder: 'Please select the version to be tagged.' })
 
-        if (resultVersion !== undefined) {
-            const bar = await vscode.authentication.getSession('github', ['repo'], { createIfNone: true })
-            const accessToken = bar.accessToken
-            const account = bar.account.label
+            if (resultVersion === 'Custom') {
+                resultVersion = await vscode.window.showInputBox({ prompt: 'Please enter the version number you want to tag.' })
+            }
 
-            const exepath = await getJuliaExePath()
+            if (resultVersion !== undefined) {
+                const bar = await vscode.authentication.getSession('github', ['repo'], { createIfNone: true })
+                const accessToken = bar.accessToken
+                const account = bar.account.label
 
-            const newTerm = vscode.window.createTerminal(
-                {
-                    name: 'Julia: Tag a new package version',
-                    shellPath: exepath,
-                    shellArgs: [
-                        path.join(this.context.extensionPath, 'scripts', 'packagedev', 'tagnewpackageversion.jl'),
-                        accessToken,
-                        account,
-                        resultVersion
-                    ],
-                    cwd: vscode.workspace.workspaceFolders[0].uri.fsPath,
-                    env: {
-                        JULIA_PROJECT: path.join(this.context.extensionPath, 'scripts', 'environments', 'pkgdev')
-                    },
+                const exepath = await getJuliaExePath()
 
-                }
-            )
+                const newTerm = vscode.window.createTerminal(
+                    {
+                        name: 'Julia: Tag a new package version',
+                        shellPath: exepath,
+                        shellArgs: [
+                            path.join(this.context.extensionPath, 'scripts', 'packagedev', 'tagnewpackageversion.jl'),
+                            accessToken,
+                            account,
+                            resultVersion
+                        ],
+                        cwd: vscode.workspace.workspaceFolders[0].uri.fsPath,
+                        env: {
+                            JULIA_PROJECT: path.join(this.context.extensionPath, 'scripts', 'environments', 'pkgdev')
+                        },
 
-            newTerm.show(true)
+                    }
+                )
+
+                newTerm.show(true)
+            }
         }
     }
 


### PR DESCRIPTION
I'm going to tackle the entire strict typing mode for TypeScript, i.e. try to switch that on. For now this fixes a small number of problems discovered by that mode.

Once the new exe file search PR is merged, I'll try to convert the entire code base over to strict typing.