### PR TITLE
Use normal function syntax for gotoFrame

### DIFF
--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -471,4 +471,6 @@ function findFrameIndex(frame: Frame) {
     })
 }
 
-const gotoFrame = (frame: Frame) => openFile(frame.path, frame.line)
+function gotoFrame(frame: Frame) {
+    return openFile(frame.path, frame.line)
+}


### PR DESCRIPTION
This might help us diagnose a crash reporting issue.