### PR TITLE
Use PATH for LS start

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -211,7 +211,8 @@ async function startLanguageServer(juliaExecutablesFeature: JuliaExecutablesFeat
             JULIA_DEPOT_PATH: languageServerDepotPath,
             JULIA_LOAD_PATH: process.platform === 'win32' ? ';' : ':',
             HOME: process.env.HOME ? process.env.HOME : os.homedir(),
-            JULIA_LANGUAGESERVER: '1'
+            JULIA_LANGUAGESERVER: '1',
+            PATH: process.env.PATH
         }
     }
 


### PR DESCRIPTION
This might fix the other error we got reported on Slack.

The logic here would be that I think at the moment we might try to start the LS without a `PATH` being set at all. I don't fully understand why anything would have ever worked if that is the case, though...

Again, I can't test this right now because my juliaup is broken and I need to fix that first...