### PR TITLE
Use a hack to fix a tasks problem with juliaup

### DIFF
--- a/src/juliaexepath.ts
+++ b/src/juliaexepath.ts
@@ -12,6 +12,7 @@ import { resolvePath } from './utils'
 
 export class JuliaExecutable {
     private _baseRootFolderPath: string | undefined
+    private _fullPath: string | undefined
 
     constructor(public version: string, public file: string, public args: string[], public arch: string | undefined, public channel: string | undefined, public officialChannel: boolean) {
     }
@@ -37,6 +38,27 @@ export class JuliaExecutable {
         }
 
         return this._baseRootFolderPath
+    }
+
+    // TODO This is a faulyt implementation because it won't work when the config value is not
+    // just a simple file path like thing, in particular it won't work with any combined commands
+    public async getFAULTYFullPathAsync() {
+        if (!this._fullPath) {
+            const result = await execFile(
+                this.file,
+                [
+                    ...this.args,
+                    '--startup-file=no',
+                    '--history-file=no',
+                    '-e',
+                    'println(Sys.BINDIR)'
+                ]
+            )
+
+            this._fullPath = path.normalize(path.join(result.stdout.toString().trim(), process.platform === 'win32' ? 'julia.exe' : 'julia'))
+        }
+
+        return this._fullPath
     }
 
     public getCommand() {

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -38,6 +38,7 @@ class JuliaTaskProvider {
             const result: vscode.Task[] = []
 
             const juliaExecutable = await this.juliaExecutablesFeature.getActiveJuliaExecutableAsync()
+            const fullPath = await juliaExecutable.getFAULTYFullPathAsync()
             const pkgenvpath = await jlpkgenv.getAbsEnvPath()
 
             if (await fs.exists(path.join(rootPath, 'test', 'runtests.jl'))) {
@@ -50,9 +51,8 @@ class JuliaTaskProvider {
                     `Run tests`,
                     'julia',
                     new vscode.ProcessExecution(
-                        juliaExecutable.file,
+                        fullPath,
                         [
-                            ...juliaExecutable.args,
                             '--color=yes',
                             `--project=${pkgenvpath}`,
                             '-e',
@@ -77,9 +77,8 @@ class JuliaTaskProvider {
                     `Run tests with coverage`,
                     'julia',
                     new vscode.ProcessExecution(
-                        juliaExecutable.file,
+                        fullPath,
                         [
-                            ...juliaExecutable.args,
                             '--color=yes',
                             `--project=${pkgenvpath}`,
                             path.join(this.context.extensionPath, 'scripts', 'tasks', 'task_test.jl'),
@@ -112,9 +111,8 @@ class JuliaTaskProvider {
                 `Build custom sysimage for current environment (experimental)`,
                 'julia',
                 new vscode.ProcessExecution(
-                    juliaExecutable.file,
+                    fullPath,
                     [
-                        ...juliaExecutable.args,
                         '--color=yes',
                         `--project=${path.join(this.context.extensionPath, 'scripts', 'environments', 'sysimagecompile')}`,
                         '--startup-file=no',
@@ -139,9 +137,8 @@ class JuliaTaskProvider {
                     `Run build`,
                     'julia',
                     new vscode.ProcessExecution(
-                        juliaExecutable.file,
+                        fullPath,
                         [
-                            ...juliaExecutable.args,
                             '--color=yes',
                             `--project=${pkgenvpath}`,
                             '-e',
@@ -165,9 +162,8 @@ class JuliaTaskProvider {
                     `Run benchmark`,
                     'julia',
                     new vscode.ProcessExecution(
-                        juliaExecutable.file,
+                        fullPath,
                         [
-                            ...juliaExecutable.args,
                             '--color=yes',
                             `--project=${pkgenvpath}`,
                             '-e',
@@ -191,9 +187,8 @@ class JuliaTaskProvider {
                     `Build documentation`,
                     'julia',
                     new vscode.ProcessExecution(
-                        juliaExecutable.file,
+                        fullPath,
                         [
-                            ...juliaExecutable.args,
                             `--project=${pkgenvpath}`,
                             '--color=yes',
                             path.join(this.context.extensionPath, 'scripts', 'tasks', 'task_docbuild.jl'),


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/juliaup/issues/125.

This is a short term hack and I'll try to find a better way to solve this. The problem is this: in general, it seems, that tasks in VS Code don't work with anything that is MSIX installed on Windows and has an execution alias. I tested for example `winget`, and trying to run that also doesn't work. So this is almost certainly an upstream bug in VS Code itself. For now this hack works around that. It breaks the scenario where our config setting is something like `julia +1.2`, i.e. where the config setting is not just pointing to one executable, but rather a combined command. But given that we didn't support that in the past and didn't announce yet that we (thought)  supported that now, I think this hack is OK for now.