### PR TITLE
Save notebook metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1048,12 +1048,6 @@
                     ],
                     "description": "Functions or modules that are set to compiled mode when setting the defaults.",
                     "scope": "window"
-                },
-                "julia.notebookController": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Enable the experimental native Jupyter notebook integration.",
-                    "scope": "application"
                 }
             }
         },

--- a/src/notebook/notebookFeature.ts
+++ b/src/notebook/notebookFeature.ts
@@ -32,12 +32,10 @@ export class JuliaNotebookFeature {
 
     constructor(private context: vscode.ExtensionContext, private juliaExecutableFeature: JuliaExecutablesFeature, private workspaceFeature: WorkspaceFeature) {
         const section = vscode.workspace.getConfiguration('julia')
-        const enabled = section ? section.get<boolean>('notebookController', false) : false
-        if (enabled) {
-            this.init()
 
-            vscode.workspace.onDidOpenNotebookDocument(this.onDidOpenNotebookDocument, this, this.disposables)
-        }
+        this.init()
+
+        vscode.workspace.onDidOpenNotebookDocument(this.onDidOpenNotebookDocument, this, this.disposables)
     }
 
     private async init() {

--- a/src/notebook/notebookFeature.ts
+++ b/src/notebook/notebookFeature.ts
@@ -214,7 +214,10 @@ export class JuliaNotebookFeature {
             mimetype: 'application/julia',
             file_extension: '.jl'
         }
-        // TODO: Update the notebook metadata (when its stable).
+
+        const edit = new vscode.WorkspaceEdit()
+        edit.replaceNotebookMetadata(notebook.uri, nbmetadata)
+        vscode.workspace.applyEdit(edit)
     }
 
     private isJuliaNotebook(notebook: vscode.NotebookDocument) {


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/2256.

Uses an API that will only ship in the next VS Code release, so has to wait until then.