### PR TITLE
Fix arg passing to Julia

### DIFF
--- a/src/jlpkgenv.ts
+++ b/src/jlpkgenv.ts
@@ -71,8 +71,9 @@ export async function switchEnvToPath(envpath: string, notifyLS: boolean) {
                 `--project=${g_resolved_path_of_environment}`,
                 '--startup-file=no',
                 '--history-file=no',
-                '-e "using Pkg; println(in(ARGS[1], VERSION>=VersionNumber(1,1,0) ? realpath.(filter(i->i!==nothing && isdir(i), getproperty.(values(Pkg.Types.Context().env.manifest), :path))) : realpath.(filter(i->i!=nothing && isdir(i), map(i->get(i[1], string(:path), nothing), values(Pkg.Types.Context().env.manifest)))) ))"',
-                `"${case_adjusted}"`
+                '-e',
+                'using Pkg; println(in(ARGS[1], VERSION>=VersionNumber(1,1,0) ? realpath.(filter(i->i!==nothing && isdir(i), getproperty.(values(Pkg.Types.Context().env.manifest), :path))) : realpath.(filter(i->i!=nothing && isdir(i), map(i->get(i[1], string(:path), nothing), values(Pkg.Types.Context().env.manifest)))) ))',
+                `${case_adjusted}`
             ]
         )
 

--- a/src/juliaexepath.ts
+++ b/src/juliaexepath.ts
@@ -30,7 +30,7 @@ export class JuliaExecutable {
                     '--startup-file=no',
                     '--history-file=no',
                     '-e',
-                    '"println(Sys.BINDIR)"'
+                    'println(Sys.BINDIR)'
                 ]
             )
 

--- a/src/packagepath.ts
+++ b/src/packagepath.ts
@@ -19,7 +19,8 @@ export async function getPkgPath() {
             [
                 '--startup-file=no',
                 '--history-file=no',
-                '-e "using Pkg;println(Pkg.depots()[1])"'
+                '-e',
+                'using Pkg; println(Pkg.depots()[1])'
             ]
         )
         juliaPackagePath = join(res.stdout.toString().trim(), 'dev')
@@ -35,7 +36,8 @@ export async function getPkgDepotPath() {
             [
                 '--startup-file=no',
                 '--history-file=no',
-                '-e "using Pkg; println.(Pkg.depots())"'
+                '-e',
+                'using Pkg; println.(Pkg.depots())'
             ]
         )
         juliaDepotPath = res.stdout.toString().trim().split('\n')


### PR DESCRIPTION
This continues the work started in https://github.com/julia-vscode/julia-vscode/pull/2372.

At least on my system things are _really_ broken without that. I don't understand why that is coming up now... Maybe it has something to do with `juliaup` and that that requires properly escaped arguments, not sure... In any case, the theory here is that `execFile` handles all subtleties of quoting and escaping for us. I hope that is right :)