### PR TITLE
print eval errors to stdout instead of stderr

### DIFF
--- a/scripts/packages/VSCodeServer/src/eval.jl
+++ b/scripts/packages/VSCodeServer/src/eval.jl
@@ -163,15 +163,15 @@ function repl_runcode_request(conn, params::ReplRunCodeRequestParams)
                 end
 
                 if show_error && res isa EvalError || res isa EvalErrorStack
-                    Base.display_error(stderr, res)
+                    Base.display_error(stdout, res)
                 elseif show_result
                     if res isa EvalError || res isa EvalErrorStack
-                        Base.display_error(stderr, res)
+                        Base.display_error(stdout, res)
                     elseif res !== nothing && !ends_with_semicolon(source_code)
                         try
                             Base.invokelatest(display, res)
                         catch err
-                            Base.display_error(stderr, err, catch_backtrace())
+                            Base.display_error(stdout, err, catch_backtrace())
                         end
                     end
                 else
@@ -179,8 +179,8 @@ function repl_runcode_request(conn, params::ReplRunCodeRequestParams)
                         Base.invokelatest(display, InlineDisplay(), res)
                     catch err
                         if !(err isa MethodError)
-                            printstyled(stderr, "Display Error: ", color = Base.error_color(), bold = true)
-                            Base.display_error(stderr, err, catch_backtrace())
+                            printstyled(stdout, "Display Error: ", color = Base.error_color(), bold = true)
+                            Base.display_error(stdout, err, catch_backtrace())
                         end
                     end
                 end

--- a/scripts/packages/VSCodeServer/src/repl.jl
+++ b/scripts/packages/VSCodeServer/src/repl.jl
@@ -124,17 +124,17 @@ function evalrepl(m, line, repl, main_mode)
             PROGRESS_ENABLED[] ? Logging.with_logger(f, VSCodeLogger()) : f()
         end
         if r isa EvalError
-            display_repl_error(stderr, r.err, r.bt)
+            display_repl_error(stdout, r.err, r.bt)
             nothing
         elseif r isa EvalErrorStack
-            display_repl_error(stderr, r)
+            display_repl_error(stdout, r)
             nothing
         else
             r
         end
     catch err
         # This is for internal errors only.
-        Base.display_error(stderr, err, catch_backtrace())
+        Base.display_error(stdout, err, catch_backtrace())
         nothing
     finally
         if did_notify


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/2392.

I'm not 100% this is more correct though.