### PR TITLE
Remove Azure pipeline badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Julia
 
-[![Build Status](https://dev.azure.com/julia-vscode/julia-vscode/_apis/build/status/julia-vscode.julia-vscode?branchName=master)](https://dev.azure.com/julia-vscode/julia-vscode/_build/latest?definitionId=1&branchName=master)
-
 This [VS Code](https://code.visualstudio.com) extension provides support for the [Julia programming language](http://julialang.org/).
 
 ## Getting started


### PR DESCRIPTION
It does not appear this badge is setup to work with anything so we should remove it or update the link it points to.
