### PR TITLE
Limit supported schemes for LS

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -181,6 +181,17 @@ function changeConfig(event: vscode.ConfigurationChangeEvent) {
     }
 }
 
+const supportedSchemes = [
+    'file',
+    'untitled',
+    'vscode-notebook-cell'
+]
+
+const supportedLanguages = [
+    'julia',
+    'juliamarkdown'
+]
+
 async function startLanguageServer(juliaExecutablesFeature: JuliaExecutablesFeature) {
     g_startupNotification.text = 'Starting Julia Language Server…'
     g_startupNotification.show()
@@ -232,8 +243,19 @@ async function startLanguageServer(juliaExecutablesFeature: JuliaExecutablesFeat
             debug: { command: juliaExecutable.file, args: [...juliaExecutable.args, ...serverArgsDebug], options: spawnOptions }
         }
 
+    const selector = []
+    for (const scheme of supportedSchemes) {
+        for (const language of supportedLanguages) {
+            selector.push({
+                language,
+                scheme
+            })
+        }
+    }
+
+
     const clientOptions: LanguageClientOptions = {
-        documentSelector: ['julia', 'juliamarkdown'],
+        documentSelector: selector,
         synchronize: {
             fileEvents: vscode.workspace.createFileSystemWatcher('**/*.{jl,jmd}')
         },


### PR DESCRIPTION
Basically an updated version of https://github.com/julia-vscode/julia-vscode/pull/485/.

This uses the same schemes the TS extension supports: 
https://github.com/microsoft/vscode/blob/94c9ea46838a9a619aeafb7e8afd1170c967bb55/extensions/typescript-language-features/src/utils/fileSchemes.ts#L14-L19