### PR TITLE
Use tokens for timeout in dynamic completions

### DIFF
--- a/src/canceltokenutils.ts
+++ b/src/canceltokenutils.ts
@@ -1,0 +1,17 @@
+import { CancellationToken, CancellationTokenSource } from 'vscode-jsonrpc'
+
+export function createTimeoutCancellation(millis: number): CancellationToken {
+    const source = new CancellationTokenSource()
+    setTimeout(() => source.cancel(), millis)
+    return source.token
+}
+
+export function combineCancellationTokens(a: CancellationToken, b: CancellationToken): CancellationToken {
+    if (a.isCancellationRequested || b.isCancellationRequested) {
+        return CancellationToken.Cancelled
+    }
+    const source = new CancellationTokenSource()
+    a.onCancellationRequested(() => source.cancel())
+    b.onCancellationRequested(() => source.cancel())
+    return source.token
+}

--- a/src/interactive/completions.ts
+++ b/src/interactive/completions.ts
@@ -3,6 +3,7 @@
 import * as vscode from 'vscode'
 import * as rpc from 'vscode-jsonrpc'
 import { Disposable, MessageConnection } from 'vscode-jsonrpc'
+import { combineCancellationTokens, createTimeoutCancellation } from '../canceltokenutils'
 import { getModuleForEditor } from './modules'
 import { onExit, onInit } from './repl'
 
@@ -36,42 +37,34 @@ const requestTypeGetCompletionItems = new rpc.RequestType<
     void
     >('repl/getcompletions')
 
+
 function completionItemProvider(conn: MessageConnection): vscode.CompletionItemProvider {
     return {
         provideCompletionItems: async (document, position, token, context) => {
             if (!vscode.workspace.getConfiguration('julia.runtimeCompletions')) {
                 return
             }
-            const completionPromise = (async () => {
-                const startPosition = new vscode.Position(position.line, 0)
-                const lineRange = new vscode.Range(startPosition, position)
-                const line = document.getText(lineRange)
-                const mod: string = await getModuleForEditor(document, position)
-                return {
-                    items: await conn.sendRequest(requestTypeGetCompletionItems, { line, mod }),
-                    isIncomplete: true
-                }
-            })()
 
-            const cancelPromise: Promise<vscode.CompletionList> = new Promise(resolve => {
-                token.onCancellationRequested(() => resolve({
-                    items: [],
-                    isIncomplete: true
-                }))
-                setTimeout(() => {
-                    if (!token.isCancellationRequested) {
-                        resolve({
-                            items: [],
-                            isIncomplete: true
-                        })
-                    }
-                }, 500)
-            })
+            const newToken = combineCancellationTokens(
+                token,
+                createTimeoutCancellation(500)
+            )
 
-            return Promise.race([
-                completionPromise,
-                cancelPromise
-            ])
+            const startPosition = new vscode.Position(position.line, 0)
+            const lineRange = new vscode.Range(startPosition, position)
+            const line = document.getText(lineRange)
+            const mod: string = await getModuleForEditor(document, position) // TODO pass newToken once we support tokens in JSONRPC.jl
+
+            if (newToken.isCancellationRequested) { return }
+
+            const items = await conn.sendRequest(requestTypeGetCompletionItems, { line, mod }) // TODO pass newToken once we support tokens in JSONRPC.jl
+
+            if (newToken.isCancellationRequested) { return }
+
+            return {
+                items: items,
+                isIncomplete: true
+            }
         }
     }
 }


### PR DESCRIPTION
This rewrites the timeout functionality in terms of cancel tokens, which I think is a) more in line with the general VS Code patterns and b) will allow us to cancel even more aggressively once we support cancel tokens across the JSONRPC boundary.

The code for the two functions is copied from https://github.com/microsoft/vscode/blob/be7046f09199da197a2b566f90f51f7e2653fed7/src/vs/platform/remote/common/remoteAgentConnection.ts#L89, I don't fully understand why that isn't just part of the json-rpc npm package, but whatever :)

The one thing that is not entirely clear to me is whether we should just call `return` if cancelled, or return an empty result? The old code seemed to do both things.