### PR TITLE
focus existing REPL in startREPLCommand

### DIFF
--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -34,7 +34,7 @@ let g_juliaExecutablesFeature: JuliaExecutablesFeature
 function startREPLCommand() {
     telemetry.traceEvent('command-startrepl')
 
-    startREPL(false)
+    startREPL(false, true)
 }
 
 function is_remote_env(): boolean {
@@ -63,6 +63,9 @@ function isConnected() {
 
 async function startREPL(preserveFocus: boolean, showTerminal: boolean = true) {
     if (isConnected()) {
+        if (g_terminal && showTerminal) {
+            g_terminal.show(preserveFocus)
+        }
         return
     }
 


### PR DESCRIPTION
This ensure that we focus an already existing REPL when the `Start REPL` command is used.

Fixes https://github.com/julia-vscode/julia-vscode/issues/2436
