### PR TITLE
Correct indentation when `end` appears within iterator definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Julia paths are now properly deduplicated ([#2428](https://github.com/julia-vscode/julia-vscode/pull/2428))
 * The extension is now activated when Julia specific toolbar items are shown ([#2430](https://github.com/julia-vscode/julia-vscode/pull/2430))
 * The play button to run the current file now uses the editor content instead of the file content ([#2431](https://github.com/julia-vscode/julia-vscode/pull/2431))
+* Indentation will behave correctly when the `end` keyword has non-whitespace characters after it, e.g. `for i in nums[2:end]` ([#2149](https://github.com/julia-vscode/julia-vscode/issues/2149))
 
 ## [1.3.34] - 2021-09-03
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Julia paths are now properly deduplicated ([#2428](https://github.com/julia-vscode/julia-vscode/pull/2428))
 * The extension is now activated when Julia specific toolbar items are shown ([#2430](https://github.com/julia-vscode/julia-vscode/pull/2430))
 * The play button to run the current file now uses the editor content instead of the file content ([#2431](https://github.com/julia-vscode/julia-vscode/pull/2431))
-* Indentation will behave correctly when the `end` keyword has non-whitespace characters after it, e.g. `for i in nums[2:end]` ([#2149](https://github.com/julia-vscode/julia-vscode/issues/2149))
+* Indentation will behave correctly when `end` appears in a for loop definition, e.g. `for i in nums[2:end]` ([#2459](https://github.com/julia-vscode/julia-vscode/pull/2459))
 
 ## [1.3.34] - 2021-09-03
 ### Changed

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,7 +56,7 @@ export async function activate(context: vscode.ExtensionContext) {
         // Language settings
         vscode.languages.setLanguageConfiguration('julia', {
             indentationRules: {
-                increaseIndentPattern: /^(\s*|.*=\s*|.*@\w*\s*)[\w\s]*(?:["'`][^"'`]*["'`])*[\w\s]*\b(if|while|for|function|macro|(mutable\s+)?struct|abstract\s+type|primitive\s+type|let|quote|try|begin|.*\)\s*do|else|elseif|catch|finally)\b(?!(?:.*\bend\b\s*$)|(?:[^\[]*\].*)$).*$/,
+                increaseIndentPattern: /^(\s*|.*=\s*|.*@\w*\s*)[\w\s]*(?:["'`][^"'`]*["'`])*[\w\s]*\b(if|while|for|function|macro|(mutable\s+)?struct|abstract\s+type|primitive\s+type|let|quote|try|begin|.*\)\s*do|else|elseif|catch|finally)\b(?!(?:.*\bend\b(\s*|\s*#.*)$)|(?:[^\[]*\].*)$).*$/,
                 decreaseIndentPattern: /^\s*(end|else|elseif|catch|finally)\b.*$/
             }
         })

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,9 @@ let g_watchedEnvironmentFile: string = null
 let g_startupNotification: vscode.StatusBarItem = null
 let g_juliaExecutablesFeature: JuliaExecutablesFeature = null
 
+export let increaseIndentPattern: RegExp = /^(\s*|.*=\s*|.*@\w*\s*)[\w\s]*(?:["'`][^"'`]*["'`])*[\w\s]*\b(if|while|for|function|macro|(mutable\s+)?struct|abstract\s+type|primitive\s+type|let|quote|try|begin|.*\)\s*do|else|elseif|catch|finally)\b(?!(?:.*\bend\b(\s*|\s*#.*)$)|(?:[^\[]*\].*)$).*$/
+export let decreaseIndentPattern: RegExp = /^\s*(end|else|elseif|catch|finally)\b.*$/
+
 export async function activate(context: vscode.ExtensionContext) {
     if (vscode.extensions.getExtension('julialang.language-julia') && vscode.extensions.getExtension('julialang.language-julia-insider')) {
         vscode.window.showErrorMessage('You have both the Julia Insider and regular Julia extension installed at the same time, which is not supported. Please uninstall or disable one of the two extensions.')
@@ -56,8 +59,8 @@ export async function activate(context: vscode.ExtensionContext) {
         // Language settings
         vscode.languages.setLanguageConfiguration('julia', {
             indentationRules: {
-                increaseIndentPattern: /^(\s*|.*=\s*|.*@\w*\s*)[\w\s]*(?:["'`][^"'`]*["'`])*[\w\s]*\b(if|while|for|function|macro|(mutable\s+)?struct|abstract\s+type|primitive\s+type|let|quote|try|begin|.*\)\s*do|else|elseif|catch|finally)\b(?!(?:.*\bend\b(\s*|\s*#.*)$)|(?:[^\[]*\].*)$).*$/,
-                decreaseIndentPattern: /^\s*(end|else|elseif|catch|finally)\b.*$/
+                increaseIndentPattern: increaseIndentPattern,
+                decreaseIndentPattern: decreaseIndentPattern
             }
         })
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,8 +56,8 @@ export async function activate(context: vscode.ExtensionContext) {
         // Language settings
         vscode.languages.setLanguageConfiguration('julia', {
             indentationRules: {
-                increaseIndentPattern: /^(\s*|.*=\s*|.*@\w*\s*)[\w\s]*(?:["'`][^"'`]*["'`])*[\w\s]*\b(if|while|for|function|macro|(mutable\s+)?struct|abstract\s+type|primitive\s+type|let|quote|try|begin|.*\)\s*do|else|elseif|catch|finally)\b(?!(?:.*\bend\b[^\]]*)|(?:[^\[]*\].*)$).*$/,
-                decreaseIndentPattern: /^\s*(elseif\b.*|(end|else|catch|finally)\s*)$/
+                increaseIndentPattern: /^(\s*|.*=\s*|.*@\w*\s*)[\w\s]*(?:["'`][^"'`]*["'`])*[\w\s]*\b(if|while|for|function|macro|(mutable\s+)?struct|abstract\s+type|primitive\s+type|let|quote|try|begin|.*\)\s*do|else|elseif|catch|finally)\b(?!(?:.*\bend\b\s*$)|(?:[^\[]*\].*)$).*$/,
+                decreaseIndentPattern: /^\s*(end|else|elseif|catch|finally)\b.*$/
             }
         })
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,7 +57,7 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.languages.setLanguageConfiguration('julia', {
             indentationRules: {
                 increaseIndentPattern: /^(\s*|.*=\s*|.*@\w*\s*)[\w\s]*(?:["'`][^"'`]*["'`])*[\w\s]*\b(if|while|for|function|macro|(mutable\s+)?struct|abstract\s+type|primitive\s+type|let|quote|try|begin|.*\)\s*do|else|elseif|catch|finally)\b(?!(?:.*\bend\b[^\]]*)|(?:[^\[]*\].*)$).*$/,
-                decreaseIndentPattern: /^\s*(end|else|elseif|catch|finally)\b.*$/
+                decreaseIndentPattern: /^\s*(elseif\b.*|(end|else|catch|finally)\s*)$/
             }
         })
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -12,6 +12,7 @@ suite('Indentation', () => {
         assert.strictEqual(ext.increaseIndentPattern.test("for i = 1:5"), true)
         assert.strictEqual(ext.increaseIndentPattern.test("  for i = 1:5"), true)
         assert.strictEqual(ext.increaseIndentPattern.test("for i = 1:inds[end]"), true)
+        assert.strictEqual(ext.increaseIndentPattern.test("for i in inds[2:end]"), true)
         assert.strictEqual(ext.increaseIndentPattern.test("for i = 1:inds[end ]"), true)
         assert.strictEqual(ext.increaseIndentPattern.test("for i = 1:inds[end] "), true)
         assert.strictEqual(ext.increaseIndentPattern.test("for i = 1:inds[end]  # comment"), true)
@@ -19,6 +20,7 @@ suite('Indentation', () => {
         // Should not indent next line
         assert.strictEqual(ext.increaseIndentPattern.test("for i = 1:5; end"), false)
         assert.strictEqual(ext.increaseIndentPattern.test("for i = 1:inds[end]; end"), false)
+        assert.strictEqual(ext.increaseIndentPattern.test("for i in inds[2:end]; end"), false)
         assert.strictEqual(ext.increaseIndentPattern.test("for i = 1:5; end "), false)
         assert.strictEqual(ext.increaseIndentPattern.test("for i = 1:5; end  # comment"), false)
         assert.strictEqual(ext.increaseIndentPattern.test("  for i = 1:5; end  # comment"), false)

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,18 +1,30 @@
-import * as assert from 'assert'
-import { after } from 'mocha'
-// You can import and use all API from the 'vscode' module
-// as well as import your extension to test it
-import * as vscode from 'vscode'
+import * as assert from 'assert';
+import * as ext from '../../extension';
 
-// import * as myExtension from '../extension';
 
-suite('Extension Test Suite', () => {
-    after(() => {
-        vscode.window.showInformationMessage('All tests done!')
+suite('Indentation', () => {
+    test('functions', () => {
+        assert.strictEqual(ext.increaseIndentPattern.test("function f()"), true)
     })
 
-    test('Sample test', () => {
-        assert.equal(-1, [1, 2, 3].indexOf(5))
-        assert.equal(-1, [1, 2, 3].indexOf(0))
+    test('for loops', () => {
+        // Should indent next line
+        assert.strictEqual(ext.increaseIndentPattern.test("for i = 1:5"), true)
+        assert.strictEqual(ext.increaseIndentPattern.test("  for i = 1:5"), true)
+        assert.strictEqual(ext.increaseIndentPattern.test("for i = 1:inds[end]"), true)
+        assert.strictEqual(ext.increaseIndentPattern.test("for i = 1:inds[end ]"), true)
+        assert.strictEqual(ext.increaseIndentPattern.test("for i = 1:inds[end] "), true)
+        assert.strictEqual(ext.increaseIndentPattern.test("for i = 1:inds[end]  # comment"), true)
+
+        // Should not indent next line
+        assert.strictEqual(ext.increaseIndentPattern.test("for i = 1:5; end"), false)
+        assert.strictEqual(ext.increaseIndentPattern.test("for i = 1:inds[end]; end"), false)
+        assert.strictEqual(ext.increaseIndentPattern.test("for i = 1:5; end "), false)
+        assert.strictEqual(ext.increaseIndentPattern.test("for i = 1:5; end  # comment"), false)
+        assert.strictEqual(ext.increaseIndentPattern.test("  for i = 1:5; end  # comment"), false)
+    })
+
+    test('end', () => {
+        assert.strictEqual(ext.decreaseIndentPattern.test("    end"), true)
     })
 })


### PR DESCRIPTION
Fixes #2149.

I just started learning Julia, so please correct me if I've misunderstood something.

This updates the indent regex so that indentation is triggered when `end` appears in the for loop as an index:

```julia
for i in nums[2:end]  # next line should be indented
```

The old regex seemed to be trying to look for closing brackets as an indicator. I think that wasn't working because it was actually doing a double negative when it only wanted one? I'm not really sure. I just removed that part and replaced it so that an indent will only not be triggered when `end` is followed by whitespace only (or no characters).

You can play with the new regex here: https://regex101.com/r/oAUCTC/1