### PR TITLE
Various fixes for cell and inline evaluation

### DIFF
--- a/package.json
+++ b/package.json
@@ -569,12 +569,12 @@
             {
                 "command": "language-julia.executeJuliaCodeInREPL",
                 "key": "ctrl+Enter",
-                "when": "editorTextFocus && editorLangId == julia && activeEditor != workbench.editor.notebook"
+                "when": "editorTextFocus && editorLangId == julia || editorLangId == juliamarkdown && activeEditor != workbench.editor.notebook"
             },
             {
                 "command": "language-julia.executeCodeBlockOrSelectionAndMove",
                 "key": "alt+Enter",
-                "when": "editorTextFocus && editorLangId == julia"
+                "when": "editorTextFocus && editorLangId == julia || editorLangId == juliamarkdown"
             },
             {
                 "command": "language-julia.interrupt",
@@ -584,7 +584,7 @@
             {
                 "command": "language-julia.executeCellAndMove",
                 "key": "shift+Enter",
-                "when": "editorTextFocus && editorLangId == julia && activeEditor != workbench.editor.notebook"
+                "when": "editorTextFocus && editorLangId == julia || editorLangId == juliamarkdown && activeEditor != workbench.editor.notebook"
             },
             {
                 "command": "language-julia.clearCurrentInlineResult",
@@ -594,12 +594,12 @@
             {
                 "command": "language-julia.clearAllInlineResultsInEditor",
                 "key": "ctrl+I ctrl+C",
-                "when": "editorTextFocus && editorLangId == julia"
+                "when": "editorTextFocus && editorLangId == julia || editorLangId == juliamarkdown"
             },
             {
                 "command": "language-julia.chooseModule",
                 "key": "Alt+J Alt+M",
-                "when": "editorTextFocus && editorLangId == julia"
+                "when": "editorTextFocus && editorLangId == julia || editorLangId == juliamarkdown"
             },
             {
                 "command": "language-julia.startREPL",
@@ -612,17 +612,12 @@
             {
                 "command": "language-julia.changeCurrentEnvironment",
                 "key": "Alt+J Alt+E",
-                "when": "editorTextFocus && editorLangId == julia"
-            },
-            {
-                "command": "language-julia.executeJuliaCodeInREPL",
-                "key": "ctrl+Enter",
-                "when": "editorTextFocus && editorLangId == juliamarkdown"
+                "when": "editorTextFocus && editorLangId == julia || editorLangId == juliamarkdown"
             },
             {
                 "command": "language-julia.show-documentation",
                 "key": "alt+J alt+D",
-                "when": "editorTextFocus && editorLangId == julia"
+                "when": "editorTextFocus && editorLangId == julia || editorLangId == juliamarkdown"
             },
             {
                 "command": "language-julia.browse-back-documentation",

--- a/scripts/packages/VSCodeServer/src/misc.jl
+++ b/scripts/packages/VSCodeServer/src/misc.jl
@@ -108,7 +108,10 @@ function remove_ansi_control_chars(str::String)
 end
 
 function ends_with_semicolon(x)
-    return REPL.ends_with_semicolon(split(x, '\n', keepempty=false)[end])
+    lines = split(x, '\n', keepempty=false)
+    return length(lines) > 0 ?
+        REPL.ends_with_semicolon(last(lines)) :
+        false
 end
 
 const splitlines = Base.Fix2(split, '\n')

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -559,23 +559,30 @@ const g_cellDelimiters = [
     /^#(\s?)%%/
 ]
 
-function isCellBorder(s: string) {
+function isCellBorder(s: string, isStart: boolean, isJmd: boolean) {
+    if (isJmd) {
+        if (isStart) {
+            return /^```julia/.test(s)
+        } else {
+            return /^```(?!\w)/.test(s)
+        }
+    }
     return g_cellDelimiters.some(regex => regex.test(s))
 }
 
-function _nextCellBorder(doc, line_num: number, direction: number) {
+function _nextCellBorder(doc, line: number, direction: number, isStart: boolean, isJmd: boolean) {
     assert(direction === 1 || direction === -1)
-    while (0 <= line_num && line_num < doc.lineCount) {
-        if (isCellBorder(doc.lineAt(line_num).text)) {
+    while (0 <= line && line < doc.lineCount) {
+        if (isCellBorder(doc.lineAt(line).text, isStart, isJmd)) {
             break
         }
-        line_num += direction
+        line += direction
     }
-    return line_num
+    return line
 }
 
-const nextCellBorder = (doc, line_num) => _nextCellBorder(doc, line_num, +1)
-const prevCellBorder = (doc, line_num) => _nextCellBorder(doc, line_num, -1)
+const nextCellBorder = (doc, line, isStart, isJmd) => _nextCellBorder(doc, line, +1, isStart, isJmd)
+const prevCellBorder = (doc, line, isStart, isJmd) => _nextCellBorder(doc, line, -1, isStart, isJmd)
 
 function validateMoveAndReveal(editor: vscode.TextEditor, startpos: vscode.Position, endpos: vscode.Position) {
     const doc = editor.document
@@ -591,8 +598,9 @@ async function moveCellDown() {
     if (ed === undefined) {
         return
     }
+    const isJmd = ed.document.languageId === 'juliamarkdown'
     const currline = ed.selection.active.line
-    const newpos = new vscode.Position(nextCellBorder(ed.document, currline + 1) + 1, 0)
+    const newpos = new vscode.Position(nextCellBorder(ed.document, currline + 1, true, isJmd) + 1, 0)
     validateMoveAndReveal(ed, newpos, newpos)
 }
 
@@ -602,16 +610,37 @@ async function moveCellUp() {
     if (ed === undefined) {
         return
     }
+    const isJmd = ed.document.languageId === 'juliamarkdown'
     const currline = ed.selection.active.line
-    const newpos = new vscode.Position(Math.max(0, prevCellBorder(ed.document, currline) - 1), 0)
+
+    let newpos: vscode.Position
+    if (isJmd) {
+        const prevEnd = Math.max(0, prevCellBorder(ed.document, currline, false, isJmd))
+        const prevStart = Math.max(0, prevCellBorder(ed.document, currline, true, isJmd))
+
+        if (prevEnd <= prevStart) {
+            newpos = new vscode.Position(Math.max(0, prevCellBorder(ed.document, prevStart - 1, true, isJmd) + 1), 0)
+        } else {
+            newpos = new vscode.Position(prevStart + 1, 0)
+        }
+    } else {
+        newpos = new vscode.Position(Math.max(0, prevCellBorder(ed.document, currline, true, isJmd) - 1), 0)
+    }
     validateMoveAndReveal(ed, newpos, newpos)
 }
 
 function currentCellRange(editor: vscode.TextEditor) {
     const doc = editor.document
     const currline = editor.selection.active.line
-    const startline = prevCellBorder(doc, currline) + 1
-    const endline = nextCellBorder(doc, currline + 1) - 1
+    const isJmd = doc.languageId === 'juliamarkdown'
+    const startline = prevCellBorder(doc, currline, true, isJmd) + 1
+    if (isJmd && startline === 0) {
+        return null
+    }
+    const endline = nextCellBorder(doc, startline + 1, false, isJmd) - 1
+    if (startline > currline || endline < currline) {
+        return null
+    }
     const startpos = doc.validatePosition(new vscode.Position(startline, 0))
     const endpos = doc.validatePosition(new vscode.Position(endline, doc.lineAt(endline).text.length))
     return new vscode.Range(startpos, endpos)
@@ -628,6 +657,9 @@ async function executeCell(shouldMove: boolean = false) {
     const doc = ed.document
     const selection = ed.selection
     const cellrange = currentCellRange(ed)
+    if (cellrange === null) {
+        return
+    }
     const code = doc.getText(cellrange)
 
     const module: string = await modules.getModuleForEditor(ed.document, cellrange.start)
@@ -635,7 +667,8 @@ async function executeCell(shouldMove: boolean = false) {
     await startREPL(true, false)
 
     if (shouldMove && ed.selection === selection) {
-        const nextpos = new vscode.Position(cellrange.end.line + 2, 0)
+        const isJmd = doc.languageId === 'juliamarkdown'
+        const nextpos = new vscode.Position(nextCellBorder(doc, cellrange.end.line + 1, true, isJmd) + 1, 0)
         validateMoveAndReveal(ed, nextpos, nextpos)
     }
 
@@ -706,28 +739,35 @@ async function evaluate(editor: vscode.TextEditor, range: vscode.Range, text: st
     if (resultType !== 'REPL') {
         r = results.addResult(editor, range, ' ⟳ ', '')
     }
+    try {
+        const result: ReturnResult = await g_connection.sendRequest(
+            requestTypeReplRunCode,
+            {
+                filename: editor.document.fileName,
+                line: range.start.line,
+                column: range.start.character,
+                code: text,
+                mod: module,
+                showCodeInREPL: codeInREPL,
+                showResultInREPL: resultType === 'REPL' || resultType === 'both',
+                showErrorInREPL: resultType.indexOf('error') > -1,
+                softscope: true
+            }
+        )
 
-    const result: ReturnResult = await g_connection.sendRequest(
-        requestTypeReplRunCode,
-        {
-            filename: editor.document.fileName,
-            line: range.start.line,
-            column: range.start.character,
-            code: text,
-            mod: module,
-            showCodeInREPL: codeInREPL,
-            showResultInREPL: resultType === 'REPL' || resultType === 'both',
-            showErrorInREPL: resultType.indexOf('error') > -1,
-            softscope: true
+        if (resultType !== 'REPL') {
+            if (r.destroyed) {
+                r = results.addResult(editor, range, '', '')
+            }
+            if (result.stackframe) {
+                results.clearStackTrace()
+                results.setStackTrace(r, result.all, result.stackframe)
+            }
+            r.setContent(results.resultContent(' ' + result.inline + ' ', result.all, Boolean(result.stackframe)))
         }
-    )
-
-    if (resultType !== 'REPL') {
-        if (result.stackframe) {
-            results.clearStackTrace()
-            results.setStackTrace(r, result.all, result.stackframe)
-        }
-        r.setContent(results.resultContent(' ' + result.inline + ' ', result.all, Boolean(result.stackframe)))
+    } catch (err) {
+        r.remove(true)
+        telemetry.handleNewCrashReportFromException(err, 'Extension')
     }
 }
 


### PR DESCRIPTION
- cell evaluation now properly works in jmd files
- Julia keybindings now work in jmd files
- fixed an error when evaluating code strings only containing new lines
- fixed a cause of orphaned error highlights

Fixes https://github.com/julia-vscode/julia-vscode/issues/2466 and probably a bunch of other issues.