### PR TITLE
Impove the system image build script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 * `InteractiveUtils` is now properly loaded in notebooks ([#2457](https://github.com/julia-vscode/julia-vscode/pull/2457))
 
+### Changed
+* system image building now excludes development packages (e.g. added by `dev`).
+
+### Added
+* Allow customising precompile statements and execution files for system image building based on a `vscode-compileenv.toml` file inside the project root folder.
+
 ## [1.4.3] - 2021-09-15
 ### Changed
 * Cursor now changes to indicate that plots are zoomable/panable ([#2445](https://github.com/julia-vscode/julia-vscode/pull/2445))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * system image building now excludes development packages (e.g. added by `dev`).
 
 ### Added
-* Allow customising precompile statements and execution files for system image building based on a `vscode-compileenv.toml` file inside the project root folder.
+* Allow customising precompile statements and execution files for system image building based on a `./.vscode/JuliaSysimage.toml` file inside the project root folder.
 
 ## [1.4.3] - 2021-09-15
 ### Changed

--- a/scripts/tasks/task_compileenv.jl
+++ b/scripts/tasks/task_compileenv.jl
@@ -1,4 +1,59 @@
 import Pkg, Libdl, PackageCompiler
+import TOML
+
+
+const config_fname = "vscode-compileenv.toml"
+
+"""
+    find_dev_packages(envdir::AbstractString)
+
+Locate the packages that are in `dev` mode for a given project environment
+"""
+function find_dev_packages(envdir::AbstractString)
+    fname = joinpath(envdir, "Manifest.toml")
+    !isfile(fname) && return Symbol[]
+    devpkgs = Symbol[]
+    parsed = TOML.parse(read(fname, String))
+    for key in keys(parsed)
+        sub = parsed[key]
+        "path" in keys(sub[1]) && push!(devpkgs, Symbol(key))
+    end
+    devpkgs
+end
+
+
+"""
+    read_configuration(envdir)
+
+Read the configuration file `vscode-compileenv.toml` from the environment directory.
+
+This file has the format:
+
+```
+[sysimage]
+excluded_packages=[]   # Additional packages to be exlucded in the system image
+precompile_statements_file=[]  # Precompile statements file to be used
+precompile_execution_file=[] # Precompile execution file to be used
+```
+
+Please see `PackageCompiler.jl` package's documention for the use of the last two options.
+"""
+function read_configuration(envdir)
+    fname = joinpath(envdir, config_fname)
+    output = Dict(
+        :precompile_execution_file=>String[],
+        :precompile_statements_file=>String[],
+        :excluded_packages=>Symbol[],
+    )
+    !isfile(fname) && return output
+
+    parsed = get(TOML.parse(read(fname, String)), "sysimage", Dict{Any, Any}())
+    output[:precompile_execution_file] = String[joinpath(envdir, x) for x in get(parsed, "precompile_execution_file", String[])]
+    output[:precompile_statements_file] = String[joinpath(envdir, x) for x in get(parsed, "precompile_statements_file", String[])]
+    output[:excluded_packages] = Symbol.(get(parsed, "excluded_packages", Symbol[]))
+
+    output
+end
 
 env_to_precompile = ARGS[1]
 
@@ -8,8 +63,18 @@ project_filename = isfile(joinpath(env_to_precompile, "JuliaProject.toml")) ? jo
 
 project = Pkg.API.read_project(project_filename)
 
-used_packages = Symbol.(collect(keys(project.deps)))
+# Read the configuration file
+config = read_configuration(env_to_precompile)
+dev_packages = find_dev_packages(env_to_precompile)
 
-@info "Now building a custom sysimage for the environment '$env_to_precompile'."
+# Assemble the arguments for the `create_sysimage` function
+used_packages = filter(x -> !(x in dev_packages || x in config[:excluded_packages]), Symbol.(collect(keys(project.deps))))
+precompile_statements = config[:precompile_statements_file]
+precompile_execution = config[:precompile_execution_file]
 
-PackageCompiler.create_sysimage(used_packages, sysimage_path = sysimage_path, project = env_to_precompile)
+@info "Now building a custom sysimage for the environment '$env_to_precompile', excluding dev packages '$dev_packages'."
+@info "Precompile statement files: $precompile_statements"
+@info "Precompile execution files: $precompile_execution"
+
+PackageCompiler.create_sysimage(used_packages, sysimage_path = sysimage_path, project = env_to_precompile,
+                                precompile_statements_file=precompile_statements, precompile_execution_file=precompile_execution)

--- a/scripts/tasks/task_compileenv.jl
+++ b/scripts/tasks/task_compileenv.jl
@@ -7,7 +7,7 @@ const config_fname = "vscode-compileenv.toml"
 """
     find_dev_packages(envdir::AbstractString)
 
-Locate the packages that are in `dev` mode for a given project environment
+Locate the packages that are in `dev` mode for a given project environment.
 """
 function find_dev_packages(envdir::AbstractString)
     fname = joinpath(envdir, "Manifest.toml")

--- a/scripts/tasks/task_compileenv.jl
+++ b/scripts/tasks/task_compileenv.jl
@@ -27,7 +27,7 @@ end
 
 Read the configuration file `vscode-compileenv.toml` from the environment directory.
 
-This file has the format:
+This file should look like:
 
 ```
 [sysimage]


### PR DESCRIPTION
Fixes #1673

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.

Default to exclude development packages during system image building. Also, allow passing additional options to the `PackageCompiler.create_sysimge` function based on a `vscode-compileenv.toml` file located inside the project root folder. 
This can be used to pass precompile execution/statement files and further reduced the first-call latency. 