### PR TITLE
Tmux session names: replace `$[workspace]` with current file's workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 * tmux session names can now include `$[workspace]` which will be replaced with
   the name of the current file's workspace when the REPL is first opened. (This
-  allows for multiple persistent sessions across different VSCode windows).
+  allows for multiple persistent sessions across different VSCode windows). ([#2504](https://github.com/julia-vscode/julia-vscode/pull/2504))
 
 ## [1.4.3] - 2021-09-15
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 * `InteractiveUtils` is now properly loaded in notebooks ([#2457](https://github.com/julia-vscode/julia-vscode/pull/2457))
 
+### Changed
+* tmux session names can now include `$[workspace]` which will be replaced with
+  the name of the current file's workspace when the REPL is first opened. (This
+  allows for multiple persistent sessions across different VSCode windows).
+
 ## [1.4.3] - 2021-09-15
 ### Changed
 * Cursor now changes to indicate that plots are zoomable/panable ([#2445](https://github.com/julia-vscode/julia-vscode/pull/2445))

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Julia 
+# Julia
 [![Build and Test](https://github.com/julia-vscode/julia-vscode/actions/workflows/main.yml/badge.svg)](https://github.com/julia-vscode/julia-vscode/actions/workflows/main.yml)
 
 This [VS Code](https://code.visualstudio.com) extension provides support for the [Julia programming language](http://julialang.org/).

--- a/package.json
+++ b/package.json
@@ -1007,7 +1007,7 @@
                     "type": "boolean",
                     "default": false,
                     "scope": "machine-overridable",
-                    "markdownDescription": "Experimental: Starts the interactive Julia session in a persistent `tmux` session. Note that `tmux` must be available in the shell defined below."
+                    "markdownDescription": "Experimental: Starts the interactive Julia session in a persistent `tmux` session. Note that `tmux` must be available in the shell defined below. If present the string `$[workspace]` will be replaced with the current file's workspace when the REPL is first opened."
                 },
                 "julia.persistentSession.shell": {
                     "type": "string",

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -62,12 +62,7 @@ function isConnected() {
 }
 
 function sanitize(str: string) {
-    str = str.toLowerCase()
-    const unclean = /[^0-9a-zA-Z_-]+/
-    while (str.match(unclean)) {
-        str = str.replace(unclean,'-')
-    }
-    return str
+    return str.toLowerCase().replace(/[^\p{L}\p{N}_-]+/ug, '-')
 }
 function parseSessionArgs(name: string) {
     if (name.match(/\$\[workspace\]/)){

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -61,6 +61,30 @@ function isConnected() {
     return Boolean(g_connection)
 }
 
+function sanitize(str: string) {
+    str = str.toLowerCase()
+    const unclean = /[^0-9a-zA-Z_-]+/
+    while (str.match(unclean)) {
+        str = str.replace(unclean,'-')
+    }
+    return str
+}
+function parseSessionArgs(name: string) {
+    if (name.match(/\$\[workspace\]/)){
+        const ed = vscode.window.activeTextEditor
+        if (ed) {
+            const folder = vscode.workspace.getWorkspaceFolder(ed.document.uri)
+            if (folder) {
+                return name.replace('$[workspace]', sanitize(folder.name))
+            } else {
+                return name.replace('$[workspace]', '')
+            }
+        }
+    }
+
+    return name
+}
+
 async function startREPL(preserveFocus: boolean, showTerminal: boolean = true) {
     if (isConnected()) {
         if (g_terminal && showTerminal) {
@@ -124,7 +148,7 @@ async function startREPL(preserveFocus: boolean, showTerminal: boolean = true) {
         if (Boolean(config.get('persistentSession.enabled'))) {
             const shellPath: string = config.get('persistentSession.shell')
             const connectJuliaCode = juliaConnector(pipename)
-            const sessionName = config.get('persistentSession.tmuxSessionName')
+            const sessionName = parseSessionArgs(config.get('persistentSession.tmuxSessionName'))
             const tmuxArgs = [
                 <string>config.get('persistentSession.shellExecutionArgument'),
                 // create a new tmux session, set remain-on-exit to true, and attach; if the session already exists we just attach to the existing session


### PR DESCRIPTION
Addresses #2349. This adds a single variable `$[workspace]` which is probably the most useful one to add.

- [x] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.
