### PR TITLE
bugfix: correctly escape `"` characters when starting julia

### DIFF
--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -146,7 +146,7 @@ async function startREPL(preserveFocus: boolean, showTerminal: boolean = true) {
             const shellPath: string = config.get('persistentSession.shell')
             const connectJuliaCode = juliaConnector(pipename)
             const sessionName = parseSessionArgs(config.get('persistentSession.tmuxSessionName'))
-            const juliaAndArgs = `JULIA_NUM_THREADS=${env.JULIA_NUM_THREADS} JULIA_EDITOR=${env.JULIA_EDITOR} ${juliaExecutable.file} ${[...juliaExecutable.args, ...jlarg1, ...getArgs()].join(' ')}`.replace('"', '\\"')
+            const juliaAndArgs = `JULIA_NUM_THREADS=${env.JULIA_NUM_THREADS} JULIA_EDITOR=${env.JULIA_EDITOR} ${juliaExecutable.file} ${[...juliaExecutable.args, ...jlarg1, ...getArgs()].join(' ')}`.replace(/"/g, '\\"')
             const tmuxArgs: string[] = [
                 <string>config.get('persistentSession.shellExecutionArgument'),
                 // create a new tmux session, set remain-on-exit to true, and attach; if the session already exists we just attach to the existing session


### PR DESCRIPTION
Ran into an error when trying to run the newly released insiders. Turns out the current version doesn't properly replace `"` characters. (I was worried it was something to do with my changes in #2534, but it seems unrelated).

- [x] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.
