### PR TITLE
Various fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Julia extension will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+* Runtime completions can now be properly disabled ([#2551](https://github.com/julia-vscode/julia-vscode/pull/2551))
+* Code execution keybindings are now consistent for Weave files ([#2551](https://github.com/julia-vscode/julia-vscode/pull/2551))
+* Introduced a helpful warning when `@profview` failed to collect any traces ([#2551](https://github.com/julia-vscode/julia-vscode/pull/2551))
+* The REPL is now terminated when VS Code is closed, which should work around issues introduced by the `terminal.integrated.enablePersistentSessions` setting ([#2551](https://github.com/julia-vscode/julia-vscode/pull/2551))
+* Fixed various issues with the integrated table viewer ([#2551](https://github.com/julia-vscode/julia-vscode/pull/2551))
+* It's now once again possible to use the `Run/Debug in New Process` commands concurrently ([#2551](https://github.com/julia-vscode/julia-vscode/pull/2551))
 
 ## [1.5.4] - 2021-11-11
 ### Changed

--- a/package.json
+++ b/package.json
@@ -451,22 +451,22 @@
                 },
                 {
                     "command": "language-julia.clearAllInlineResultsInEditor",
-                    "when": "editorLangId == julia"
+                    "when": "editorLangId == julia || editorLangId == juliamarkdown"
                 },
                 {
                     "command": "language-julia.cdHere",
                     "group": "julia",
-                    "when": "editorLangId == julia"
+                    "when": "editorLangId == julia || editorLangId == juliamarkdown"
                 },
                 {
                     "command": "language-julia.activateHere",
                     "group": "julia",
-                    "when": "editorLangId == julia"
+                    "when": "editorLangId == julia || editorLangId == juliamarkdown"
                 },
                 {
                     "command": "language-julia.activateFromDir",
                     "group": "julia",
-                    "when": "editorLangId == julia"
+                    "when": "editorLangId == julia || editorLangId == juliamarkdown"
                 }
             ],
             "editor/title/run": [
@@ -568,7 +568,7 @@
             "editor/context": [
                 {
                     "command": "language-julia.show-documentation",
-                    "when": "editorLangId == julia",
+                    "when": "editorLangId == julia || editorLangId == juliamarkdown",
                     "group": "z_commands"
                 }
             ]
@@ -587,7 +587,7 @@
             {
                 "command": "language-julia.executeCell",
                 "key": "Alt+Enter",
-                "when": "editorTextFocus && editorLangId == julia && activeEditor != workbench.editor.notebook"
+                "when": "editorTextFocus &&activeEditor != workbench.editor.notebook && editorLangId == julia || editorLangId == juliamarkdown"
             },
             {
                 "command": "language-julia.executeCellAndMove",
@@ -602,7 +602,7 @@
             {
                 "command": "language-julia.clearCurrentInlineResult",
                 "key": "Escape",
-                "when": "editorTextFocus && !editorHasSelection && !findWidgetVisible && !markerNavigationVisible && !parameterHintsVisible && !inSnippetMode && !isInEmbeddedEditor && !suggestWidgetVisible && !onTypeRenameInputVisible && !renameInputVisible && editorLangId == julia && juliaHasInlineResult"
+                "when": "editorTextFocus && !editorHasSelection && !findWidgetVisible && !markerNavigationVisible && !parameterHintsVisible && !inSnippetMode && !isInEmbeddedEditor && !suggestWidgetVisible && !onTypeRenameInputVisible && !renameInputVisible && juliaHasInlineResult && editorLangId == julia || editorLangId == juliamarkdown"
             },
             {
                 "command": "language-julia.clearAllInlineResultsInEditor",

--- a/scripts/packages/VSCodeServer/src/completions.jl
+++ b/scripts/packages/VSCodeServer/src/completions.jl
@@ -11,7 +11,7 @@ function repl_getcompletions_request(_, params::GetCompletionsRequestParams)
     mod = module_from_string(mod)
 
     cs = try
-        first(completions(line, lastindex(line), mod))
+        first(Base.invokelatest(completions, line, lastindex(line), mod))
     catch err
         @debug "completion error" exception=(err, catch_backtrace())
         # might error when e.g. type inference fails
@@ -40,7 +40,7 @@ completion_label(c) = completion_text(c)
 completion_label(c::DictCompletion) = rstrip(completion_text(c), (']', '"'))
 
 completion_detail(c::PropertyCompletion) = begin
-    isdefined(c.value, c.property) || return ""
+    hasproperty(c.value, c.property) || return ""
     t = typeof(getproperty(c.value, c.property))
     string(t)
 end

--- a/scripts/packages/VSCodeServer/src/profiler.jl
+++ b/scripts/packages/VSCodeServer/src/profiler.jl
@@ -1,11 +1,14 @@
 # TODO Instead of saving to a file, send content via this message
-function view_profile(data::Union{Nothing,Vector{UInt}} = nothing, period::Union{Nothing,UInt64} = nothing; kwargs...)
+function view_profile(data::Union{Nothing,Vector{UInt}} = copy(Profile.fetch()), period::Union{Nothing,UInt64} = nothing; kwargs...)
+    if data !== nothing && isempty(data)
+        @info "No profile data collected."
+        return
+    end
     filename = string(tempname(), ".cpuprofile")
 
     ChromeProfileFormat.save_cpuprofile(filename, data, period, kwargs...)
 
     JSONRPC.send(conn_endpoint[], repl_showprofileresult_file_notification_type, (; filename = filename))
-    # JSONRPC.send(conn_endpoint[], repl_showprofileresult_notification_type, (;content=content))
 end
 
 

--- a/scripts/packages/VSCodeServer/src/tables/filtering.jl
+++ b/scripts/packages/VSCodeServer/src/tables/filtering.jl
@@ -46,7 +46,7 @@ function generate_filter(params, col)
     if filter_type == "number"
         generate_number_filter(params, col)
     elseif filter_type == "text"
-        generate_text_filter(params, col)
+        generate_string_filter(params, col)
     elseif filter_type == "date"
         generate_date_filter(params, col)
     else
@@ -68,22 +68,22 @@ function generate_string_filter(params, col)
     op = params["type"]
     if op == "equals"
         matcher = Regex("^" * filtervalue * "\$", "i")
-        row -> occursin(matcher, col_access(row, col))
+        row -> occursin(matcher, string(col_access(row, col)))
     elseif op == "notEqual"
         matcher = Regex("^" * filtervalue * "\$", "i")
-        row -> !occursin(matcher, col_access(row, col))
+        row -> !occursin(matcher, string(col_access(row, col)))
     elseif op == "startsWith"
         matcher = Regex("^" * filtervalue, "i")
-        row -> occursin(matcher, col_access(row, col))
+        row -> occursin(matcher, string(col_access(row, col)))
     elseif op == "endsWith"
         matcher = Regex(filtervalue * "\$", "i")
-        row -> occursin(matcher, col_access(row, col))
+        row -> occursin(matcher, string(col_access(row, col)))
     elseif op == "contains"
         matcher = Regex(filtervalue, "i")
-        row -> occursin(matcher, col_access(row, col))
+        row -> occursin(matcher, string(col_access(row, col)))
     elseif op == "notContains"
         matcher = Regex(filtervalue, "i")
-        row -> !occursin(matcher, col_access(row, col))
+        row -> !occursin(matcher, string(col_access(row, col)))
     end
 end
 

--- a/src/debugger/juliaDebug.ts
+++ b/src/debugger/juliaDebug.ts
@@ -1,6 +1,6 @@
 import { Subject } from 'await-notify'
 import * as net from 'net'
-import { join } from 'path'
+import { basename, join } from 'path'
 import { uuid } from 'uuidv4'
 import * as vscode from 'vscode'
 import { InitializedEvent, Logger, logger, LoggingDebugSession, StoppedEvent, TerminatedEvent } from 'vscode-debugadapter'
@@ -224,11 +224,13 @@ export class JuliaDebugSession extends LoggingDebugSession {
 
         const task = new vscode.Task(
             {
-                type: 'julia-proc'
+                type: 'julia-proc',
+                id: uuid()
             },
             vscode.TaskScope.Workspace,
-            'Julia debugger',
-            'julia',
+            `Debug ${basename(args.program)}`,
+            'Julia',
+
             new vscode.ProcessExecution(
                 this.juliaExecutable.file,
                 [
@@ -288,11 +290,12 @@ export class JuliaDebugSession extends LoggingDebugSession {
     protected async runRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments) {
         const task = new vscode.Task(
             {
-                type: 'julia-proc'
+                type: 'julia-proc',
+                id: uuid()
             },
             vscode.TaskScope.Workspace,
-            'Julia process',
-            'julia',
+            `Run ${basename(args.program)}`,
+            'Julia',
             new vscode.ProcessExecution(
                 this.juliaExecutable.file,
                 [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -148,7 +148,9 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 
 // this method is called when your extension is deactivated
-export function deactivate() { }
+export function deactivate() {
+    repl.deactivate()
+}
 
 const g_onSetLanguageClient = new vscode.EventEmitter<LanguageClient>()
 export const onSetLanguageClient = g_onSetLanguageClient.event

--- a/src/interactive/completions.ts
+++ b/src/interactive/completions.ts
@@ -39,7 +39,7 @@ const requestTypeGetCompletionItems = new rpc.RequestType<
 function completionItemProvider(conn: MessageConnection): vscode.CompletionItemProvider {
     return {
         provideCompletionItems: async (document, position, token, context) => {
-            if (!vscode.workspace.getConfiguration('julia.runtimeCompletions')) {
+            if (!vscode.workspace.getConfiguration('julia').get('runtimeCompletions')) {
                 return
             }
             const completionPromise = (async () => {

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -1162,3 +1162,7 @@ export function activate(context: vscode.ExtensionContext, compiledProvider, jul
     modules.activate(context)
     completions.activate(context)
 }
+
+export function deactivate() {
+    killREPL()
+}


### PR DESCRIPTION
Fixes:
- runtime completions
- Weave keybindings
- error on empty profile traces
- tableviewer issues
- adds a uuid to "Run/Debug in new process" tasks, so that multiple can be active at the same time

and will try to kill the REPL when the extension is deactivated, which should help with the new VS Code persistent terminal issues.

Fixes https://github.com/julia-vscode/julia-vscode/issues/2540. Fixes https://github.com/julia-vscode/julia-vscode/issues/2559.