### PR TITLE
Use pixelated rendering for images in the plot pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to the Julia extension will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Changed
+* Use pixelated rendering mode for images in the plot pane, in the same way VS Code renders images. ([#2570](https://github.com/julia-vscode/julia-vscode/pull/2570))
 
 ## [1.5.5] - 2021-11-16
 ### Fixed

--- a/src/interactive/plots.ts
+++ b/src/interactive/plots.ts
@@ -343,6 +343,7 @@ const plotElementStyle = `
     max-width: 100vw;
     display: block;
     position: absolute;
+    image-rendering: pixelated;
 }
 
 #plot-element.pan-zoom {


### PR DESCRIPTION
This will be closer to how VSCode renders images.

See the difference in the rendering of the current behavior:
![image](https://user-images.githubusercontent.com/333519/142409410-b79b4f8f-922b-4b26-a60f-954f055ecd96.png)
