### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Julia
 [![Build and Test](https://github.com/julia-vscode/julia-vscode/actions/workflows/main.yml/badge.svg)](https://github.com/julia-vscode/julia-vscode/actions/workflows/main.yml)
+[![Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://www.julia-vscode.org/docs/latest/)
+<!-- [![Docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://www.julia-vscode.org/docs/dev/) -->
 
 This [VS Code](https://code.visualstudio.com) extension provides support for the [Julia programming language](http://julialang.org/).
 


### PR DESCRIPTION
Hello, I was looking around in Discourse and found the link to the docs in an answer. I didn't know that there was a Documenter docs available. I think it would be a good idea to have an upper link to the docs in this repository. I know it's in the README, but the idea would be for users to enter to the docs just by looking at the top of the README on Github. Maybe this could save some questions on Discourse. For example, I learned how to configure the execution files to compile a sysimage which is something I've meaning to ask for a couple of weeks.

Thanks for maintining this excellent tool for us. 