### PR TITLE
Remove duplicate plot pane keybindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -666,28 +666,8 @@
                 "when": "jlplotpaneFocus"
             },
             {
-                "command": "language-julia.plotpane-previous",
-                "key": "up",
-                "when": "jlplotpaneFocus"
-            },
-            {
-                "command": "language-julia.plotpane-previous",
-                "key": "pageup",
-                "when": "jlplotpaneFocus"
-            },
-            {
                 "command": "language-julia.plotpane-next",
                 "key": "right",
-                "when": "jlplotpaneFocus"
-            },
-            {
-                "command": "language-julia.plotpane-next",
-                "key": "down",
-                "when": "jlplotpaneFocus"
-            },
-            {
-                "command": "language-julia.plotpane-next",
-                "key": "pagedown",
                 "when": "jlplotpaneFocus"
             },
             {


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/2689.

This removes some of the duplicate keybindings to navigate the plot pane. With this,
- Left/Right will move to the previous/next plot
- Home/End will move to the first/last plot

Removed are the PgUp/PgDown/Up/Down keybindings, all of which go to the previous/next plot and are confusing in the context of the plot navigator.