### PR TITLE
Add when clause to notebook toolbar icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -646,12 +646,12 @@
                 {
                     "command": "language-julia.restartKernel",
                     "group": "navigation/execute@1",
-                    "when": "notebookType == 'jupyter-notebook' && isWorkspaceTrusted"
+                    "when": "notebookType == 'jupyter-notebook' && isWorkspaceTrusted && notebookKernel =~ /julialang/"
                 },
                 {
                     "command": "language-julia.stopKernel",
                     "group": "navigation/execute@2",
-                    "when": "notebookType == 'jupyter-notebook' && isWorkspaceTrusted"
+                    "when": "notebookType == 'jupyter-notebook' && isWorkspaceTrusted && notebookKernel =~ /julialang/"
                 }
             ],
             "commandPalette": [


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/2757.

Using `/^julialang.julia\///` or anything like that *should* work, but apparently never returns true currently.