### PR TITLE
Check loaded tables modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the Julia extension will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+* The table viewer is now available even when TableTraits is loaded before we connect to the Julia session, e.g. because it's compiled into the sysimage ([#2775](https://github.com/julia-vscode/julia-vscode/pull/2775))
+
 ## [1.6.1] - 2022-03-10
 ### Added
 * "Always copy" option for "Connect to external REPL" command ([#2759](https://github.com/julia-vscode/julia-vscode/pull/2759))

--- a/scripts/packages/VSCodeServer/src/VSCodeServer.jl
+++ b/scripts/packages/VSCodeServer/src/VSCodeServer.jl
@@ -19,6 +19,10 @@ function __init__()
     end
 
     push!(Base.package_callbacks, on_pkg_load)
+
+    for pkgid in keys(Base.loaded_modules)
+        on_pkg_load(pkgid)
+    end
 end
 
 include("../../JSON/src/JSON.jl")


### PR DESCRIPTION
This enables the table viewer if TableTraits/DataValues is loaded before we connect (e.g. via a sysimg or by connecting to an existing Julia session).