### PR TITLE
Remove LS middleware

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,6 @@
 'use strict'
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
-import { SeverityLevel } from 'applicationinsights/out/Declarations/Contracts'
 import * as fs from 'async-file'
 import { unwatchFile, watchFile } from 'async-file'
 import * as net from 'net'

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -273,35 +273,6 @@ async function startLanguageServer(juliaExecutablesFeature: JuliaExecutablesFeat
         },
         revealOutputChannelOn: RevealOutputChannelOn.Never,
         traceOutputChannel: vscode.window.createOutputChannel('Julia Language Server trace'),
-        middleware: {
-            provideCompletionItem: async (document, position, context, token, next) => {
-
-                const validatedPosition = document.validatePosition(position)
-
-                if (validatedPosition !== position) {
-                    telemetry.traceTrace({
-                        message: `Middleware found a change in position in provideCompletionItem. Original ${position.line}:${position.character}, validated ${validatedPosition.line}:${validatedPosition.character}`,
-                        severity: SeverityLevel.Error
-                    })
-
-                }
-
-                return await next(document, position, context, token)
-            },
-            provideDefinition: async (document, position, token, next) => {
-
-                const validatedPosition = document.validatePosition(position)
-
-                if (validatedPosition !== position) {
-                    telemetry.traceTrace({
-                        message: `Middleware found a change in position in provideDefinition. Original ${position.line}:${position.character}, validated ${validatedPosition.line}:${validatedPosition.character}`,
-                        severity: SeverityLevel.Error
-                    })
-                }
-
-                return await next(document, position, token)
-            }
-        }
     }
 
     // Create the language client and start the client.


### PR DESCRIPTION
I haven't seen a crash report from this in ages, and it really was just a temporary diagnostic tool, so I think we can remove at this point. Just creates overhead.