### PR TITLE
Display diagnostic MIME type in REPL

### DIFF
--- a/scripts/packages/VSCodeServer/src/display.jl
+++ b/scripts/packages/VSCodeServer/src/display.jl
@@ -120,7 +120,10 @@ Anything printed to `io` is discarded.
 """
 const DIAGNOSTIC_MIME = "application/vnd.julia-vscode.diagnostics"
 Base.Multimedia.displayable(::InlineDisplay, ::MIME{Symbol(DIAGNOSTIC_MIME)}) = DIAGNOSTICS_ENABLED[]
-Base.Multimedia.display(::InlineDisplay, m::MIME{Symbol(DIAGNOSTIC_MIME)}, diagnostics) = sendDisplayMsg(DIAGNOSTIC_MIME, show(IOBuffer(), m, diagnostics))
+function Base.Multimedia.display(::InlineDisplay, m::MIME{Symbol(DIAGNOSTIC_MIME)}, diagnostics)
+    display(MIME"text/plain", diagnostics)
+    sendDisplayMsg(DIAGNOSTIC_MIME, show(IOBuffer(), m, diagnostics))
+end
 
 function is_table_like(x)
     if showable("application/vnd.dataresource+json", x)


### PR DESCRIPTION
JET output shows in the REPL with this.

Is this the right idea? I'm not quite clear on when `display` or `show` and family is appropriate.

Fixes https://github.com/julia-vscode/julia-vscode/issues/2484.
