### PR TITLE
Fix toolbar icon

### DIFF
--- a/images/julia-dots-outline.svg
+++ b/images/julia-dots-outline.svg
@@ -1,13 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="24" height="24" viewBox="0 0 325 300" version="1.1" xml:space="preserve">
-<style type="text/css">
-	circle {
-		stroke: #d7dae0;
-		fill: transparent;
-		stroke-width: 20;
-		r: 65;
-	}
-</style>
-<circle cx="75.8" cy="225" />
-<circle cx="162.5" cy="75" />
-<circle cx="249.1" cy="225" />
+<circle cx="75.8" cy="225" r="65" style="stroke: #d7dae0;fill: transparent;stroke-width: 20;"/>
+<circle cx="162.5" cy="75" r="65" style="stroke: #d7dae0;fill: transparent;stroke-width: 20;"/>
+<circle cx="249.1" cy="225" r="65" style="stroke: #d7dae0;fill: transparent;stroke-width: 20;"/>
 </svg>


### PR DESCRIPTION
SVG 1.1 does not necessarily support the style element. The current
solution seems to work fine in Chromium derivates, but not in e.g. Firefox.