### PR TITLE
Improve juliaup integration with LS

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -247,7 +247,7 @@ async function startLanguageServer(juliaExecutablesFeature: JuliaExecutablesFeat
     // If the user is using juliaup, we need to prevent the LS process to try to use a juliaup
     // install in our LS depot, which would normally happen becuse we set the JULIA_DEPOT_PATH
     // env variable. This here works around that.
-    if (juliaExecutablesFeature.getUsingJuliaup() &&
+    if (juliaExecutablesFeature.isJuliaup() &&
         juliaExecutable.file.toLocaleLowerCase() === 'julia' &&
         juliaExecutable.args.length > 0 &&
         juliaExecutable.args[0].startsWith('+')) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -241,7 +241,27 @@ async function startLanguageServer(juliaExecutablesFeature: JuliaExecutablesFeat
         }
     }
 
-    const juliaExecutable = await juliaExecutablesFeature.getActiveJuliaExecutableAsync()
+    let juliaExecutable = await juliaExecutablesFeature.getActiveJuliaExecutableAsync()
+
+    // Special case the situation where a user configured something like `julia +lts`
+    // If the user is using juliaup, we need to prevent the LS process to try to use a juliaup
+    // install in our LS depot, which would normally happen becuse we set the JULIA_DEPOT_PATH
+    // env variable. This here works around that.
+    if (juliaExecutablesFeature.getUsingJuliaup() &&
+        juliaExecutable.file.toLocaleLowerCase() === 'julia' &&
+        juliaExecutable.args.length > 0 &&
+        juliaExecutable.args[0].startsWith('+')) {
+
+        const channel = juliaExecutable.args[0].slice(1)
+
+        const juliaExePaths = await juliaExecutablesFeature.getJuliaExePathsAsync()
+
+        const channelExecutable = juliaExePaths.find(i => i.channel === channel)
+
+        if (channelExecutable) {
+            juliaExecutable = channelExecutable
+        }
+    }
 
     const serverOptions: ServerOptions = Boolean(process.env.DETACHED_LS) ?
         async () => {

--- a/src/juliaexepath.ts
+++ b/src/juliaexepath.ts
@@ -282,7 +282,7 @@ export class JuliaExecutablesFeature {
         return this.actualJuliaExePath
     }
 
-    public getUsingJuliaup() {
+    public isJuliaup() {
         return this.usingJuliaup
     }
 

--- a/src/juliaexepath.ts
+++ b/src/juliaexepath.ts
@@ -60,6 +60,7 @@ export class JuliaExecutable {
 export class JuliaExecutablesFeature {
     private actualJuliaExePath: JuliaExecutable | undefined
     private cachedJuliaExePaths: JuliaExecutable[] | undefined
+    private usingJuliaup: boolean | undefined
 
     constructor(private context: vscode.ExtensionContext) {
         this.context.subscriptions.push(
@@ -67,6 +68,7 @@ export class JuliaExecutablesFeature {
                 if (event.affectsConfiguration('julia.executablePath')) {
                     this.actualJuliaExePath = undefined
                     this.cachedJuliaExePaths = undefined
+                    this.usingJuliaup = undefined
                 }
             })
         )
@@ -189,6 +191,7 @@ export class JuliaExecutablesFeature {
     }
 
     async tryJuliaup() {
+        this.usingJuliaup = false
         try {
             const { stdout, } = await execFile('juliaup', ['api', 'getconfig1'])
 
@@ -214,6 +217,8 @@ export class JuliaExecutablesFeature {
                     i.Name,
                     true
                 )).concat(this.actualJuliaExePath)
+
+                this.usingJuliaup = true
 
                 return true
             }
@@ -275,6 +280,10 @@ export class JuliaExecutablesFeature {
             }
         }
         return this.actualJuliaExePath
+    }
+
+    public getUsingJuliaup() {
+        return this.usingJuliaup
     }
 
     getExecutablePath() {


### PR DESCRIPTION
This makes things work when a user configures something like `julia +lts` as their exe. Right now that is broken because we start the LS with a special depot, and then juliaup tries to install julia versions into that special folder, which we don't want to happen.