### PR TITLE
'Go to Definition' for workspace items

### DIFF
--- a/package.json
+++ b/package.json
@@ -304,6 +304,11 @@
                 "icon": "$(preview)"
             },
             {
+                "command": "language-julia.workspaceGoToFile",
+                "title": "Go to definition",
+                "icon": "$(go-to-file)"
+            },
+            {
                 "command": "language-julia.clearAllInlineResults",
                 "title": "Julia: Clear All Inline Results"
             },
@@ -540,7 +545,12 @@
             "view/item/context": [
                 {
                     "command": "language-julia.showInVSCode",
-                    "when": "view == REPLVariables && viewItem == globalvariable",
+                    "when": "view == REPLVariables && viewItem =~ /globalvariable/",
+                    "group": "inline"
+                },
+                {
+                    "command": "language-julia.workspaceGoToFile",
+                    "when": "view == REPLVariables && viewItem =~ /haslocation/",
                     "group": "inline"
                 },
                 {

--- a/scripts/packages/VSCodeServer/src/repl_protocol.jl
+++ b/scripts/packages/VSCodeServer/src/repl_protocol.jl
@@ -29,6 +29,11 @@ JSONRPC.@dict_readable struct ReplRunCodeRequestReturn <: JSONRPC.Outbound
 end
 ReplRunCodeRequestReturn(inline, all) = ReplRunCodeRequestReturn(inline, all, nothing)
 
+JSONRPC.@dict_readable mutable struct Location <: JSONRPC.Outbound
+    file::String
+    line::Int
+end
+
 JSONRPC.@dict_readable mutable struct ReplWorkspaceItem <: JSONRPC.Outbound
     head::String
     id::Int
@@ -38,6 +43,7 @@ JSONRPC.@dict_readable mutable struct ReplWorkspaceItem <: JSONRPC.Outbound
     value::String
     canshow::Bool
     type::String
+    location::Union{Nothing, Location}
 end
 
 JSONRPC.@dict_readable struct GetCompletionsRequestParams <: JSONRPC.Outbound

--- a/scripts/packages/VSCodeServer/src/trees.jl
+++ b/scripts/packages/VSCodeServer/src/trees.jl
@@ -17,8 +17,8 @@ struct SubTree
     location::Union{Location, Nothing}
 end
 
-SubTree(head, child) = SubTree(head, "", child, nothing)
-SubTree(head, icon, child) = SubTree(head, icon, child, nothing)
+SubTree(head, child) = SubTree(head, "", child, location(child))
+SubTree(head, icon, child) = SubTree(head, icon, child, location(child))
 
 struct Leaf
     val::Any
@@ -289,7 +289,7 @@ function getvariables()
         s = string(n)
         startswith(s, "#") && continue
         try
-            tree = treerender(SubTree(s, wsicon(x), x, location(x)))
+            tree = treerender(SubTree(s, wsicon(x), x))
             tree.canshow = can_display(x)
             push!(variables, tree)
         catch err

--- a/scripts/packages/VSCodeServer/src/trees.jl
+++ b/scripts/packages/VSCodeServer/src/trees.jl
@@ -278,13 +278,13 @@ function getvariables()
         Base.isdeprecated(M, n) && continue
 
         x = getfield(M, n)
-        x in Set([
+        x in (
             vscodedisplay,
             VSCodeServer,
             Main,
             Main.include,
             Main.eval
-        ]) && continue
+        ) && continue
 
         s = string(n)
         startswith(s, "#") && continue


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6735977/160585538-e6bb3d23-4312-4a1c-a7f4-63d06f73e2ab.png)

This adds a 'Go to definition' button for modules and methods; it also adds all methods as children to their function.