### PR TITLE
Fix notebook output diagnostics

### DIFF
--- a/scripts/notebook/notebook.jl
+++ b/scripts/notebook/notebook.jl
@@ -1,23 +1,33 @@
-@info "Starting notebook kernel server"
+println(Base.stderr, "Starting notebook kernel server")
 
 pushfirst!(LOAD_PATH, joinpath(@__DIR__, "..", "packages"))
 using VSCodeServer
 popfirst!(LOAD_PATH)
 
-@info "Core notebook support loaded"
+println(Base.stderr, "Core notebook support loaded")
 
 using InteractiveUtils
 
 let
+    outputchannel_logger = Base.CoreLogging.SimpleLogger(Base.stderr)
+
+    Base.with_logger(outputchannel_logger) do
+        @info "Processing command line arguments..."
+    end
+
     args = [popfirst!(Base.ARGS) for _ in 1:2]
 
     conn_pipeline, telemetry_pipeline = args[1:2]
 
+    Base.with_logger(outputchannel_logger) do
+        @info "Command line arguments processed"
+    end
+
     ccall(:jl_exit_on_sigint, Nothing, (Cint,), false)
 
-    outputchannel_logger = Base.CoreLogging.SimpleLogger(Base.stderr)
-
-    @info "Handing things off to VSCodeServer.serve_notebook"
+    Base.with_logger(outputchannel_logger) do
+        @info "Handing things off to VSCodeServer.serve_notebook"
+    end
 
     VSCodeServer.serve_notebook(conn_pipeline, outputchannel_logger, crashreporting_pipename=telemetry_pipeline)
 end


### PR DESCRIPTION
This is purely aethetic, the old version of the code ended up using escape sequences which are not supported in output channels.