### PR TITLE
Fix a readonly problem

### DIFF
--- a/src/notebook/notebookKernel.ts
+++ b/src/notebook/notebookKernel.ts
@@ -166,7 +166,7 @@ export class JuliaKernel {
                 this.notebook.uri.scheme === 'file' &&
                 vscode.workspace.getWorkspaceFolder(this.notebook.uri) !== undefined
             ) {
-                let currentFolder = path.dirname(this.notebook.uri.fsPath)
+                let currentFolder = path.dirname(vscode.Uri.parse(this.notebook.uri.toString()).fsPath)
 
                 // We run this loop until we are looking at a folder that is no longer part of the workspace
                 while (


### PR DESCRIPTION
This might fix a crash report. It seems that accessing the `fsPath` file tries to manipulate the uri instance, but it is read only or something like that...