### PR TITLE
Fix a case where missing introduces 3VL

### DIFF
--- a/scripts/packages/VSCodeServer/src/trees.jl
+++ b/scripts/packages/VSCodeServer/src/trees.jl
@@ -277,7 +277,7 @@ function getvariables()
         !isdefined(M, n) && continue
         Base.isdeprecated(M, n) && continue
 
-        x = getfield(M, n)
+        x = coalesce(getfield(M, n), nothing)
         x in (
             vscodedisplay,
             VSCodeServer,

--- a/scripts/packages/VSCodeServer/src/trees.jl
+++ b/scripts/packages/VSCodeServer/src/trees.jl
@@ -277,8 +277,8 @@ function getvariables()
         !isdefined(M, n) && continue
         Base.isdeprecated(M, n) && continue
 
-        x = coalesce(getfield(M, n), nothing)
-        x in (
+        x = getfield(M, n)
+        x !== missing && x in (
             vscodedisplay,
             VSCodeServer,
             Main,


### PR DESCRIPTION
I think technically we would actually need to special case handle _any_ case anywhere in our code base where we take any value from a user provided function and turn it into a boolean via some function that one would expect to return  a bool... But this at least fixes one case that showed up in crash reporting.