### PR TITLE
Workspace: Add toggle to hide modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -425,15 +425,11 @@
             },
             {
                 "command": "language-julia.showModules",
-                "title": "Julia: Show modules in Workspace",
-                "shortTitle": "Show modules",
-                "icon": "$(debug-stop)"
+                "title": "Show modules in Workspace"
             },
             {
                 "command": "language-julia.hideModules",
-                "title": "Julia: Hide modules in Workspace",
-                "shortTitle": "Hide modules",
-                "icon": "$(debug-restart)"
+                "title": "Hide modules in Workspace"
             }
         ],
         "menus": {
@@ -667,12 +663,12 @@
                 {
                     "command": "language-julia.showModules",
                     "when": "view == REPLVariables && julia.showingModules == false",
-                    "group": "navigation"
+                    "group": "menu"
                 },
                 {
                     "command": "language-julia.hideModules",
                     "when": "view == REPLVariables && julia.showingModules == true",
-                    "group": "navigation"
+                    "group": "menu"
                 }
             ],
             "editor/context": [
@@ -706,6 +702,14 @@
                 },
                 {
                     "command": "language-julia.stopKernel",
+                    "when": "false"
+                },
+                {
+                    "command": "language-julia.showModules",
+                    "when": "false"
+                },
+                {
+                    "command": "language-julia.hideModules",
                     "when": "false"
                 }
             ],

--- a/package.json
+++ b/package.json
@@ -422,6 +422,18 @@
                 "command": "language-julia.stopKernel",
                 "title": "Stop",
                 "icon": "$(debug-stop)"
+            },
+            {
+                "command": "language-julia.showModules",
+                "title": "Julia: Show modules in Workspace",
+                "shortTitle": "Show modules",
+                "icon": "$(debug-stop)"
+            },
+            {
+                "command": "language-julia.hideModules",
+                "title": "Julia: Hide modules in Workspace",
+                "shortTitle": "Hide modules",
+                "icon": "$(debug-restart)"
             }
         ],
         "menus": {
@@ -650,6 +662,16 @@
                 {
                     "command": "language-julia.enable-compiled-mode",
                     "when": "view == debugger-compiled && juliaCompiledMode == false",
+                    "group": "navigation"
+                },
+                {
+                    "command": "language-julia.showModules",
+                    "when": "view == REPLVariables && julia.showingModules == false",
+                    "group": "navigation"
+                },
+                {
+                    "command": "language-julia.hideModules",
+                    "when": "view == REPLVariables && julia.showingModules == true",
                     "group": "navigation"
                 }
             ],

--- a/scripts/packages/VSCodeServer/src/repl_protocol.jl
+++ b/scripts/packages/VSCodeServer/src/repl_protocol.jl
@@ -98,7 +98,7 @@ end
 
 const repl_runcode_request_type = JSONRPC.RequestType("repl/runcode", ReplRunCodeRequestParams, ReplRunCodeRequestReturn)
 const repl_interrupt_notification_type = JSONRPC.NotificationType("repl/interrupt", Nothing)
-const repl_getvariables_request_type = JSONRPC.RequestType("repl/getvariables", Nothing, Vector{ReplWorkspaceItem})
+const repl_getvariables_request_type = JSONRPC.RequestType("repl/getvariables", NamedTuple{(:modules,),Tuple{Bool}}, Vector{ReplWorkspaceItem})
 const repl_getlazy_request_type = JSONRPC.RequestType("repl/getlazy", NamedTuple{(:id,),Tuple{Int}}, Vector{ReplWorkspaceItem})
 const repl_showingrid_notification_type = JSONRPC.NotificationType("repl/showingrid", NamedTuple{(:code,),Tuple{String}})
 const repl_loadedModules_request_type = JSONRPC.RequestType("repl/loadedModules", Nothing, Vector{String})

--- a/scripts/packages/VSCodeServer/src/trees.jl
+++ b/scripts/packages/VSCodeServer/src/trees.jl
@@ -266,10 +266,7 @@ end
 
 # workspace
 
-repl_getvariables_request(conn, params) = begin
-    @show params
-    Base.invokelatest(getvariables, params.modules)
-end
+repl_getvariables_request(conn, params::NamedTuple{(:modules,),Tuple{Bool}}) =  Base.invokelatest(getvariables, params.modules)
 
 function getvariables(show_modules)
     M = Main

--- a/scripts/packages/VSCodeServer/src/trees.jl
+++ b/scripts/packages/VSCodeServer/src/trees.jl
@@ -266,9 +266,12 @@ end
 
 # workspace
 
-repl_getvariables_request(conn, params::Nothing) = Base.invokelatest(getvariables)
+repl_getvariables_request(conn, params) = begin
+    @show params
+    Base.invokelatest(getvariables, params.modules)
+end
 
-function getvariables()
+function getvariables(show_modules)
     M = Main
     variables = ReplWorkspaceItem[]
     clear_lazy()
@@ -285,6 +288,8 @@ function getvariables()
             Main.include,
             Main.eval
         )) && continue
+
+        !show_modules && x isa Module && continue
 
         s = string(n)
         startswith(s, "#") && continue

--- a/src/interactive/workspace.ts
+++ b/src/interactive/workspace.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import * as rpc from 'vscode-jsonrpc'
 import { JuliaKernel } from '../notebook/notebookKernel'
-import { registerCommand } from '../utils'
+import { registerCommand, setContext } from '../utils'
 import { displayPlot } from './plots'
 import {
     notifyTypeDisplay,
@@ -31,7 +31,7 @@ interface WorkspaceVariable {
 }
 
 const requestTypeGetVariables = new rpc.RequestType<
-    void,
+    { modules: boolean },
     WorkspaceVariable[],
     void
 >('repl/getvariables')
@@ -49,6 +49,12 @@ abstract class AbstractWorkspaceNode {
 }
 
 abstract class SessionNode extends AbstractWorkspaceNode {
+    _showModules = true
+
+    public toggleModules(show) {
+        this._showModules = show
+    }
+
     public abstract getConnection()
 }
 
@@ -69,7 +75,7 @@ export class NotebookNode extends SessionNode {
     async updateReplVariables() {
         const variables = await this.kernel._msgConnection.sendRequest(
             requestTypeGetVariables,
-            undefined
+            { modules: this._showModules }
         )
         this.variablesNodes = variables.map((i) => new VariableNode(this, i))
 
@@ -120,7 +126,7 @@ class REPLNode extends SessionNode {
         const variables: WorkspaceVariable[] =
             await this.getConnection().sendRequest(
                 requestTypeGetVariables,
-                undefined
+                { modules: this._showModules }
             )
         this.variablesNodes = variables.map((v) => new VariableNode(this, v))
 
@@ -161,10 +167,11 @@ export class WorkspaceFeature {
     _REPLTreeDataProvider: REPLTreeDataProvider
 
     _REPLNode: REPLNode
-    _NotebokNodes: NotebookNode[] = []
+    _NotebookNodes: NotebookNode[] = []
 
     constructor(private context: vscode.ExtensionContext) {
         this._REPLTreeDataProvider = new REPLTreeDataProvider(this)
+        setContext('julia.showingModules', true)
 
         this.context.subscriptions.push(
             // registries
@@ -181,6 +188,12 @@ export class WorkspaceFeature {
             ),
             registerCommand('language-julia.workspaceGoToFile', (node: VariableNode) =>
                 this.openLocation(node)
+            ),
+            registerCommand('language-julia.showModules', () =>
+                this._REPLTreeDataProvider.toggleModules(true)
+            ),
+            registerCommand('language-julia.hideModules', () =>
+                this._REPLTreeDataProvider.toggleModules(false)
             )
         )
     }
@@ -212,14 +225,14 @@ export class WorkspaceFeature {
 
     public async addNotebookKernel(kernel: JuliaKernel) {
         const node = new NotebookNode(kernel, this._REPLTreeDataProvider)
-        this._NotebokNodes.push(node)
+        this._NotebookNodes.push(node)
         kernel.onCellRunFinished((e) => node.updateReplVariables())
         kernel.onConnected((e) => {
             kernel._msgConnection.onNotification(notifyTypeDisplay, (params) => displayPlot(params, kernel))
             node.updateReplVariables()
         })
         kernel.onStopped((e) => {
-            this._NotebokNodes = this._NotebokNodes.filter(x => x !== node)
+            this._NotebookNodes = this._NotebookNodes.filter(x => x !== node)
             this._REPLTreeDataProvider.refresh()
         })
         this._REPLTreeDataProvider.refresh()
@@ -236,7 +249,7 @@ implements vscode.TreeDataProvider<AbstractWorkspaceNode>
         AbstractWorkspaceNode | undefined
     > = this._onDidChangeTreeData.event
 
-    constructor(private workspaceFeautre: WorkspaceFeature) { }
+    constructor(private workspaceFeature: WorkspaceFeature) { }
 
     refresh(): void {
         this._onDidChangeTreeData.fire(undefined)
@@ -246,13 +259,13 @@ implements vscode.TreeDataProvider<AbstractWorkspaceNode>
         if (node) {
             return await node.getChildren()
         } else {
-            if (this.workspaceFeautre._REPLNode) {
+            if (this.workspaceFeature._REPLNode) {
                 return [
-                    this.workspaceFeautre._REPLNode,
-                    ...this.workspaceFeautre._NotebokNodes,
+                    this.workspaceFeature._REPLNode,
+                    ...this.workspaceFeature._NotebookNodes,
                 ]
             } else {
-                return [...this.workspaceFeautre._NotebokNodes]
+                return [...this.workspaceFeature._NotebookNodes]
             }
         }
     }
@@ -289,5 +302,15 @@ implements vscode.TreeDataProvider<AbstractWorkspaceNode>
             treeItem.collapsibleState = vscode.TreeItemCollapsibleState.Expanded
             return treeItem
         }
+    }
+
+    toggleModules(show: boolean) {
+        this.workspaceFeature._REPLNode.toggleModules(show)
+        this.workspaceFeature._REPLNode.updateReplVariables()
+        this.workspaceFeature._NotebookNodes.forEach(node => {
+            node.toggleModules(show)
+            node.updateReplVariables()
+        })
+        setContext('julia.showingModules', show)
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6735977/167820543-97870c50-687b-44b9-bb1d-b3c5a35f6ecf.png)

Ideally this would use a toggleable menu entry, but those aren't available to extensions atm (ref https://github.com/microsoft/vscode/issues/148633).
