### PR TITLE
Make inline result and profiler colors themable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1082,12 +1082,6 @@
                         "Shows inline execution results in REPL and inline bubbles"
                     ]
                 },
-                "julia.execution.inlineResults.colors": {
-                    "type": "object",
-                    "default": {},
-                    "markdownDescription": "Customizes the colors of inline results when they are displayed in the editor. \n* Available keys for this setting are : \n\t* `foreground`: foreground text color\n\t* `foreground-light`: foreground text color in light themes \n\t* `foreground-dark`: foreground text color in dark themes\n\t* `background`: background color\n\t* `background-light`: background color in light themes\n\t* `background-dark`: background color in dark themes\n\t* `accent`: accent color for normal execution results\n\t* `accent-error`: accent color for error execution results \n* Accepted values are: \n\t* valid CSS color strings\n\t* VS Code [Theme Colors](https://code.visualstudio.com/api/references/theme-color), prefixed by `vscode.` (i.e. `vscode.editor.foreground`)",
-                    "scope": "window"
-                },
                 "julia.execution.codeInREPL": {
                     "type": "boolean",
                     "default": false,
@@ -1382,6 +1376,78 @@
                 ],
                 "variables": {
                     "activeJuliaEnvironment": "language-julia.debug.getActiveJuliaEnvironment"
+                }
+            }
+        ],
+        "colors": [
+            {
+                "id": "julia.result.foreground",
+                "description": "Result text color.",
+                "defaults": {
+                    "dark": "editor.foreground",
+                    "light": "editor.foreground",
+                    "highContrast": "editor.foreground",
+                    "highContrastLight": "editor.foreground"
+                }
+            },
+            {
+                "id": "julia.result.background",
+                "description": "Result background color.",
+                "defaults": {
+                    "dark": "#ffffff22",
+                    "light": "#00000011",
+                    "highContrast": "#ffffff22",
+                    "highContrastLight": "#00000011"
+                }
+            },
+            {
+                "id": "julia.result.success",
+                "description": "Accent color for non-error results.",
+                "defaults": {
+                    "dark": "#159eed",
+                    "light": "#159eed",
+                    "highContrast": "#159eed",
+                    "highContrastLight": "#159eed"
+                }
+            },
+            {
+                "id": "julia.result.error",
+                "description": "Accent color for error results.",
+                "defaults": {
+                    "dark": "#d11111",
+                    "light": "#d11111",
+                    "highContrast": "#d11111",
+                    "highContrastLight": "#d11111"
+                }
+            },
+            {
+                "id": "julia.profiler.dispatch",
+                "description": "Inline profiler color for traces with dynamic dispatch.",
+                "defaults": {
+                    "dark": "#cc676732",
+                    "light": "#cc676732",
+                    "highContrast": "#cc676732",
+                    "highContrastLight": "#cc676732"
+                }
+            },
+            {
+                "id": "julia.profiler.gc",
+                "description": "Inline profiler color for traces with GC events/allocations.",
+                "defaults": {
+                    "dark": "#cc994432",
+                    "light": "#cc994432",
+                    "highContrast": "#cc994432",
+                    "highContrastLight": "#cc994432"
+                }
+            },
+            {
+                "id": "julia.profiler.default",
+                "description": "Default inline profiler color.",
+                "defaults": {
+                    "dark": "#4063dd32",
+                    "light": "#4063dd32",
+                    "highContrast": "#4063dd32",
+                    "highContrastLight": "#4063dd32"
                 }
             }
         ]

--- a/src/interactive/profiler.ts
+++ b/src/interactive/profiler.ts
@@ -129,12 +129,12 @@ export class ProfilerFeature {
     inlineTraceColor(highlight: InlineTraceElement | number) {
         const flags = typeof highlight === 'number' ? highlight : highlight.flags
         if (flags & 0x01) {
-            return 'rgba(204, 103, 103, 0.2)'
+            return new vscode.ThemeColor('julia.profiler.dispatch')
         }
         if (flags & 0x02) {
-            return 'rgba(204, 153, 68, 0.2)'
+            return new vscode.ThemeColor('julia.profiler.gc')
         }
-        return 'rgba(64, 99, 221, 0.2)'
+        return new vscode.ThemeColor('julia.profiler.default')
     }
 
     collateTrace(editors: readonly vscode.TextEditor[]) {

--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -85,50 +85,21 @@ export class Result {
     }
 
     createResultDecoration(): vscode.DecorationRenderOptions {
-
-        const section = vscode.workspace.getConfiguration('julia')
-        const colorConfig = section.get<object>('execution.inlineResults.colors')
-
-        const colorFor = function (candidates: string[], defaultTo: string | vscode.ThemeColor): string | vscode.ThemeColor {
-            if (candidates.length > 0) {
-                if (colorConfig && colorConfig[candidates[0]]) {
-                    const color: string = colorConfig[candidates[0]]
-                    return color.startsWith('vscode.') ? new vscode.ThemeColor(color.replace(/^(vscode\.)/, '')) : color
-                } else {
-                    return colorFor(candidates.slice(1), defaultTo)
-                }
-            } else {
-                return defaultTo
-            }
-        }
-
         const accentColor = this.content.isError
-            ? colorFor(['accent-error'], '#d11111')
-            : colorFor(['accent'], '#159eed')
+            ? new vscode.ThemeColor('julia.result.success')
+            : new vscode.ThemeColor('julia.result.error')
 
         return {
             before: {
                 contentIconPath: undefined,
                 contentText: undefined,
-                color: colorFor(['foreground'], new vscode.ThemeColor('editor.foreground')),
-                backgroundColor: colorFor(['background'], '#ffffff22'),
+                color: new vscode.ThemeColor('julia.result.foreground'),
+                backgroundColor: new vscode.ThemeColor('julia.result.background'),
                 margin: '0 0 0 10px',
                 border: '2px solid',
                 borderColor: accentColor,
                 // HACK: CSS injection to get custom styling in:
                 textDecoration: 'none; white-space: pre; border-top: 0px; border-right: 0px; border-bottom: 0px; border-radius: 2px'
-            },
-            dark: {
-                before: {
-                    color: colorFor(['foreground-dark', 'foreground'], new vscode.ThemeColor('editor.foreground')),
-                    backgroundColor: colorFor(['background-dark', 'background'], '#ffffff22')
-                }
-            },
-            light: {
-                before: {
-                    color: colorFor(['foreground-light', 'foreground'], new vscode.ThemeColor('editor.foreground')),
-                    backgroundColor: colorFor(['background-light', 'background'], '#00000011')
-                }
             },
             rangeBehavior: vscode.DecorationRangeBehavior.OpenClosed,
         }


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/2883. 

Also removes the inline result color settings in favor of the colors contribution point (which means that themes can specifically style our inline results).