### PR TITLE
Use await for all sendNotification calls

### DIFF
--- a/src/debugger/juliaDebug.ts
+++ b/src/debugger/juliaDebug.ts
@@ -177,7 +177,7 @@ export class JuliaDebugSession extends LoggingDebugSession {
         // await this._configurationDone.wait(1000);
         await this._configurationDone.wait()
 
-        this._connection.sendNotification(notifyTypeExec, {
+        await this._connection.sendNotification(notifyTypeExec, {
             stopOnEntry: args.stopOnEntry,
             code: args.code,
             file: args.file,
@@ -287,9 +287,9 @@ export class JuliaDebugSession extends LoggingDebugSession {
         this._launchedWithoutDebug = args.noDebug ?? false
 
         if (args.noDebug) {
-            this._connection.sendNotification(notifyTypeRun, { program: args.program })
+            await this._connection.sendNotification(notifyTypeRun, { program: args.program })
         } else {
-            this._connection.sendNotification(notifyTypeDebug, {
+            await this._connection.sendNotification(notifyTypeDebug, {
                 stopOnEntry: args.stopOnEntry ?? false,
                 program: args.program,
                 compiledModulesOrFunctions: args.compiledModulesOrFunctions,
@@ -465,9 +465,9 @@ export class JuliaDebugSession extends LoggingDebugSession {
 
     protected async customRequest(request: string, response: any, args: any) {
         if (request === 'setCompiledItems') {
-            this._connection.sendNotification(notifyTypeSetCompiledItems, args)
+            await this._connection.sendNotification(notifyTypeSetCompiledItems, args)
         } else if (request === 'setCompiledMode') {
-            this._connection.sendNotification(notifyTypeSetCompiledMode, args)
+            await this._connection.sendNotification(notifyTypeSetCompiledMode, args)
         }
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -333,10 +333,10 @@ async function startLanguageServer(juliaExecutablesFeature: JuliaExecutablesFeat
     g_watchedEnvironmentFile = (await jlpkgenv.getProjectFilePaths(jlEnvPath)).manifest_toml_path
     // polling watch for robustness
     if (g_watchedEnvironmentFile) {
-        watchFile(g_watchedEnvironmentFile, { interval: 10000 }, (curr, prev) => {
+        watchFile(g_watchedEnvironmentFile, { interval: 10000 }, async (curr, prev) => {
             if (curr.mtime > prev.mtime) {
                 if (!languageClient.needsStop()) { return } // this client already gets stopped
-                refreshLanguageServer(languageClient)
+                await refreshLanguageServer(languageClient)
             }
         })
     }
@@ -357,10 +357,10 @@ async function startLanguageServer(juliaExecutablesFeature: JuliaExecutablesFeat
     g_startupNotification.hide()
 }
 
-function refreshLanguageServer(languageClient: LanguageClient = g_languageClient) {
+async function refreshLanguageServer(languageClient: LanguageClient = g_languageClient) {
     if (!languageClient) { return }
     try {
-        languageClient.sendNotification('julia/refreshLanguageServer')
+        await languageClient.sendNotification('julia/refreshLanguageServer')
     } catch (err) {
         vscode.window.showErrorMessage('Failed to refresh the language server cache.', {
             detail: err

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -991,10 +991,10 @@ export async function executeInREPL(code: string, { filename = 'code', line = 0,
 
 const interrupts = []
 let last_interrupt_index = -1
-function interrupt() {
+async function interrupt() {
     telemetry.traceEvent('command-interrupt')
     // always send out internal interrupt
-    softInterrupt()
+    await softInterrupt()
     // but we'll try sending a SIGINT if more than 3 interrupts were sent in the last second
     last_interrupt_index = (last_interrupt_index + 1) % 5
     interrupts[last_interrupt_index] = new Date()
@@ -1004,9 +1004,9 @@ function interrupt() {
     }
 }
 
-function softInterrupt() {
+async function softInterrupt() {
     try {
-        g_connection.sendNotification('repl/interrupt')
+        await g_connection.sendNotification('repl/interrupt')
     } catch (err) {
         console.warn(err)
     }
@@ -1034,7 +1034,7 @@ async function cdToHere(uri: vscode.Uri) {
     await startREPL(true, false)
     if (uriPath) {
         try {
-            g_connection.sendNotification('repl/cd', { uri: uriPath })
+            await g_connection.sendNotification('repl/cd', { uri: uriPath })
         } catch (err) {
             console.log(err)
         }
@@ -1052,7 +1052,7 @@ async function activatePath(path: string) {
     await startREPL(true, false)
     if (path) {
         try {
-            g_connection.sendNotification('repl/activateProject', { uri: path })
+            await g_connection.sendNotification('repl/activateProject', { uri: path })
             switchEnvToPath(path, true)
         } catch (err) {
             console.log(err)
@@ -1159,7 +1159,7 @@ function updateCellDelimiters() {
 export async function replStartDebugger(pipename: string) {
     await startREPL(true)
 
-    g_connection.sendNotification(notifyTypeReplStartDebugger, { debugPipename: pipename })
+    await g_connection.sendNotification(notifyTypeReplStartDebugger, { debugPipename: pipename })
 }
 
 export function activate(context: vscode.ExtensionContext, compiledProvider, juliaExecutablesFeature: JuliaExecutablesFeature, profilerFeature) {
@@ -1207,22 +1207,22 @@ export function activate(context: vscode.ExtensionContext, compiledProvider, jul
             clearProgress()
             setContext('isJuliaEvaluating', false)
         }),
-        vscode.workspace.onDidChangeConfiguration(event => {
+        vscode.workspace.onDidChangeConfiguration(async event => {
             if (event.affectsConfiguration('julia.usePlotPane')) {
                 try {
-                    g_connection.sendNotification('repl/togglePlotPane', { enable: vscode.workspace.getConfiguration('julia').get('usePlotPane') })
+                    await g_connection.sendNotification('repl/togglePlotPane', { enable: vscode.workspace.getConfiguration('julia').get('usePlotPane') })
                 } catch (err) {
                     console.warn(err)
                 }
             } else if (event.affectsConfiguration('julia.useProgressFrontend')) {
                 try {
-                    g_connection.sendNotification('repl/toggleProgress', { enable: vscode.workspace.getConfiguration('julia').get('useProgressFrontend') })
+                    await g_connection.sendNotification('repl/toggleProgress', { enable: vscode.workspace.getConfiguration('julia').get('useProgressFrontend') })
                 } catch (err) {
                     console.warn(err)
                 }
             } else if (event.affectsConfiguration('julia.showRuntimeDiagnostics')) {
                 try {
-                    g_connection.sendNotification('repl/toggleDiagnostics', { enable: vscode.workspace.getConfiguration('julia').get('showRuntimeDiagnostics') })
+                    await g_connection.sendNotification('repl/toggleDiagnostics', { enable: vscode.workspace.getConfiguration('julia').get('showRuntimeDiagnostics') })
                 } catch (err) {
                     console.warn(err)
                 }

--- a/src/interactive/tables.ts
+++ b/src/interactive/tables.ts
@@ -37,9 +37,9 @@ export function displayTable(payload, context, isLazy = false, kernel?: JuliaKer
     if (isLazy) {
         const objectId = parsedPayload.id
 
-        panel.onDidDispose(() => {
+        panel.onDidDispose(async () => {
             try {
-                g_connection.sendNotification(
+                await g_connection.sendNotification(
                     clearLazyTable,
                     {
                         id: objectId

--- a/src/interactive/workspace.ts
+++ b/src/interactive/workspace.ts
@@ -155,7 +155,7 @@ class VariableNode extends AbstractWorkspaceNode {
     }
 
     public async showInVSCode() {
-        this.parentREPL
+        await this.parentREPL
             .getConnection()
             .sendNotification(notifyTypeReplShowInGrid, {
                 code: this.workspaceVariable.head,

--- a/src/jlpkgenv.ts
+++ b/src/jlpkgenv.ts
@@ -104,7 +104,7 @@ export async function switchEnvToPath(envpath: string, notifyLS: boolean) {
         if (!g_languageClient) {
             return
         }
-        g_languageClient.sendNotification('julia/activateenvironment', { envPath: envpath })
+        await g_languageClient.sendNotification('julia/activateenvironment', { envPath: envpath })
     }
 }
 


### PR DESCRIPTION
`sendNotification` now returns a promise, so we can actually catch errors if a notification can't be written to the underlying transport because it was already closed or something like that.