### PR TITLE
Fix type for default in `julia.deleteJuliaCovFiles`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1150,7 +1150,7 @@
                 },
                 "julia.deleteJuliaCovFiles": {
                     "type": "boolean",
-                    "default": "true",
+                    "default": true,
                     "description": "Delete Julia .cov files when running tests with coverage, leaving only a .lcov file behind.",
                     "scope": "window"
                 },


### PR DESCRIPTION
Tiny change - the type of `julia.deleteJuliaCovFiles`` is specified as boolean, but default was assigned to string.

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs. - not required
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR. - not required
