### PR TITLE
Various shell integration fixes

### DIFF
--- a/scripts/packages/VSCodeServer/src/eval.jl
+++ b/scripts/packages/VSCodeServer/src/eval.jl
@@ -155,6 +155,7 @@ function repl_runcode_request(conn, params::ReplRunCodeRequestParams)::ReplRunCo
                     println(line)
                 end
                 print(stdout, SHELL.output_start())
+                print(stdout, SHELL.update_cmd(source_code))
             end
 
             return withpath(source_filename) do

--- a/scripts/packages/VSCodeServer/src/repl.jl
+++ b/scripts/packages/VSCodeServer/src/repl.jl
@@ -86,7 +86,7 @@ const SHELL = (
             ""
         else
             exitcode = LAST_REPL_EVAL_ERRORED[]
-            LAST_REPL_EVAL_ERRORED[] === nothing
+            LAST_REPL_EVAL_ERRORED[] = nothing
             "\e]633;D;$(Int(exitcode))\a"
         end
     end),


### PR DESCRIPTION
- mutli-line inputs now work properly thanks to 633 E
- prompt refreshs now don't print multiple decorations (e.g. when deleting code)

![Peek 2022-07-18 21-15](https://user-images.githubusercontent.com/6735977/179599954-5872381c-201f-4046-80e7-5112f6ac9ee6.gif)
![Peek 2022-07-18 20-58](https://user-images.githubusercontent.com/6735977/179583662-fbe3a83d-ae7c-4f12-9051-837cc916243a.gif)

Ref https://github.com/microsoft/vscode/issues/155315.