### PR TITLE
Added missing parentheses in "when" clauses of keybindings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 * `Assigned but not used` linter annotations are now slightly more correct ([#339](https://github.com/julia-vscode/StaticLint.jl/pull/339))
 * Actually fixed that issue with copying `Expr`s while debugging ([#60](https://github.com/julia-vscode/DebugAdapter.jl/pull/60))
+* Fixed `when` clauses of some keybindings that caused incorrect matches when `editorLangId != julia` ([#2971](https://github.com/julia-vscode/julia-vscode/pull/2971))
 
 ## [1.6.25] - 2022-06-17
 ### Changed

--- a/package.json
+++ b/package.json
@@ -674,7 +674,7 @@
             "editor/context": [
                 {
                     "command": "language-julia.executeCodeBlockOrSelection",
-                    "when": "activeEditor != workbench.editor.notebook && editorLangId == julia || editorLangId == juliamarkdown",
+                    "when": "activeEditor != workbench.editor.notebook && (editorLangId == julia || editorLangId == juliamarkdown)",
                     "group": "z_commands"
                 },
                 {
@@ -724,22 +724,22 @@
             {
                 "command": "language-julia.executeCodeBlockOrSelectionAndMove",
                 "key": "Shift+Enter",
-                "when": "editorTextFocus && activeEditor != workbench.editor.notebook && editorLangId == julia || editorLangId == juliamarkdown || editorLangId == markdown"
+                "when": "editorTextFocus && activeEditor != workbench.editor.notebook && (editorLangId == julia || editorLangId == juliamarkdown || editorLangId == markdown)"
             },
             {
                 "command": "language-julia.executeCodeBlockOrSelection",
                 "key": "Ctrl+Enter",
-                "when": "editorTextFocus && activeEditor != workbench.editor.notebook && editorLangId == julia || editorLangId == juliamarkdown || editorLangId == markdown"
+                "when": "editorTextFocus && activeEditor != workbench.editor.notebook && (editorLangId == julia || editorLangId == juliamarkdown || editorLangId == markdown)"
             },
             {
                 "command": "language-julia.executeCell",
                 "key": "Alt+Enter",
-                "when": "editorTextFocus && activeEditor != workbench.editor.notebook && editorLangId == julia || editorLangId == juliamarkdown || editorLangId == markdown"
+                "when": "editorTextFocus && activeEditor != workbench.editor.notebook && (editorLangId == julia || editorLangId == juliamarkdown || editorLangId == markdown)"
             },
             {
                 "command": "language-julia.executeCellAndMove",
                 "key": "Alt+Shift+Enter",
-                "when": "editorTextFocus && activeEditor != workbench.editor.notebook && editorLangId == julia || editorLangId == juliamarkdown || editorLangId == markdown"
+                "when": "editorTextFocus && activeEditor != workbench.editor.notebook && (editorLangId == julia || editorLangId == juliamarkdown || editorLangId == markdown)"
             },
             {
                 "command": "language-julia.interrupt",
@@ -749,17 +749,17 @@
             {
                 "command": "language-julia.clearCurrentInlineResult",
                 "key": "Escape",
-                "when": "editorTextFocus && !editorHasSelection && !findWidgetVisible && !markerNavigationVisible && !parameterHintsVisible && !inSnippetMode && !isInEmbeddedEditor && !suggestWidgetVisible && !onTypeRenameInputVisible && !renameInputVisible && juliaHasInlineResult && editorLangId == julia || editorLangId == juliamarkdown || editorLangId == markdown"
+                "when": "editorTextFocus && !editorHasSelection && !findWidgetVisible && !markerNavigationVisible && !parameterHintsVisible && !inSnippetMode && !isInEmbeddedEditor && !suggestWidgetVisible && !onTypeRenameInputVisible && !renameInputVisible && juliaHasInlineResult && (editorLangId == julia || editorLangId == juliamarkdown || editorLangId == markdown)"
             },
             {
                 "command": "language-julia.clearAllInlineResultsInEditor",
                 "key": "Ctrl+I Ctrl+C",
-                "when": "editorTextFocus && activeEditor != workbench.editor.notebook && editorLangId == julia || editorLangId == juliamarkdown || editorLangId == markdown"
+                "when": "editorTextFocus && activeEditor != workbench.editor.notebook && (editorLangId == julia || editorLangId == juliamarkdown || editorLangId == markdown)"
             },
             {
                 "command": "language-julia.chooseModule",
                 "key": "Alt+J Alt+M",
-                "when": "editorTextFocus && activeEditor != workbench.editor.notebook && editorLangId == julia || editorLangId == juliamarkdown || editorLangId == markdown"
+                "when": "editorTextFocus && activeEditor != workbench.editor.notebook && (editorLangId == julia || editorLangId == juliamarkdown || editorLangId == markdown)"
             },
             {
                 "command": "language-julia.newJuliaFile",
@@ -780,12 +780,12 @@
             {
                 "command": "language-julia.changeCurrentEnvironment",
                 "key": "Alt+J Alt+E",
-                "when": "editorTextFocus && activeEditor != workbench.editor.notebook && editorLangId == julia || editorLangId == juliamarkdown || editorLangId == markdown"
+                "when": "editorTextFocus && activeEditor != workbench.editor.notebook && (editorLangId == julia || editorLangId == juliamarkdown || editorLangId == markdown)"
             },
             {
                 "command": "language-julia.show-documentation",
                 "key": "Alt+J Alt+D",
-                "when": "editorTextFocus && activeEditor != workbench.editor.notebook && editorLangId == julia || editorLangId == juliamarkdown || editorLangId == markdown"
+                "when": "editorTextFocus && activeEditor != workbench.editor.notebook && (editorLangId == julia || editorLangId == juliamarkdown || editorLangId == markdown)"
             },
             {
                 "key": "Alt+J Alt+P",
@@ -794,11 +794,6 @@
             {
                 "key": "Alt+J Alt+W",
                 "command": "REPLVariables.focus"
-            },
-            {
-                "key": "escape",
-                "command": "language-julia.clearCurrentInlineResult",
-                "when": "editorTextFocus && juliaHasInlineResult && !editorHasSelection && !findWidgetVisible && !inSnippetMode && !isInEmbeddedEditor && !markerNavigationVisible && !onTypeRenameInputVisible && !parameterHintsVisible && !renameInputVisible && !suggestWidgetVisible && editorLangId == julia || editorLangId == juliamarkdown"
             },
             {
                 "key": "Ctrl+Shift+C",


### PR DESCRIPTION
Fixes #2970. (Maybe. Untested.)

The scope of this PR extends a bit beyond #2970. It motivated the fix to the keybinding for `Escape`, but in the process revealed what is likely a similar error for other keybindings.

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.
