### PR TITLE
More shell integration fixes

### DIFF
--- a/scripts/packages/VSCodeServer/src/repl.jl
+++ b/scripts/packages/VSCodeServer/src/repl.jl
@@ -85,6 +85,7 @@ const SHELL = (
         if REPL_PROMPT_STATE[] === REPLPromptStates.NoUpdate
             return ""
         elseif REPL_PROMPT_STATE[] === REPLPromptStates.NoStatus
+            REPL_PROMPT_STATE[] = REPLPromptStates.NoUpdate
             return "\e]633;D\a"
         else
             exitcode = REPL_PROMPT_STATE[] == REPLPromptStates.Error

--- a/scripts/terminalserver/terminalserver.jl
+++ b/scripts/terminalserver/terminalserver.jl
@@ -26,7 +26,7 @@ let
         end
     end
 
-    if "ENABLE_SHELL_INTEGRATION=true" in args && !Sys.iswindows()
+    if "ENABLE_SHELL_INTEGRATION=true" in args
         VSCodeServer.ENABLE_SHELL_INTEGRATION[] = true
     end
 


### PR DESCRIPTION
This is more correct, since it properly marks every prompt (exactly once).

It also enables shell integration on Windows (with a few conhost fixes enabled by `\e]633;P;IsWindows=True\a`), but the experience is still pretty wonky due to https://github.com/microsoft/terminal/issues/8698:
![image](https://user-images.githubusercontent.com/6735977/181909757-f3a59468-2932-4f7e-be28-7eb832ca1f86.png)
