### PR TITLE
simplify and optimze sorting a table view

### DIFF
--- a/scripts/packages/VSCodeServer/src/tables/filtering.jl
+++ b/scripts/packages/VSCodeServer/src/tables/filtering.jl
@@ -4,31 +4,12 @@ const SORTED_CACHE = Dict{UUID, UInt64}()
 col_access(row, col) = row[col]
 
 function generate_sorter(params, fixed_col_names)
-    lts = []
     for sortspec in params
-        let col = sortspec["colId"]
-            ind = findfirst(==(col), fixed_col_names)
-            if ind === nothing
-                continue
-            end
-            if sortspec["sort"] == "asc"
-                push!(lts, (r -> col_access(r, ind), (r1, r2) -> col_access(r1, ind) < col_access(r2, ind)))
-            else
-                push!(lts, (r -> col_access(r, ind), (r1, r2) -> !(col_access(r1, ind) < col_access(r2, ind))))
-            end
+        col = sortspec["colId"]
+        ind = findfirst(==(col), fixed_col_names)
+        if ind !== nothing
+            return (row -> col_access(row, ind)), sortspec["sort"] != "asc"
         end
-    end
-    function (row1, row2)
-        lt = false
-        for (accessor, ltf) in lts
-            if ltf(row1, row2)
-                return true
-            end
-            if accessor(row1) != accessor(row2)
-                return false
-            end
-        end
-        return lt
     end
 end
 

--- a/scripts/packages/VSCodeServer/src/tables/tableviewer.jl
+++ b/scripts/packages/VSCodeServer/src/tables/tableviewer.jl
@@ -230,8 +230,8 @@ function get_table_data(conn, params::GetTableDataRequest)
     will_sort = !isempty(params.sortModel)
 
     # this will only be called for medium-sized tables
+    filter_hash = hash(params.filterModel)
     if will_filter
-        filter_hash = hash(params.filterModel)
         # we have already filtered this table with the specified filterModel
         if haskey(FILTER_CACHE, id) && first(FILTER_CACHE[id]) == filter_hash
             table = last(FILTER_CACHE[id])
@@ -243,7 +243,7 @@ function get_table_data(conn, params::GetTableDataRequest)
         tablelength = length(table)
     end
     if will_sort
-        sort_hash = hash(params.sortModel)
+        sort_hash = hash((params.sortModel, filter_hash))
         if get(SORTED_CACHE, id, 0x0) != sort_hash
             sorter = generate_sorter(params.sortModel, fixed_col_names)
             if sorter !== nothing

--- a/scripts/packages/VSCodeServer/src/tables/tableviewer.jl
+++ b/scripts/packages/VSCodeServer/src/tables/tableviewer.jl
@@ -246,7 +246,9 @@ function get_table_data(conn, params::GetTableDataRequest)
         sort_hash = hash(params.sortModel)
         if get(SORTED_CACHE, id, 0x0) != sort_hash
             sorter = generate_sorter(params.sortModel, fixed_col_names)
-            Base.invokelatest(sort!, table, lt = sorter)
+            if sorter !== nothing
+                Base.invokelatest(sort!, table, by=sorter[1], rev=sorter[2])
+            end
             SORTED_CACHE[id] = sort_hash
         end
     end


### PR DESCRIPTION
When a user toggles a sort button on a table view, one semantic is to prepend that to the comparison function. i.e. sort by the most recently clicked sort breaking ties with less recently clicked sorts. This is equivalent to the semantic "when a user clicks a sort button, perform a stable sort according to that column". The latter phrasing lends itself better to eager sorting.

This can 
1) sort more quickly by using a simpler comparison function
2) sort more simply by storing history implicitly in the order of the table rather than explicitly

Somewhat orthogonally, this also fixes a minor issue where a filter change results in unsorted data being displayed despite having a sort selected.

It is probably possible to simplify `sortModel` because it now only needs to store the latest sort, but I couldn't find out where it is constructed. All I found was the declaration of `GetTableDataRequest`.

This PR is incompatible with lazy sorting via `partialsort`ing only what is displayed, but I don't think the perofrmance of partialsort is good enough to warrant doing that anyway.