### PR TITLE
Disable shell integration on Windows

### DIFF
--- a/scripts/terminalserver/terminalserver.jl
+++ b/scripts/terminalserver/terminalserver.jl
@@ -26,7 +26,7 @@ let
         end
     end
 
-    if "ENABLE_SHELL_INTEGRATION=true" in args
+    if !Sys.iswindows() && "ENABLE_SHELL_INTEGRATION=true" in args
         VSCodeServer.ENABLE_SHELL_INTEGRATION[] = true
     end
 


### PR DESCRIPTION
because it causes performance issues.