### PR TITLE
Fix a cancellation bug

### DIFF
--- a/src/interactive/completions.ts
+++ b/src/interactive/completions.ts
@@ -46,9 +46,15 @@ function completionItemProvider(conn: MessageConnection): vscode.CompletionItemP
                 const startPosition = new vscode.Position(position.line, 0)
                 const lineRange = new vscode.Range(startPosition, position)
                 const line = document.getText(lineRange)
+
                 const mod: string = await getModuleForEditor(document, position)
+                if(token.isCancellationRequested) { return }
+
+                const items = await conn.sendRequest(requestTypeGetCompletionItems, { line, mod })
+                if(token.isCancellationRequested) { return }
+
                 return {
-                    items: await conn.sendRequest(requestTypeGetCompletionItems, { line, mod }),
+                    items: items,
                     isIncomplete: true
                 }
             })()


### PR DESCRIPTION
This should fix a bug from crash reporting.

I need to look into how to do this properly one day, I would actually think that a function that detects that it is cancelled should throw an error, but I haven't really been able to confirm that... For now this should fix things, though.