### PR TITLE
Use `sprintlimited` instead of `strlimit`

### DIFF
--- a/scripts/packages/VSCodeServer/src/tables/tableviewer.jl
+++ b/scripts/packages/VSCodeServer/src/tables/tableviewer.jl
@@ -34,7 +34,7 @@ schema_type(::Type{T}) where {T<:Dates.DateTime} = "datetime"
 schema_type(::Type{T}) where {T<:AbstractString} = "string"
 
 julia_type(::Type{Union{}}) = nothing
-julia_type(::Type{T}) where {T} = strlimit(string(T); limit = 100)
+julia_type(::Type{T}) where {T} = sprintlimited(T; limit=100)
 
 ag_schema_type(::Type{Union{}}) = nothing
 ag_schema_type(::Type{T}) where {T} = nothing

--- a/scripts/packages/VSCodeServer/src/trees.jl
+++ b/scripts/packages/VSCodeServer/src/trees.jl
@@ -195,22 +195,22 @@ function treerender(err::Exception, bt)
     treerender(LazyTree(string("Internal Error: ", sprint(showerror, err)), wsicon(err), length(st) == 0, () -> [Leaf(sprint(show, x), wsicon(x)) for x in st], nothing))
 end
 
-treerender(x::Number) = treerender(Leaf(strlimit(repr(x), limit = 100), wsicon(x)))
-treerender(x::AbstractString) = treerender(Leaf(strlimit(repr(x), limit = 100), wsicon(x)))
-treerender(x::AbstractChar) = treerender(Leaf(strlimit(repr(x), limit = 100), wsicon(x)))
-treerender(x::Symbol) = treerender(Leaf(strlimit(repr(x), limit = 100), wsicon(x)))
-treerender(x::Nothing) = treerender(Leaf(strlimit(repr(x), limit = 100), wsicon(x)))
-treerender(x::Missing) = treerender(Leaf(strlimit(repr(x), limit = 100), wsicon(x)))
+treerender(x::Number) = treerender(Leaf(sprintlimited(x; limit=100), wsicon(x)))
+treerender(x::AbstractString) = treerender(Leaf(sprintlimited(x; limit=100), wsicon(x)))
+treerender(x::AbstractChar) = treerender(Leaf(sprintlimited(x; limit=100), wsicon(x)))
+treerender(x::Symbol) = treerender(Leaf(sprintlimited(x; limit=100), wsicon(x)))
+treerender(x::Nothing) = treerender(Leaf(sprintlimited(x; limit=100), wsicon(x)))
+treerender(x::Missing) = treerender(Leaf(sprintlimited(x; limit=100), wsicon(x)))
 treerender(x::Ptr) = treerender(Leaf(string(typeof(x), ": 0x", string(UInt(x), base = 16, pad = Sys.WORD_SIZE >> 2)), wsicon(x)))
 treerender(x::Text) = treerender(Leaf(x.content, wsicon(x)))
-treerender(x::Type) = treerender(Leaf(strlimit(string(x), limit = 100), wsicon(x)))
+treerender(x::Type) = treerender(Leaf(sprintlimited(x; limit=100), wsicon(x)))
 treerender(x::Undef) = treerender(Leaf("#undef", wsicon(x)))
 treerender(x::StackTraces.StackFrame) = treerender(Leaf(string(x), wsicon(x)))
 treerender(x::Enum) = treerender(Leaf(sprint(show, MIME"text/plain"(), x), wsicon(x)))
 
 function treerender(x::Function)
     treerender(LazyTree(
-        strlimit(string(x), limit=100),
+        sprintlimited(x; limit=100),
         wsicon(x),
         function ()
             try


### PR DESCRIPTION
because that eagerly aborts printing and is therefore less likely
to cause performance issues when objects with very large
representations are displayed in the workspace.