### PR TITLE
Always use shell when we exec julia on Unix

### DIFF
--- a/src/jlpkgenv.ts
+++ b/src/jlpkgenv.ts
@@ -82,7 +82,10 @@ export async function switchEnvToPath(envpath: string, notifyLS: boolean) {
                     println(false)
                 end`,
                 `${case_adjusted}`
-            ]
+            ],
+            {
+                shell: process.platform !== 'win32',
+            }
         )
 
         if (res.stdout.toString().trim() === 'false') {
@@ -200,7 +203,10 @@ async function getDefaultEnvPath() {
                 '--startup-file=no',
                 '--history-file=no',
                 '-e', 'using Pkg; println(dirname(Pkg.Types.Context().env.project_file))'
-            ])
+            ],
+            {
+                shell: process.platform !== 'win32',
+            })
         g_path_of_default_environment = res.stdout.toString().trim()
     }
     return g_path_of_default_environment

--- a/src/juliaexepath.ts
+++ b/src/juliaexepath.ts
@@ -42,7 +42,10 @@ export class JuliaExecutable {
                     '--history-file=no',
                     '-e',
                     'println(Sys.BINDIR)'
-                ]
+                ],
+                {
+                    shell: process.platform !== 'win32',
+                }
             )
 
             this._baseRootFolderPath = path.normalize(path.join(result.stdout.toString().trim(), '..', 'share', 'julia', 'base'))
@@ -98,7 +101,7 @@ export class JuliaExecutablesFeature {
                     parsedArgs = argv.slice(1)
                 }
             }
-            const { stdout, } = await execFile(parsedPath, [...parsedArgs, '--version'])
+            const { stdout, } = await execFile(parsedPath, [...parsedArgs, '--version'], {shell: process.platform !== 'win32',})
 
             const versionStringFromJulia = stdout.toString().trim()
 
@@ -200,7 +203,7 @@ export class JuliaExecutablesFeature {
     async tryJuliaup() {
         this.usingJuliaup = false
         try {
-            const { stdout, } = await execFile('juliaup', ['api', 'getconfig1'])
+            const { stdout, } =  await execFile('juliaup', ['api', 'getconfig1'], {shell: process.platform !== 'win32',})
 
             const apiResult = stdout.toString().trim()
 

--- a/src/notebook/notebookKernel.ts
+++ b/src/notebook/notebookKernel.ts
@@ -328,7 +328,8 @@ export class JuliaKernel {
                 ],
                 {
                     env,
-                    cwd: cwdPath
+                    cwd: cwdPath,
+                    shell: process.platform !== 'win32',
                 }
             )
 

--- a/src/packagepath.ts
+++ b/src/packagepath.ts
@@ -21,7 +21,10 @@ export async function getPkgPath() {
                 '--history-file=no',
                 '-e',
                 'using Pkg; println(Pkg.depots()[1])'
-            ]
+            ],
+            {
+                shell: process.platform !== 'win32',
+            }
         )
         juliaPackagePath = join(res.stdout.toString().trim(), 'dev')
     }
@@ -38,7 +41,10 @@ export async function getPkgDepotPath() {
                 '--history-file=no',
                 '-e',
                 'using Pkg; println.(Pkg.depots())'
-            ]
+            ],
+            {
+                shell: process.platform !== 'win32',
+            }
         )
         juliaDepotPath = res.stdout.toString().trim().split('\n')
     }

--- a/src/weave.ts
+++ b/src/weave.ts
@@ -65,7 +65,7 @@ async function weave_core(column, selected_format: string = undefined) {
     console.log(args)
 
     if (g_weaveNextChildProcess === null) {
-        g_weaveNextChildProcess = spawn(juliaExecutable.file, [...juliaExecutable.args, ...args])
+        g_weaveNextChildProcess = spawn(juliaExecutable.file, [...juliaExecutable.args, ...args], {shell: process.platform !== 'win32',})
     }
     g_weaveChildProcess = g_weaveNextChildProcess
 
@@ -80,7 +80,7 @@ async function weave_core(column, selected_format: string = undefined) {
         g_weaveOutputChannel.append(String('Weaving ' + source_filename + ' to ' + output_filename + '\n'))
     }
 
-    g_weaveNextChildProcess = spawn(juliaExecutable.file, [...juliaExecutable.args, ...args])
+    g_weaveNextChildProcess = spawn(juliaExecutable.file, [...juliaExecutable.args, ...args], {shell: process.platform !== 'win32',})
 
     g_weaveChildProcess.stdout.on('data', function (data) {
         g_weaveOutputChannel.append(String(data))


### PR DESCRIPTION
I think whenever we start a new Julia process, we actually should use a shell on Linux/Mac because there might be some startup script that actually modifies the `PATH` that is needed.

My understanding is that `createTerminal` does this automatically, so in a way we are just mimic that behavior here. It might be that `createTerminal` also uses a shell on Windows, but not sure. But in any case, it seems to me that on Windows we generally don't want to add that extra overhead.