### PR TITLE
Typo fix in the Package Server setting description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1099,7 +1099,7 @@
                 "julia.packageServer": {
                     "type": "string",
                     "default": "",
-                    "markdownDescription": "Julia package server. Set's the `JULIA_PKG_SERVER` environment variable *before* starting a Julia process. Leave this empty to use the systemwide default. Requires a restart of the Julia process.",
+                    "markdownDescription": "Julia package server. Sets the `JULIA_PKG_SERVER` environment variable *before* starting a Julia process. Leave this empty to use the systemwide default. Requires a restart of the Julia process.",
                     "scope": "machine-overridable"
                 },
                 "julia.liveTestFile": {


### PR DESCRIPTION
`s/Set's/Sets` — don't need an apostrophe there.