### PR TITLE
fix bug in extension.ts

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -237,11 +237,11 @@ async function startLanguageServer(juliaExecutablesFeature: JuliaExecutablesFeat
         jlEnvPath = await jlpkgenv.getAbsEnvPath()
     } catch (e) {
         vscode.window.showErrorMessage(
-            'Could not start the Julia language server. Make sure the `julia.environmentPath` setting is valid.',
+            'Could not start the Julia language server. Make sure the `julia.executablePath` setting is valid.',
             'Open Settings'
         ).then(val => {
             if (val) {
-                vscode.commands.executeCommand('workbench.action.openSettings', 'julia.environmentPath')
+                vscode.commands.executeCommand('workbench.action.openSettings', 'julia.executablePath')
             }
         })
         g_startupNotification.hide()


### PR DESCRIPTION
Fixes bug where the user is pointed to the vscode environmentPath setting when I believe they should be sent to executablePath.

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.

Not sure if this needs to be in the changelog. Can add if needed.