### PR TITLE
Check whether ls is ready in getmodule

### DIFF
--- a/src/interactive/modules.ts
+++ b/src/interactive/modules.ts
@@ -72,6 +72,7 @@ export async function getModuleForEditor(document: vscode.TextDocument, position
     const languageClient = g_languageClient
 
     if (!languageClient) { return 'Main' }
+    if (!languageClient.isRunning) { return 'Main' }
     try {
         const params: VersionedTextDocumentPositionParams = {
             textDocument: vslc.TextDocumentIdentifier.create(document.uri.toString()),


### PR DESCRIPTION
Fixes the most frequent bug from crash reporting, I hope.