### PR TITLE
Fix more errors in get module

### DIFF
--- a/src/debugger/debugConfig.ts
+++ b/src/debugger/debugConfig.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import * as rpc from 'vscode-jsonrpc/node'
 import { onExit, onFinishEval, onInit } from '../interactive/repl'
-import { setContext } from '../utils'
+import { setContext, wrapCrashReporting } from '../utils'
 
 interface DebugConfigTreeItem {
     label: string
@@ -279,10 +279,10 @@ export function activate(context: vscode.ExtensionContext) {
             provider.disableCompiledMode()
             setContext('julia.debuggerCompiledMode', false)
         }),
-        onInit(connection => {
+        onInit(wrapCrashReporting(connection => {
             provider.setConnection(connection)
             provider.refresh()
-        }),
+        })),
         onFinishEval(_ => provider.refresh()),
         onExit(e => {
             provider.setConnection(null)

--- a/src/interactive/completions.ts
+++ b/src/interactive/completions.ts
@@ -3,6 +3,8 @@
 import * as vscode from 'vscode'
 import * as rpc from 'vscode-jsonrpc'
 import { Disposable, MessageConnection } from 'vscode-jsonrpc'
+import { handleNewCrashReportFromException } from '../telemetry'
+import { wrapCrashReporting } from '../utils'
 import { getModuleForEditor } from './modules'
 import { onExit, onInit } from './repl'
 
@@ -17,13 +19,13 @@ const completionTriggerCharacters = [
 export function activate(context: vscode.ExtensionContext) {
     let completionSubscription: undefined | Disposable = undefined
     context.subscriptions.push(
-        onInit(conn => {
+        onInit(wrapCrashReporting(conn => {
             completionSubscription = vscode.languages.registerCompletionItemProvider(
                 selector,
                 completionItemProvider(conn),
                 ...completionTriggerCharacters
             )
-        }),
+        })),
         onExit(() => {
             if (completionSubscription) { completionSubscription.dispose() }
         })
@@ -43,19 +45,25 @@ function completionItemProvider(conn: MessageConnection): vscode.CompletionItemP
                 return
             }
             const completionPromise = (async () => {
-                const startPosition = new vscode.Position(position.line, 0)
-                const lineRange = new vscode.Range(startPosition, position)
-                const line = document.getText(lineRange)
+                try {
+                    const startPosition = new vscode.Position(position.line, 0)
+                    const lineRange = new vscode.Range(startPosition, position)
+                    const line = document.getText(lineRange)
 
-                const mod: string = await getModuleForEditor(document, position)
-                if(token.isCancellationRequested) { return }
+                    const mod: string = await getModuleForEditor(document, position)
+                    if(token.isCancellationRequested) { return }
 
-                const items = await conn.sendRequest(requestTypeGetCompletionItems, { line, mod })
-                if(token.isCancellationRequested) { return }
+                    const items = await conn.sendRequest(requestTypeGetCompletionItems, { line, mod })
+                    if(token.isCancellationRequested) { return }
 
-                return {
-                    items: items,
-                    isIncomplete: true
+                    return {
+                        items: items,
+                        isIncomplete: true
+                    }
+                }
+                catch(err) {
+                    handleNewCrashReportFromException(err, 'Extension')
+                    throw (err)
                 }
             })()
 

--- a/src/interactive/modules.ts
+++ b/src/interactive/modules.ts
@@ -1,9 +1,10 @@
 import * as vscode from 'vscode'
 import * as rpc from 'vscode-jsonrpc'
+import { ResponseError } from 'vscode-jsonrpc'
 import * as vslc from 'vscode-languageclient/node'
 import { onSetLanguageClient } from '../extension'
 import * as telemetry from '../telemetry'
-import { registerCommand } from '../utils'
+import { registerCommand, wrapCrashReporting } from '../utils'
 import { VersionedTextDocumentPositionParams } from './misc'
 import { onExit, onInit } from './repl'
 
@@ -65,51 +66,46 @@ function cancelCurrentGetModuleRequest() {
     }
 }
 
-export async function getModuleForEditor(document: vscode.TextDocument, position: vscode.Position, token?: vscode.CancellationToken) {
+export async function getModuleForEditor(document: vscode.TextDocument, position: vscode.Position, token?: vscode.CancellationToken): Promise<string> {
     const manuallySetModule = manuallySetDocuments[document.fileName]
     if (manuallySetModule) { return manuallySetModule }
 
     const languageClient = g_languageClient
 
     if (!languageClient) { return 'Main' }
-    if (!languageClient.isRunning) { return 'Main' }
-    try {
-        const params: VersionedTextDocumentPositionParams = {
-            textDocument: vslc.TextDocumentIdentifier.create(document.uri.toString()),
-            version: document.version,
-            position: position
-        }
 
-        for (let i = 0; i < 3; i++) {
-            if (token === undefined || !token.isCancellationRequested) {
-                try {
-                    return await languageClient.sendRequest<string>('julia/getModuleAt', params)
-                }
-                catch (err) {
-                    // Is this a version mismatch situation? Only if not, rethrow
-                    if (err.code !== -32099) {
-                        throw err
-                    }
-                }
-            }
-            else {
-                // We were canceled, so we give up
-                return
-            }
-        }
-
-        // We tried three times, now give up
-        return
-
-    } catch (err) {
-        if (err.message === 'Language client is not ready yet') {
-            vscode.window.showErrorMessage(err)
-        } else if (languageClient) {
-            console.error(err)
-            telemetry.handleNewCrashReportFromException(err, 'Extension')
-        }
-        return 'Main'
+    const params: VersionedTextDocumentPositionParams = {
+        textDocument: vslc.TextDocumentIdentifier.create(document.uri.toString()),
+        version: document.version,
+        position: position
     }
+
+    for (let i = 0; i < 3; i++) {
+        if (token === undefined || !token.isCancellationRequested) {
+            try {
+                return await languageClient.sendRequest<string>('julia/getModuleAt', params)
+            }
+            catch (err) {
+                if (err instanceof ResponseError && err.code===rpc.ErrorCodes.ConnectionInactive) {
+                    return 'Main'
+                }
+                else if (err instanceof ResponseError && err.code===1001) {
+                    // This is a version out of sync situation
+                    return 'Main'
+                }
+                else {
+                    throw err
+                }
+            }
+        }
+        else {
+            // We were canceled, so we give up
+            return 'Main'
+        }
+    }
+
+    // We tried three times, now give up
+    return 'Main'
 }
 
 function isJuliaEditor(editor: vscode.TextEditor = vscode.window.activeTextEditor) {

--- a/src/interactive/modules.ts
+++ b/src/interactive/modules.ts
@@ -45,10 +45,10 @@ export function activate(context: vscode.ExtensionContext) {
     statusBarItem.command = 'language-julia.chooseModule'
     statusBarItem.tooltip = 'Choose Current Module'
 
-    onInit(conn => {
+    onInit(wrapCrashReporting(conn => {
         g_connection = conn
         updateStatusBarItem()
-    })
+    }))
     onExit(hadError => {
         g_connection = null
         updateStatusBarItem()

--- a/src/interactive/modules.ts
+++ b/src/interactive/modules.ts
@@ -89,7 +89,7 @@ export async function getModuleForEditor(document: vscode.TextDocument, position
                 if (err instanceof ResponseError && err.code===rpc.ErrorCodes.ConnectionInactive) {
                     return 'Main'
                 }
-                else if (err instanceof ResponseError && err.code===1001) {
+                else if (err instanceof ResponseError && err.code===-33101) {
                     // This is a version out of sync situation
                     return 'Main'
                 }

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -14,7 +14,7 @@ import * as jlpkgenv from '../jlpkgenv'
 import { switchEnvToPath } from '../jlpkgenv'
 import { JuliaExecutablesFeature } from '../juliaexepath'
 import * as telemetry from '../telemetry'
-import { generatePipeName, getVersionedParamsAtPosition, inferJuliaNumThreads, registerCommand, setContext } from '../utils'
+import { generatePipeName, getVersionedParamsAtPosition, inferJuliaNumThreads, registerCommand, setContext, wrapCrashReporting } from '../utils'
 import * as completions from './completions'
 import { VersionedTextDocumentPositionParams } from './misc'
 import * as modules from './modules'
@@ -1176,7 +1176,7 @@ export function activate(context: vscode.ExtensionContext, compiledProvider, jul
         onSetLanguageClient(languageClient => {
             g_languageClient = languageClient
         }),
-        onInit(connection => {
+        onInit(wrapCrashReporting(connection => {
             connection.onNotification(notifyTypeDisplay, display)
             connection.onNotification(notifyTypeDebuggerRun, debuggerRun)
             connection.onNotification(notifyTypeDebuggerEnter, debuggerEnter)
@@ -1190,7 +1190,7 @@ export function activate(context: vscode.ExtensionContext, compiledProvider, jul
             connection.onNotification(notifyTypeProgress, updateProgress)
             setContext('julia.isEvaluating', false)
             setContext('julia.hasREPL', true)
-        }),
+        })),
         onExit(() => {
             results.removeAll()
             clearDiagnostics()

--- a/src/interactive/workspace.ts
+++ b/src/interactive/workspace.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 import * as rpc from 'vscode-jsonrpc'
 import { JuliaKernel } from '../notebook/notebookKernel'
 import { TestProcess } from '../testing/testFeature'
-import { registerCommand } from '../utils'
+import { registerCommand, wrapCrashReporting } from '../utils'
 import { displayPlot } from './plots'
 import {
     notifyTypeDisplay,
@@ -210,7 +210,7 @@ export class WorkspaceFeature {
                 this._REPLTreeDataProvider
             ),
             // listeners
-            onInit((conn) => this.openREPL(conn)),
+            onInit(wrapCrashReporting(conn => this.openREPL(conn))),
             onExit((err) => this.closeREPL(err)),
             // commands
             registerCommand('language-julia.showInVSCode', (node: VariableNode) =>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,6 +76,19 @@ export function registerCommand(cmd: string, f) {
     return vscode.commands.registerCommand(cmd, fWrapped)
 }
 
+export function wrapCrashReporting(f) {
+    const fWrapped = (...args) => {
+        try {
+            return f(...args)
+        } catch (err) {
+            handleNewCrashReportFromException(err, 'Extension')
+            throw (err)
+        }
+    }
+
+    return fWrapped
+}
+
 export function resolvePath(p: string, normalize: boolean = true) {
     p = parseEnvVariables(p)
     p = p.replace(/^~/, os.homedir())


### PR DESCRIPTION
Requires https://github.com/julia-vscode/LanguageServer.jl/pull/1176.

We are still getting crashes inside `getModuleForEditor` in crash reporting, apparently the check before the `sendRequest` whether the client is running didn't work properly. So this changes strategy to correctly use error codes to identify if the client wasn't running, which in general is a better way to handle this in an async world in any case. I also removed some nested try catch blocks that I didn't think make much sense and probably didn't work in any case as they did things like compare error message strings.

Easiest to review commit by commit, as this also adds additional error handling with crash report sending.