### PR TITLE
bugfix: eval order

### DIFF
--- a/package.json
+++ b/package.json
@@ -1495,6 +1495,7 @@
         "applicationinsights": "^2",
         "async-file": "^v2.0.2",
         "await-notify": "^1.0.1",
+        "fastq": "^1.13.0",
         "markdown-it": "^12.3.2",
         "markdown-it-footnote": "^3.0.3",
         "promised-temp": "^v0.1.0",


### PR DESCRIPTION
Fixes #3128

Added a queue to ensure evaluation order on execution of multiple cells and cell-selection mixed execution of code. 