### PR TITLE
add cmd copy howto type

### DIFF
--- a/package.json
+++ b/package.json
@@ -436,6 +436,10 @@
             {
                 "command": "language-julia.hideModules",
                 "title": "Hide modules in Workspace"
+            },
+            {
+                "command": "language-julia.copyHowToType",
+                "title": "Julia: How to Type Selected Latex/Emoji to Clipboard"
             }
         ],
         "menus": {

--- a/scripts/packages/VSCodeServer/src/VSCodeServer.jl
+++ b/scripts/packages/VSCodeServer/src/VSCodeServer.jl
@@ -122,6 +122,7 @@ function serve(args...; is_dev=false, crashreporting_pipename::Union{AbstractStr
         msg_dispatcher[repl_runcode_request_type] = repl_runcode_request
         msg_dispatcher[repl_interrupt_notification_type] = repl_interrupt_request
         msg_dispatcher[repl_getvariables_request_type] = repl_getvariables_request
+        msg_dispatcher[repl_charcompletion_request_type] = repl_charcompletion_request
         msg_dispatcher[repl_getlazy_request_type] = repl_getlazy_request
         msg_dispatcher[repl_showingrid_notification_type] = repl_showingrid_notification
         msg_dispatcher[repl_loadedModules_request_type] = repl_loadedModules_request

--- a/scripts/packages/VSCodeServer/src/eval.jl
+++ b/scripts/packages/VSCodeServer/src/eval.jl
@@ -57,7 +57,7 @@ end
 function repl_interrupt_request(conn, ::Nothing)
     println(stderr, "^C")
     if EVAL_BACKEND_TASK[] !== nothing && !istaskdone(EVAL_BACKEND_TASK[]) && IS_BACKEND_WORKING[]
-        schedule(EVAL_BACKEND_TASK[], InterruptException(); error = true)
+        schedule(EVAL_BACKEND_TASK[], InterruptException(); error=true)
     end
 end
 
@@ -154,7 +154,7 @@ function repl_runcode_request(conn, params::ReplRunCodeRequestParams)::ReplRunCo
 
             return withpath(source_filename) do
                 res = try
-                    val = inlineeval(resolved_mod, source_code, code_line, code_column, source_filename, softscope = params.softscope)
+                    val = inlineeval(resolved_mod, source_code, code_line, code_column, source_filename, softscope=params.softscope)
                     if CAN_SET_ANS[]
                         try
                             @static if @isdefined setglobal!
@@ -208,7 +208,7 @@ function repl_runcode_request(conn, params::ReplRunCodeRequestParams)::ReplRunCo
                         end
                     catch err
                         if !(err isa MethodError && err.f === display)
-                            printstyled(stderr, "Display Error: ", color = Base.error_color(), bold = true)
+                            printstyled(stderr, "Display Error: ", color=Base.error_color(), bold=true)
                             Base.display_error(stderr, err, catch_backtrace())
                         end
                     end
@@ -227,7 +227,7 @@ function repl_runcode_request(conn, params::ReplRunCodeRequestParams)::ReplRunCo
 end
 
 # don't inline this so we can find it in the stacktrace
-@noinline function inlineeval(m, code, code_line, code_column, file; softscope = false)
+@noinline function inlineeval(m, code, code_line, code_column, file; softscope=false)
     code = string('\n'^code_line, ' '^code_column, code)
     args = softscope && VERSION >= v"1.5" ? (REPL.softscope, m, code, file) : (m, code, file)
     return Base.invokelatest(include_string, args...)
@@ -262,13 +262,13 @@ Must return a `ReplRunCodeRequestReturn` with the following fields:
 - `stackframe::Vector{Frame}`: Optional, should only be given on an error
 """
 function render(x)
-    plain = sprintlimited(MIME"text/plain"(), x, limit = MAX_RESULT_LENGTH)
+    plain = sprintlimited(MIME"text/plain"(), x, limit=MAX_RESULT_LENGTH)
     md = try
-        sprintlimited(MIME"text/markdown"(), x, limit = MAX_RESULT_LENGTH)
+        sprintlimited(MIME"text/markdown"(), x, limit=MAX_RESULT_LENGTH)
     catch _
         codeblock(plain)
     end
-    inline = strlimit(first(split(plain, "\n")), limit = INLINE_RESULT_LENGTH)
+    inline = strlimit(first(split(plain, "\n")), limit=INLINE_RESULT_LENGTH)
     return ReplRunCodeRequestReturn(inline, md)
 end
 
@@ -291,14 +291,14 @@ unwrap_loaderror(err::LoadError) = err.error
 unwrap_loaderror(err) = err
 
 function sprint_error(err)
-    sprintlimited(err, [], func = Base.display_error, limit = MAX_RESULT_LENGTH)
+    sprintlimited(err, [], func=Base.display_error, limit=MAX_RESULT_LENGTH)
 end
 
 function render(err::EvalError)
     bt = crop_backtrace(err.bt)
 
     errstr = sprint_error_unwrap(err.err)
-    inline = strlimit(first(split(errstr, "\n")), limit = INLINE_RESULT_LENGTH)
+    inline = strlimit(first(split(errstr, "\n")), limit=INLINE_RESULT_LENGTH)
     all = string('\n', codeblock(errstr), '\n', backtrace_string(bt))
 
     # handle duplicates e.g. from recursion
@@ -319,7 +319,7 @@ function render(stack::EvalErrorStack)
         append!(complete_bt, bt)
 
         errstr = sprint_error_unwrap(err)
-        inline *= strlimit(first(split(errstr, "\n")), limit = INLINE_RESULT_LENGTH)
+        inline *= strlimit(first(split(errstr, "\n")), limit=INLINE_RESULT_LENGTH)
         all *= string('\n', codeblock(errstr), '\n', backtrace_string(bt))
     end
 
@@ -379,7 +379,7 @@ function backtrace_string(bt)
 
         file = string(frame.file)
         full_file = fullpath(something(Base.find_source_file(file), file))
-        cmd = vscode_cmd_uri("language-julia.openFile"; path = full_file, line = frame.line)
+        cmd = vscode_cmd_uri("language-julia.openFile"; path=full_file, line=frame.line)
 
         print(io, counter, ". `")
         Base.StackTraces.show_spec_linfo(io, frame)
@@ -393,4 +393,27 @@ function backtrace_string(bt)
     end
 
     return String(take!(io))
+end
+
+
+function repl_charcompletion_request(conn, params::CharCompletionRequest)::CharCompletionReturn
+    targetText = params.text
+    completion = ""
+    if haskey(REPL.REPLCompletions.symbols_latex_canonical, targetText)
+        completion = REPL.REPLCompletions.symbols_latex_canonical[targetText]
+    else
+        for (k, v) in REPL.REPLCompletions.latex_symbols
+            if v == targetText
+                completion = k
+                return CharCompletionReturn(completion)
+            end
+        end
+        for (k, v) in REPL.REPLCompletions.emoji_symbols
+            if v == targetText
+                completion = k
+                break
+            end
+        end
+    end
+    return CharCompletionReturn(completion)
 end

--- a/scripts/packages/VSCodeServer/src/repl_protocol.jl
+++ b/scripts/packages/VSCodeServer/src/repl_protocol.jl
@@ -43,7 +43,7 @@ JSONRPC.@dict_readable mutable struct ReplWorkspaceItem <: JSONRPC.Outbound
     value::String
     canshow::Bool
     type::String
-    location::Union{Nothing, Location}
+    location::Union{Nothing,Location}
 end
 
 JSONRPC.@dict_readable struct GetCompletionsRequestParams <: JSONRPC.Outbound
@@ -108,16 +108,25 @@ JSONRPC.@dict_readable mutable struct ProfileFrame <: JSONRPC.Outbound
     children::Vector{ProfileFrame}
 end
 
+JSONRPC.@dict_readable struct CharCompletionRequest
+    text::String
+end
+
+JSONRPC.@dict_readable struct CharCompletionReturn <: JSONRPC.Outbound
+    completion::String
+end
+
 const repl_runcode_request_type = JSONRPC.RequestType("repl/runcode", ReplRunCodeRequestParams, ReplRunCodeRequestReturn)
 const repl_interrupt_notification_type = JSONRPC.NotificationType("repl/interrupt", Nothing)
+const repl_charcompletion_request_type = JSONRPC.RequestType("repl/charcompletion", CharCompletionRequest, CharCompletionReturn)
 const repl_getvariables_request_type = JSONRPC.RequestType("repl/getvariables", NamedTuple{(:modules,),Tuple{Bool}}, Vector{ReplWorkspaceItem})
 const repl_getlazy_request_type = JSONRPC.RequestType("repl/getlazy", NamedTuple{(:id,),Tuple{Int}}, Vector{ReplWorkspaceItem})
 const repl_showingrid_notification_type = JSONRPC.NotificationType("repl/showingrid", NamedTuple{(:code,),Tuple{String}})
 const repl_loadedModules_request_type = JSONRPC.RequestType("repl/loadedModules", Nothing, Vector{String})
 const repl_isModuleLoaded_request_type = JSONRPC.RequestType("repl/isModuleLoaded", NamedTuple{(:mod,),Tuple{String}}, Bool)
 const repl_startdebugger_notification_type = JSONRPC.NotificationType("repl/startdebugger", NamedTuple{(:debugPipename,),Tuple{String}})
-const repl_showprofileresult_notification_type = JSONRPC.NotificationType("repl/showprofileresult", NamedTuple{(:trace,:typ),Tuple{Dict{String,ProfileFrame}, String}})
-const repl_open_file_notification_type = JSONRPC.NotificationType("repl/openFile", NamedTuple{(:path, :line), Tuple{String, Int}})
+const repl_showprofileresult_notification_type = JSONRPC.NotificationType("repl/showprofileresult", NamedTuple{(:trace, :typ),Tuple{Dict{String,ProfileFrame},String}})
+const repl_open_file_notification_type = JSONRPC.NotificationType("repl/openFile", NamedTuple{(:path, :line),Tuple{String,Int}})
 const repl_toggle_plot_pane_notification_type = JSONRPC.NotificationType("repl/togglePlotPane", NamedTuple{(:enable,),Tuple{Bool}})
 const repl_toggle_diagnostics_notification_type = JSONRPC.NotificationType("repl/toggleDiagnostics", NamedTuple{(:enable,),Tuple{Bool}})
 const repl_toggle_progress_notification_type = JSONRPC.NotificationType("repl/toggleProgress", Bool)

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -1159,6 +1159,27 @@ function isMarkdownEditor(editor: vscode.TextEditor) {
     return editor.document.languageId === 'juliamarkdown' || editor.document.languageId === 'markdown'
 }
 
+interface CharCompletionReturnResult {
+    completion: string
+}
+const requestTypeCharCompletion = new rpc.RequestType<{
+    text: string,
+}, CharCompletionReturnResult, void>('repl/charcompletion')
+
+async function howToTypeToClipboard() {
+    const ed = vscode.window.activeTextEditor
+    const selection = ed.selection
+    const text = ed.document.getText(selection)
+    const completion =  await g_connection.sendRequest(
+        requestTypeCharCompletion,
+        {
+            text
+        }
+    )
+    vscode.env.clipboard.writeText(completion.completion)
+    vscode.window.showInformationMessage('Copied '+completion.completion+' to clipboard.')
+}
+
 export async function replStartDebugger(pipename: string) {
     await startREPL(true)
 
@@ -1272,6 +1293,7 @@ export function activate(context: vscode.ExtensionContext, compiledProvider, jul
         registerCommand('language-julia.activateFromDir', activateFromDir),
         registerCommand('language-julia.clearRuntimeDiagnostics', clearDiagnostics),
         registerCommand('language-julia.clearRuntimeDiagnosticsByProvider', clearDiagnosticsByProvider),
+        registerCommand('language-julia.copyHowToType', howToTypeToClipboard),
     )
 
     const terminalConfig = vscode.workspace.getConfiguration('terminal.integrated')


### PR DESCRIPTION
Add the command to copy how to type selected latex/emoji char to clipboard.

Fixes https://github.com/julia-vscode/julia-vscode/issues/3153
