### PR TITLE
fix multi-line exec to repl for julia 1.9

### DIFF
--- a/scripts/packages/VSCodeServer/src/eval.jl
+++ b/scripts/packages/VSCodeServer/src/eval.jl
@@ -134,7 +134,7 @@ function repl_runcode_request(conn, params::ReplRunCodeRequestParams)::ReplRunCo
                 suffix = string("\e[0m", SHELL.update_cwd(), SHELL.prompt_end())
                 try
                     mode = get_main_mode()
-                    prompt = mode.prompt
+                    prompt = LineEdit.prompt_string(mode.prompt)
                     LineEdit.write_prompt(stdout, mode)
                 catch err
                     print(stdout, prefix, prompt, suffix)


### PR DESCRIPTION
Possibly due to changes to the REPl in Julia 1.9 ([news.md](https://github.com/JuliaLang/julia/blob/release-1.9/NEWS.md#repl)), the prompt is not just a string but can be a Union{Function, String, ...}

Uses [prompt_string](https://github.com/JuliaLang/julia/blob/c1d1bde5918c07fc377b7942c50329487d3e70ce/stdlib/REPL/src/LineEdit.jl#LL424-L425C50) to convert `prompt` to string, otherwise would cause problem in e.g. the length call in
https://github.com/julia-vscode/julia-vscode/blob/3dff67d8b2bbb7c579c04c466b89c333ec3dcc2e/scripts/packages/VSCodeServer/src/eval.jl#L145

Fixes #3220
Fixes #3235

Note: the prompt_sting function, while not exported, seems to be there since julia v1.0 [link](https://github.com/JuliaLang/julia/blob/e0837d1e64a9e4d17534a9f981e9a2a3f221356f/stdlib/REPL/src/LineEdit.jl#L369)

for reference, in the OhMyREPL.jl package, it handles just the `Union{Function, String}` part (not including the PromptState/Prompt dispatches of `prompt_sting`), [link](https://github.com/KristofferC/OhMyREPL.jl/blob/ffd8e128291c439d8435633707237a558dfeeff0/src/prompt.jl#L17), so it may also work if we just add the 2 dispatch directly as
```
prompt_string(s::AbstractString) = s
prompt_string(f::Function) = Base.invokelatest(f)
```
and not relying the unexported LineEdit.prompt_string

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.
