### PR TITLE
fix: use correct display logic for plots and errors

### DIFF
--- a/scripts/packages/VSCodeServer/src/display.jl
+++ b/scripts/packages/VSCodeServer/src/display.jl
@@ -34,10 +34,10 @@ function fix_displays(; is_repl = false)
     pushdisplay(InlineDisplay(is_repl))
 end
 
-function with_no_default_display(f)
+function with_no_default_display(f; allow_inline = false)
     stack = copy(Base.Multimedia.displays)
     filter!(Base.Multimedia.displays) do d
-        !(d isa REPL.REPLDisplay || d isa TextDisplay || d isa InlineDisplay)
+        !(d isa REPL.REPLDisplay || d isa TextDisplay || (!allow_inline && d isa InlineDisplay))
     end
     try
         return f()

--- a/scripts/packages/VSCodeServer/src/repl.jl
+++ b/scripts/packages/VSCodeServer/src/repl.jl
@@ -197,6 +197,7 @@ function evalrepl(m, line, repl, main_mode)
             display_repl_error(stderr, r.err, r.bt)
             nothing
         elseif r isa EvalErrorStack
+            set_error_global(r)
             display_repl_error(stderr, r)
             nothing
         else


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/3387.

Also makes sure we 
- don't display errors in the REPL unless requested
- correctly set the `err` and `ans` globals on 1.10 and newer
- correctly set `err` for REPL eval
