### PR TITLE
Support single quoted and pythoncall python syntax highlighting

### DIFF
--- a/syntaxes/julia_vscode.json
+++ b/syntaxes/julia_vscode.json
@@ -509,7 +509,7 @@
           ]
         },
         {
-          "begin": "(py)(\"\"\")",
+          "begin": "(py|@pyeval |@pyexec )(\"\"\")",
           "beginCaptures": {
             "1": {
               "name": "support.function.macro.julia"
@@ -519,6 +519,33 @@
             }
           },
           "end": "([\\s\\w]*)(\"\"\")",
+          "endCaptures": {
+            "2": {
+              "name": "punctuation.definition.string.end.julia"
+            }
+          },
+          "name": "embed.python.julia",
+          "contentName": "meta.embedded.inline.python",
+          "patterns": [
+            {
+              "include": "source.python"
+            },
+            {
+              "include": "#string_dollar_sign_interpolate"
+            }
+          ]
+        },
+        {
+          "begin": "(py|@pyeval |@pyexec )(\")",
+          "beginCaptures": {
+            "1": {
+              "name": "support.function.macro.julia"
+            },
+            "2": {
+              "name": "punctuation.definition.string.begin.julia"
+            }
+          },
+          "end": "([\\s\\w]*)(\")",
           "endCaptures": {
             "2": {
               "name": "punctuation.definition.string.end.julia"


### PR DESCRIPTION
This enables python syntax highlighting for `py"labmda x: x+1"`, `@pyeval "import math"`, `@pyexec "1+1"`, and  `@pyexec """1+1"""`. Previously this was only enabled for triple quoted calls to the `py` string macro. I think it's worth giving special syntax highlighting to PythonCall in addition to PyCall.

Before:
<img width="215" alt="Screenshot 2023-09-23 at 2 58 37 PM" src="https://github.com/julia-vscode/julia-vscode/assets/60898866/cfd2a1dc-66df-4d0e-8299-42d75646112b">

After:
<img width="216" alt="Screenshot 2023-09-23 at 2 58 45 PM" src="https://github.com/julia-vscode/julia-vscode/assets/60898866/9b249e03-b296-4bcb-b1ec-08c389428b3d">
