### PR TITLE
feat: set JULIA_VSCODE_INTERNAL for internal Julia processes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -259,6 +259,8 @@ async function startLanguageServer(juliaExecutablesFeature: JuliaExecutablesFeat
             JULIA_LOAD_PATH: process.platform === 'win32' ? ';' : ':',
             HOME: process.env.HOME ? process.env.HOME : os.homedir(),
             JULIA_LANGUAGESERVER: '1',
+            JULIA_VSCODE_LANGUAGESERVER: '1',
+            JULIA_VSCODE_INTERNAL: '1',
             PATH: process.env.PATH
         }
     }

--- a/src/jlpkgenv.ts
+++ b/src/jlpkgenv.ts
@@ -82,7 +82,12 @@ export async function switchEnvToPath(envpath: string, notifyLS: boolean) {
                     println(false)
                 end`,
                 `${case_adjusted}`
-            ]
+            ],
+            {
+                env: {
+                    JULIA_VSCODE_INTERNAL: '1',
+                }
+            }
         )
 
         if (res.stdout.toString().trim() === 'false') {
@@ -200,7 +205,12 @@ async function getDefaultEnvPath() {
                 '--startup-file=no',
                 '--history-file=no',
                 '-e', 'using Pkg; println(dirname(Pkg.Types.Context().env.project_file))'
-            ])
+            ],
+            {
+                env: {
+                    JULIA_VSCODE_INTERNAL: '1',
+                }
+            })
         g_path_of_default_environment = res.stdout.toString().trim()
     }
     return g_path_of_default_environment

--- a/src/juliaexepath.ts
+++ b/src/juliaexepath.ts
@@ -43,7 +43,12 @@ export class JuliaExecutable {
                     '--history-file=no',
                     '-e',
                     'println(Sys.BINDIR)'
-                ]
+                ],
+                {
+                    env: {
+                        JULIA_VSCODE_INTERNAL: '1',
+                    }
+                }
             )
 
             this._baseRootFolderPath = path.normalize(path.join(result.stdout.toString().trim(), '..', 'share', 'julia', 'base'))
@@ -99,7 +104,15 @@ export class JuliaExecutablesFeature {
                     parsedArgs = argv.slice(1)
                 }
             }
-            const { stdout, } = await execFile(parsedPath, [...parsedArgs, '--version'])
+            const { stdout, } = await execFile(
+                parsedPath,
+                [...parsedArgs, '--version'],
+                {
+                    env: {
+                        JULIA_VSCODE_INTERNAL: '1',
+                    }
+                }
+            )
 
             const versionStringFromJulia = stdout.toString().trim()
 
@@ -183,6 +196,8 @@ export class JuliaExecutablesFeature {
         }
         else if (process.platform === 'darwin') {
             pathsToSearch = ['julia',
+                path.join(homedir, 'Applications', 'Julia-1.10.app', 'Contents', 'Resources', 'julia', 'bin', 'julia'),
+                path.join('/', 'Applications', 'Julia-1.10.app', 'Contents', 'Resources', 'julia', 'bin', 'julia'),
                 path.join(homedir, 'Applications', 'Julia-1.9.app', 'Contents', 'Resources', 'julia', 'bin', 'julia'),
                 path.join('/', 'Applications', 'Julia-1.9.app', 'Contents', 'Resources', 'julia', 'bin', 'julia'),
                 path.join(homedir, 'Applications', 'Julia-1.8.app', 'Contents', 'Resources', 'julia', 'bin', 'julia'),

--- a/src/packagepath.ts
+++ b/src/packagepath.ts
@@ -21,7 +21,12 @@ export async function getPkgPath() {
                 '--history-file=no',
                 '-e',
                 'using Pkg; println(Pkg.depots()[1])'
-            ]
+            ],
+            {
+                env: {
+                    JULIA_VSCODE_INTERNAL: '1',
+                }
+            }
         )
         juliaPackagePath = join(res.stdout.toString().trim(), 'dev')
     }
@@ -38,7 +43,12 @@ export async function getPkgDepotPath() {
                 '--history-file=no',
                 '-e',
                 'using Pkg; println.(Pkg.depots())'
-            ]
+            ],
+            {
+                env: {
+                    JULIA_VSCODE_INTERNAL: '1',
+                }
+            }
         )
         juliaDepotPath = res.stdout.toString().trim().split('\n')
     }


### PR DESCRIPTION
I'm sometimes using a script that switches between a sysimg and no sysimg depending on whether the user process or the LS process runs (because the latter doesn't need to load the sysimg). This adds a new env var `JULIA_VSCODE_INTERNAL` that's set for all of these. It also adds `JULIA_VSCODE_LANGUAGESERVER` to the LS process, because that's slightly more descriptive.