### PR TITLE
Fix `ans` to write to MainInclude.ans for Julia 1.10+

### DIFF
--- a/scripts/packages/VSCodeServer/src/eval.jl
+++ b/scripts/packages/VSCodeServer/src/eval.jl
@@ -181,7 +181,9 @@ function repl_runcode_request(conn, params::ReplRunCodeRequestParams)::ReplRunCo
                     val = inlineeval(resolved_mod, source_code, code_line, code_column, source_filename, softscope = params.softscope)
                     if CAN_SET_ANS[]
                         try
-                            @static if @isdefined setglobal!
+                            @static if VERSION > v"1.10-"
+                                setglobal!(Base.MainInclude, :ans, val)
+                            elseif @isdefined setglobal!
                                 setglobal!(Main, :ans, val)
                             else
                                 ccall(:jl_set_global, Cvoid, (Any, Any, Any), Main, :ans, val)


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/3439.

Changes tested in the debug mode on 1.9.3 and 1.10-beta3.
Code mirrors what has been applied for `err` previously.

For every PR, please check the following:
- [x] End-user documentation check. -> No reference found in the docs
- [x] Changelog mention. -> Tiny fix, so probably not worth mentioning?
