### PR TITLE
Fix error message typo

### DIFF
--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -684,7 +684,7 @@ async function getBlockRange(params: VersionedTextDocumentPositionParams): Promi
             vscode.window.showErrorMessage(err.message)
         } else {
             console.error(err)
-            vscode.window.showErrorMessage('Error while communicating with the LS. Check Outputs > Julia Language Server for additional information.')
+            vscode.window.showErrorMessage('Error while communicating with the LS. Check Output > Julia Language Server for additional information.')
         }
         return zeroReturn
     }


### PR DESCRIPTION
It's called "Output" not "Outputs".

![image](https://github.com/julia-vscode/julia-vscode/assets/96840304/155fe070-5578-494e-871e-b37daa7e781e)
