### PR TITLE
fix bug: use sysimage for vscode debugger

### DIFF
--- a/package.json
+++ b/package.json
@@ -1364,6 +1364,11 @@
                                 "type": "string",
                                 "description": "Absolute path to the Julia environment.",
                                 "default": "${command:activeJuliaEnvironment}"
+                            },
+                            "sysImage": {
+                                "type": "string",
+                                "description": "Absolute path to the Julia sysimage.",
+                                "default": ""
                             }
                         }
                     }
@@ -1376,7 +1381,8 @@
                         "program": "${file}",
                         "stopOnEntry": false,
                         "cwd": "${workspaceFolder}",
-                        "juliaEnv": "${command:activeJuliaEnvironment}"
+                        "juliaEnv": "${command:activeJuliaEnvironment}",
+                        "sysImage": null
                     }
                 ],
                 "configurationSnippets": [
@@ -1534,7 +1540,7 @@
         "mocha": "^10",
         "ts-loader": "^9.2.8",
         "typescript": "^5",
-        "webpack": "^5.70.0",
-        "webpack-cli": "^5"
+        "webpack": "^5.89.0",
+        "webpack-cli": "^5.1.4"
     }
 }


### PR DESCRIPTION
The current extension do not add sysimage into arguments when debugging a julia program. I add some code to fix this.

Fixes #.

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.
