### PR TITLE
Support more VSCode variables in `environmentPath`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -91,6 +91,7 @@ export function wrapCrashReporting(f) {
 
 export function resolvePath(p: string, normalize: boolean = true) {
     p = parseEnvVariables(p)
+    p = parseWorkspaceFolder(p)
     p = p.replace(/^~/, os.homedir())
     p = normalize ? path.normalize(p) : p
     return p
@@ -99,5 +100,12 @@ export function resolvePath(p: string, normalize: boolean = true) {
 function parseEnvVariables(p: string) {
     return p.replace(/\${env:(.*?)}/g, (_, variable) => {
         return process.env[variable] || ''
+    })
+}
+
+function parseWorkspaceFolder(p: string) {
+    return p.replace(/\${workspaceFolder}/g, (_) => {
+        const workspace_folders = vscode.workspace.workspaceFolders
+        return workspace_folders.length > 0 ? vscode.workspace.workspaceFolders[0].uri.fsPath : null;
     })
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -108,6 +108,10 @@ export function resolvePath(p: string, normalize: boolean = true) {
  *
  * See https://code.visualstudio.com/docs/editor/variables-reference for definitions of the
  * above.
+ *
+ * TODO: this replicates functionality present in core VSCode! The implementation of this
+ *  function be replaced once this issue is resolved:
+ *      https://github.com/microsoft/vscode/issues/46471
  */
 function parseVSCodeVariables(p: string) {
     p = p.replace(/\${userHome}/g, os.homedir())


### PR DESCRIPTION
Some more progress towards #1781.

This adds support for:
 *  `${userHome}`
 *  `${workspaceFolder}`
 *  `${workspaceFolder:<FOLDER_NAME>}`  (to support [multi-root workspaces](https://code.visualstudio.com/docs/editor/workspaces#_multiroot-workspaces))
 *  `${pathSeparator}`

The implementation is suboptimal, in that it effectively duplicates functionality [present in core VSCode](https://github.com/microsoft/vscode-python/blob/main/src/client/common/variables/systemVariables.ts), but this seems unavoidable until https://github.com/microsoft/vscode/issues/46471 is solved properly.

**Notes** 
For `${workspaceFolder}`, the behaviour I've implemented is different in the case of a multi-root workspace. The standard behaviour will take the workspace of the current file (IIUC [this](https://github.com/microsoft/vscode-python/blob/bffc9b36e414e8f4919f09060f95196e1dabe05f/src/client/common/variables/systemVariables.ts#L109-L110) correctly). Two reasons for this:
  - I couldn't easily see how to gain access to the currently open file at this point
  - I suspect that if using this for `julia.environmentPath` then the behaviour could be unintuitive, since the julia environment is only activate once... so the behaviour would depend on which file the user happened to have open first.

Personally I have not used a multi-root workspace in my regular workflow, so not sure what behaviour would be most desirable here. But requiring explicit selection seems like a sensible initial choice to me.

In the case of failure (e.g. setting `{"julia.environmentPath": "${workspaceFolder:non-existent-directory}"}`, currently failure will be silent, and the global julia project will be activated. Maybe we should log somewhere at least? Not sure on the standard approach here, comments welcome.


btw, I'm not sure if there's anywhere to add tests for this? I had a quick look and couldn't find anything obvious.