### PR TITLE
Fix minor typo 'starting'

### DIFF
--- a/src/notebook/notebookKernel.ts
+++ b/src/notebook/notebookKernel.ts
@@ -315,7 +315,7 @@ export class JuliaKernel {
                 env['JULIA_NUM_THREADS'] = nthreads
             }
 
-            this.outputChannel.appendLine(`Now strating the kernel process from the extension with '${this.juliaExecutable.file}', '${args}'.`)
+            this.outputChannel.appendLine(`Now starting the kernel process from the extension with '${this.juliaExecutable.file}', '${args}'.`)
 
             this._kernelProcess = spawn(
                 this.juliaExecutable.file,


### PR DESCRIPTION
Fixes a very minor typo in one of the output messages. Change seemed too minor to be worth including in the changelog, but I can add it if it's preferable.

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.
