### PR TITLE
Run the Juliaup detection in a shell on Mac/Linux

### DIFF
--- a/src/juliaexepath.ts
+++ b/src/juliaexepath.ts
@@ -230,7 +230,7 @@ export class JuliaExecutablesFeature {
     async tryJuliaup() {
         this.usingJuliaup = false
         try {
-            const { stdout, } = await execFile('juliaup', ['api', 'getconfig1'])
+            const { stdout, } = await execFile('juliaup', ['api', 'getconfig1'], {shell: process.platform === 'win32' ? false : true})
 
             const apiResult = stdout.toString().trim()
 


### PR DESCRIPTION
We had a couple of reports where folks launch VS Code on MacOS from the graphical finder UI, and that seems to end up with a VS Code process that doesn't have the Juliaup `PATH` modifications. This seems one easy way here to fix this. I haven't tested it, though...