### PR TITLE
change Alt + I to Alt + J

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Changed
 * Default of `julia.persistentSession.closeStrategy` changed to overridable ([#3494](https://github.com/julia-vscode/julia-vscode/pull/3494))
+* Key combination for `language-julia.clearAllInlineResultsInEditor` changed from Alt+I Alt+C to Alt+J Alt+C to avoid clashes with the key combination for typing `|` (which is Alt+I on some keyboards)
 
 ### Fixed
 * Code execution now works properly when connected to an external REPL ([#3506](https://github.com/julia-vscode/julia-vscode/pull/3506))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Changed
 * Default of `julia.persistentSession.closeStrategy` changed to overridable ([#3494](https://github.com/julia-vscode/julia-vscode/pull/3494))
-* Key combination for `language-julia.clearAllInlineResultsInEditor` changed from Alt+I Alt+C to Alt+J Alt+C to avoid clashes with the key combination for typing `|` (which is Alt+I on some keyboards)
+* Key combination for `language-julia.clearAllInlineResultsInEditor` changed from Alt+I Alt+C to Alt+J Alt+C to avoid clashes with the key combination for typing `|` (which is Alt+I on some keyboards) ([#3509](https://github.com/julia-vscode/julia-vscode/pull/3509))
 
 ### Fixed
 * Code execution now works properly when connected to an external REPL ([#3506](https://github.com/julia-vscode/julia-vscode/pull/3506))

--- a/package.json
+++ b/package.json
@@ -769,7 +769,7 @@
             },
             {
                 "command": "language-julia.clearAllInlineResultsInEditor",
-                "key": "Alt+I Alt+C",
+                "key": "Alt+J Alt+C",
                 "when": "editorTextFocus && activeEditor != workbench.editor.notebook && editorLangId in julia.supportedLanguageIds"
             },
             {


### PR DESCRIPTION
On many keyboards (well at least mine) the combination Alt + I is used to type the |  (pipe symbol), which is important julia syntax. @pfitzseb

Fixes #.

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.
