### PR TITLE
display with `@nospecialize`

### DIFF
--- a/scripts/packages/VSCodeServer/src/display.jl
+++ b/scripts/packages/VSCodeServer/src/display.jl
@@ -58,7 +58,7 @@ function sendDisplayMsg(kind, data)
     end
 end
 
-function Base.display(d::InlineDisplay, m::MIME, x)
+function Base.display(d::InlineDisplay, m::MIME, @nospecialize(x))
     if !PLOT_PANE_ENABLED[]
         with_no_default_display(() -> display(m, x))
     else
@@ -194,7 +194,7 @@ function can_display(x)
     return is_table_like(x)
 end
 
-function Base.display(d::InlineDisplay, x)
+function Base.display(d::InlineDisplay, @nospecialize(x))
     if DIAGNOSTICS_ENABLED[] && showable(DIAGNOSTIC_MIME, x)
         return display(d, DIAGNOSTIC_MIME, x)
     end


### PR DESCRIPTION
Fixes #3511.

For some complicated types (esp. SciML/DifferentialEquations.jl solutions), the result can takes very long to show in the REPL after computation is done. This PR applies `@nospecialize` on the displayed variable to get around the slowdown.

Reference:
in julia, the display functions have the `@nospecialize` tag

https://github.com/JuliaLang/julia/blob/4919dd79dfd848eb6d9929768666977f374c7f10/base/multimedia.jl#L228-L229

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.

