### PR TITLE
ci: enforce changelog diffs in PRs and split workflow up

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
 Fixes #.
 
-For every PR, please check the following:
 - [ ] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
-- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG, please edit the CHANGELOG.md file in this PR.

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,4 +1,4 @@
-name: "changelog"
+name: changelog
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,12 @@
+name: "changelog"
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request
+  # Can be skipped with the `Skip-Changelog` label
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dangoslen/changelog-enforcer@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,13 @@
-name: Build and Test
+name: Release
 
 on:
-  pull_request:
-    branches:
-      - main
-  check_run:
-    types: [rerequested, requested_action]
   push:
-    branches:
-      - main
     tags:
       - 'v*'
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.head_ref || github.ref_name || github.run_id }}
+  group: ${{ github.head_ref || github.ref_name || github.run_id }} release
   cancel-in-progress: true
 
 defaults:
@@ -22,75 +15,6 @@ defaults:
     shell: bash
 
 jobs:
-
-  lintExtension:
-    name: Lint Extension
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: 'recursive'
-      - name: Install Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
-      - run: npm ci
-      - run: npx eslint -c .eslintrc.json --ext .ts src
-
-  testExtension:
-    name: Test Extension
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        julia_version: ['1.0', '1.1', '1.2', '1.3', '1.4', '1.5', '1.6', '1.7', '1.8', '1.9', '1.10']
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: 'recursive'
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
-      - uses: julia-actions/setup-julia@v1
-        with:
-          version: ${{matrix.julia_version}}
-      - run: npm ci
-      - run: npm run compile
-      - run: xvfb-run -a npm test
-        if: runner.os == 'Linux'
-      - run: npm test
-        if: runner.os != 'Linux'
-
-  testJuliaPackages:
-    name: Test Julia Packages
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        julia_version: ['1.0', '1.1', '1.2', '1.3', '1.4', '1.5', '1.6', '1.7', '1.8', '1.9', '1.10']
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: 'recursive'
-      - uses: julia-actions/setup-julia@v1
-        with:
-          version: ${{matrix.julia_version}}
-      - name: 'Run the Julia tests'
-        run: |
-          julia -e 'using InteractiveUtils; versioninfo()'
-          julia --project=./scripts/environments/languageserver/v${{matrix.julia_version}} -e 'using Pkg; Pkg.resolve()'
-          julia --project=./scripts/environments/languageserver/v${{matrix.julia_version}} -e 'using Pkg; Pkg.test("CSTParser", coverage=true)'
-          julia --project=./scripts/environments/languageserver/v${{matrix.julia_version}} -e 'using Pkg; Pkg.test("JSONRPC", coverage=true)'
-          julia --project=./scripts/environments/languageserver/v${{matrix.julia_version}} -e 'using Pkg; Pkg.test("LanguageServer", coverage=true)'
-          julia --project=./scripts/environments/languageserver/v${{matrix.julia_version}} -e 'using Pkg; Pkg.test("StaticLint", coverage=true)'
-          julia --project=./scripts/environments/languageserver/v${{matrix.julia_version}} -e 'using Pkg; Pkg.test("SymbolServer", coverage=true)'
-          julia --project=./scripts/environments/languageserver/v${{matrix.julia_version}} -e 'using Pkg; Pkg.test("TestItemDetection", coverage=true)'
-          julia --project=./scripts/testenvironments/debugadapter/v${{matrix.julia_version}} -e 'using Pkg; Pkg.test("DebugAdapter", coverage=true)'
-          julia --project=./scripts/testenvironments/vscodedebugger/v${{matrix.julia_version}} -e 'using Pkg; Pkg.test("VSCodeDebugger", coverage=true)'
-          julia --project=./scripts/testenvironments/vscodeserver/v${{matrix.julia_version}} -e 'using Pkg; Pkg.test("VSCodeServer", coverage=true)'
-
   deployOriginalTag:
     name: Deploy Tag Version
     needs: [lintExtension, testExtension, testJuliaPackages]

--- a/.github/workflows/test-extension.yml
+++ b/.github/workflows/test-extension.yml
@@ -1,0 +1,60 @@
+name: Extension
+
+on:
+  pull_request:
+  check_run:
+    types: [rerequested, requested_action]
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.head_ref || github.ref_name || github.run_id }} ext
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  lintExtension:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      - run: npm ci
+      - run: npx eslint -c .eslintrc.json --ext .ts src
+
+  testExtension:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        julia_version: ['1.0', '1.1', '1.2', '1.3', '1.4', '1.5', '1.6', '1.7', '1.8', '1.9', '1.10']
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{matrix.julia_version}}
+      - run: npm ci
+      - run: npm run compile
+      - run: xvfb-run -a npm test
+        if: runner.os == 'Linux'
+      - run: npm test
+        if: runner.os != 'Linux'

--- a/.github/workflows/test-julia.yml
+++ b/.github/workflows/test-julia.yml
@@ -1,0 +1,62 @@
+name: Julia Packages
+
+on:
+  pull_request:
+    paths:
+      - scripts/packages/[!VSCode]*
+      - scripts/packages/[!VSCode]*/*
+      - scripts/packages/[!VSCode]*/**
+      - scripts/environments/languageserver/*
+      - scripts/environments/languageserver/**
+      - scripts/testenvironments/debugadapter/*
+      - scripts/testenvironments/debugadapter/**
+      - scripts/testenvironments/vscodedebugger/*
+      - scripts/testenvironments/vscodedebugger/**
+      - scripts/testenvironments/vscodeserver/*
+      - scripts/testenvironments/vscodeserver/**
+  check_run:
+    types: [rerequested, requested_action]
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.head_ref || github.ref_name || github.run_id }} julia
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        julia_version: ['1.0', '1.1', '1.2', '1.3', '1.4', '1.5', '1.6', '1.7', '1.8', '1.9', '1.10']
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{matrix.julia_version}}
+      - name: 'Run the Julia tests'
+        run: |
+          julia -e 'using InteractiveUtils; versioninfo()'
+          julia --project=./scripts/environments/languageserver/v${{matrix.julia_version}} -e 'using Pkg; Pkg.resolve()'
+          julia --project=./scripts/environments/languageserver/v${{matrix.julia_version}} -e 'using Pkg; Pkg.test("CSTParser", coverage=true)'
+          julia --project=./scripts/environments/languageserver/v${{matrix.julia_version}} -e 'using Pkg; Pkg.test("JSONRPC", coverage=true)'
+          julia --project=./scripts/environments/languageserver/v${{matrix.julia_version}} -e 'using Pkg; Pkg.test("LanguageServer", coverage=true)'
+          julia --project=./scripts/environments/languageserver/v${{matrix.julia_version}} -e 'using Pkg; Pkg.test("StaticLint", coverage=true)'
+          julia --project=./scripts/environments/languageserver/v${{matrix.julia_version}} -e 'using Pkg; Pkg.test("SymbolServer", coverage=true)'
+          julia --project=./scripts/environments/languageserver/v${{matrix.julia_version}} -e 'using Pkg; Pkg.test("TestItemDetection", coverage=true)'
+          julia --project=./scripts/testenvironments/debugadapter/v${{matrix.julia_version}} -e 'using Pkg; Pkg.test("DebugAdapter", coverage=true)'
+          julia --project=./scripts/testenvironments/vscodedebugger/v${{matrix.julia_version}} -e 'using Pkg; Pkg.test("VSCodeDebugger", coverage=true)'
+          julia --project=./scripts/testenvironments/vscodeserver/v${{matrix.julia_version}} -e 'using Pkg; Pkg.test("VSCodeServer", coverage=true)'


### PR DESCRIPTION
This PR adds a https://github.com/marketplace/actions/changelog-enforcer workflow to ensure the changelog is kept updated.
It also splits up the various kinds of workflows (test extension, test julia packages, handle releases) into separate files and only runs them on demand (hopefully).