### PR TITLE
Only update notebook metadata when stale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the Julia extension will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+* Only update notebook metadata when it has actually changed ([#3530](https://github.com/julia-vscode/julia-vscode/pull/3530))
+
 ## [1.66.0] - 2024-01-09
 ### Changed
 * Default of `julia.persistentSession.closeStrategy` changed to overridable ([#3494](https://github.com/julia-vscode/julia-vscode/pull/3494))

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
                 "applicationinsights": "^2",
                 "async-file": "^v2.0.2",
                 "await-notify": "^1.0.1",
+                "lodash.isequal": "^4.5.0",
                 "markdown-it": "^12.3.2",
                 "markdown-it-footnote": "^3.0.3",
                 "promised-temp": "^v0.1.0",
@@ -29,6 +30,7 @@
             },
             "devDependencies": {
                 "@types/download": "^8.0.1",
+                "@types/lodash.isequal": "^4.5.8",
                 "@types/markdown-it": "^12.2.3",
                 "@types/mocha": "^10",
                 "@types/node": "^18",
@@ -655,6 +657,21 @@
             "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
             "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
             "dev": true
+        },
+        "node_modules/@types/lodash": {
+            "version": "4.14.202",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+            "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
+            "dev": true
+        },
+        "node_modules/@types/lodash.isequal": {
+            "version": "4.5.8",
+            "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.8.tgz",
+            "integrity": "sha512-uput6pg4E/tj2LGxCZo9+y27JNyB2OZuuI/T5F+ylVDYuqICLG2/ktjxx0v6GvVntAf8TvEzeQLcV0ffRirXuA==",
+            "dev": true,
+            "dependencies": {
+                "@types/lodash": "*"
+            }
         },
         "node_modules/@types/markdown-it": {
             "version": "12.2.3",
@@ -3969,6 +3986,11 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/lodash.isequal": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+            "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -1515,6 +1515,7 @@
         "applicationinsights": "^2",
         "async-file": "^v2.0.2",
         "await-notify": "^1.0.1",
+        "lodash.isequal": "^4.5.0",
         "markdown-it": "^12.3.2",
         "markdown-it-footnote": "^3.0.3",
         "promised-temp": "^v0.1.0",
@@ -1529,6 +1530,7 @@
     },
     "devDependencies": {
         "@types/download": "^8.0.1",
+        "@types/lodash.isequal": "^4.5.8",
         "@types/markdown-it": "^12.2.3",
         "@types/mocha": "^10",
         "@types/node": "^18",

--- a/src/docbrowser/documentation.ts
+++ b/src/docbrowser/documentation.ts
@@ -1,4 +1,4 @@
-import * as markdownit from 'markdown-it'
+import markdownit from 'markdown-it'
 import * as path from 'path'
 import * as vscode from 'vscode'
 import { withLanguageClient } from '../extension'

--- a/src/notebook/notebookFeature.ts
+++ b/src/notebook/notebookFeature.ts
@@ -5,6 +5,7 @@ import { NotebookNode, WorkspaceFeature } from '../interactive/workspace'
 import { JuliaExecutable, JuliaExecutablesFeature } from '../juliaexepath'
 import { registerCommand } from '../utils'
 import { JuliaKernel } from './notebookKernel'
+import isEqual from 'lodash.isequal'
 
 const JupyterNotebookViewType = 'jupyter-notebook'
 type JupyterNotebookMetadata = Partial<{
@@ -284,7 +285,7 @@ export class JuliaNotebookFeature {
             },
         }
 
-        if (this.vscodeIpynbApi) {
+        if (this.vscodeIpynbApi && !isEqual(notebook.metadata?.custom?.metadata, metadata)) {
             this.vscodeIpynbApi.setNotebookMetadata(notebook.uri, metadata)
         }
     }

--- a/src/scripts/updateDeps.ts
+++ b/src/scripts/updateDeps.ts
@@ -1,4 +1,4 @@
-import * as download from 'download'
+import download from 'download'
 import { promises as fs } from 'fs'
 import * as path from 'path'
 import * as process from 'process'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
         ],
         "sourceMap": true,
         "rootDir": "src",
-        "noUnusedLocals": true
+        "noUnusedLocals": true,
+        "esModuleInterop": true
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
Currently whenever one opens a Julia notebook it is marked as edited because we always apply an edit that updates the metadata. With this PR we check whether any metadata has actually changed, and only then update the metadata.