### PR TITLE
fix: disable static hints when runtime hints are displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Julia extension will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+* Static inlay hints are now automatically disabled when runtime hints are displayed ([#3539](https://github.com/julia-vscode/julia-vscode/pull/3539))
+
+### Changed
+* Static inlay hints are now disabled by default ([#3539](https://github.com/julia-vscode/julia-vscode/pull/3539))
+
+## [1.70.0] - 2024-02-10
 ### Added
 * Added static inlay hints for variable definitions and function parameters ([#3519](https://github.com/julia-vscode/julia-vscode/pull/3519), [#1077](https://github.com/julia-vscode/LanguageServer.jl/pull/1077))
 

--- a/package.json
+++ b/package.json
@@ -999,7 +999,7 @@
                 },
                 "julia.inlayHints.static.enabled": {
                     "type": "boolean",
-                    "default": true,
+                    "default": false,
                     "markdownDescription": "Enable display of static inlay hints."
                 },
                 "julia.inlayHints.static.variableTypes.enabled": {

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -515,6 +515,16 @@ function display(params: { kind: string, data: any }) {
     } else if (params.kind === 'application/vnd.julia-vscode.inlayHints') {
         clearInlayHints()
 
+        if (vscode.workspace.getConfiguration('julia').get<boolean>('inlayHints.static.enabled')) {
+            vscode.workspace.getConfiguration('julia').update('inlayHints.static.enabled', false, true)
+            vscode.window.showInformationMessage('Disabled static inlay hints for Julia to prevent duplicates.', 'Ok', 'Revert').then(val => {
+                if (val === 'Revert') {
+                    clearInlayHints()
+                    vscode.workspace.getConfiguration('julia').update('inlayHints.static.enabled', true, true)
+                }
+            })
+        }
+
         const parsedInlayHints = {}
         Object.keys(params.data).forEach(key => {
             parsedInlayHints[vscode.Uri.file(key).fsPath] = params.data[key].map((hint) => {


### PR DESCRIPTION
Fixes https://github.com/JuliaDebug/Cthulhu.jl/issues/542.

cc @Zentrik 

- [x] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
