### PR TITLE
Remove imports of removed JuliaInterpreter functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Fixed
 * Static inlay hints are now automatically disabled when runtime hints are displayed ([#3539](https://github.com/julia-vscode/julia-vscode/pull/3539))
+* `UndefVarError` on starting Julia Test Server ([#3541](https://github.com/julia-vscode/julia-vscode/pull/3541))
 
 ### Changed
 * Static inlay hints are now disabled by default ([#3539](https://github.com/julia-vscode/julia-vscode/pull/3539))

--- a/scripts/packages/VSCodeLiveUnitTesting/src/VSCodeLiveUnitTesting.jl
+++ b/scripts/packages/VSCodeLiveUnitTesting/src/VSCodeLiveUnitTesting.jl
@@ -14,7 +14,7 @@ module LoweredCodeUtils
     using ..JuliaInterpreter: SSAValue, SlotNumber, Frame
     using ..JuliaInterpreter: @lookup, moduleof, pc_expr, step_expr!, is_global_ref, whichtt,
                         next_until!, finish_and_return!, nstatements, codelocation,
-                        is_return, lookup_return, is_GotoIfNot, is_ReturnNode
+                        is_return, lookup_return
 
     include("../../LoweredCodeUtils/src/packagedef.jl")
 end
@@ -28,7 +28,7 @@ module Revise
     using ..CodeTracking: PkgFiles, basedir, srcfiles, line_is_decl, basepath
     using ..JuliaInterpreter: whichtt, is_doc_expr, step_expr!, finish_and_return!, get_return,
                         @lookup, moduleof, scopeof, pc_expr, is_quotenode_egal,
-                        linetable, codelocs, LineTypes, is_GotoIfNot, isassign, isidentical
+                        linetable, codelocs, LineTypes, isassign, isidentical
     using ..LoweredCodeUtils: next_or_nothing!, trackedheads, structheads, callee_matches
 
     include("../../Revise/src/packagedef.jl")

--- a/scripts/packages/VSCodeTestServer/src/pkg_imports.jl
+++ b/scripts/packages/VSCodeTestServer/src/pkg_imports.jl
@@ -20,7 +20,7 @@ using ..JuliaInterpreter
 using ..JuliaInterpreter: SSAValue, SlotNumber, Frame
 using ..JuliaInterpreter: @lookup, moduleof, pc_expr, step_expr!, is_global_ref, is_quotenode_egal, whichtt,
     next_until!, finish_and_return!, get_return, nstatements, codelocation, linetable,
-    is_return, lookup_return, is_GotoIfNot, is_ReturnNode
+    is_return, lookup_return
 
 include("../../LoweredCodeUtils/src/packagedef.jl")
 end
@@ -33,7 +33,7 @@ using ..JuliaInterpreter
 using ..CodeTracking: PkgFiles, basedir, srcfiles, line_is_decl, basepath
 using ..JuliaInterpreter: whichtt, is_doc_expr, step_expr!, finish_and_return!, get_return,
     @lookup, moduleof, scopeof, pc_expr, is_quotenode_egal,
-    linetable, codelocs, LineTypes, is_GotoIfNot, isassign, isidentical
+    linetable, codelocs, LineTypes, isassign, isidentical
 using ..LoweredCodeUtils: next_or_nothing!, trackedheads, callee_matches
 include("../../Revise/src/packagedef.jl")
 end


### PR DESCRIPTION
In https://github.com/JuliaDebug/JuliaInterpreter.jl/pull/598 `is_GotoIfNot` and `is_ReturnNode` were removed. With #3531 we started using JuliaInterpreter 0.9.28 which includes this change. This breaks the Julia test server:

```
 Info: Starting the Julia Test Server
ERROR: LoadError: UndefVarError: `is_GotoIfNot` not defined
Stacktrace:
 [1] include(mod::Module, _path::String)
   @ Base .\Base.jl:495
 [2] include(x::String)
   @ VSCodeTestServer c:\Users\visser_mn\.vscode\extensions\julialang.language-julia-1.71.1\scripts\packages\VSCodeTestServer\src\VSCodeTestServer.jl:1
```

With this change, that is fixed. These two functions are not used in this repo or its submodules.

The removal of these functions also caused #3526 but I think that has already been fixed by using a newer Revise version, so I think that issue can be closed as well.