### PR TITLE
Always popfirst the load path, even if using fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Fixed
 * Static inlay hints are now automatically disabled when runtime hints are displayed ([#3539](https://github.com/julia-vscode/julia-vscode/pull/3539))
+* Even if loading a Julia vs-code component fails the Julia LOAD_PATH does not get poluted.
 
 ### Changed
 * Static inlay hints are now disabled by default ([#3539](https://github.com/julia-vscode/julia-vscode/pull/3539))

--- a/scripts/debugger/run_debugger.jl
+++ b/scripts/debugger/run_debugger.jl
@@ -2,8 +2,11 @@
 print("> Connecting to debugger... ")
 
 pushfirst!(LOAD_PATH, joinpath(@__DIR__, "..", "packages"))
-import VSCodeDebugger
-popfirst!(LOAD_PATH)
+try
+    import VSCodeDebugger
+finally
+    popfirst!(LOAD_PATH)
+end
 
 Base.load_julia_startup()
 

--- a/scripts/notebook/notebook.jl
+++ b/scripts/notebook/notebook.jl
@@ -1,8 +1,11 @@
 println(Base.stderr, "Starting notebook kernel server")
 
 pushfirst!(LOAD_PATH, joinpath(@__DIR__, "..", "packages"))
-using VSCodeServer
-popfirst!(LOAD_PATH)
+try
+    using VSCodeServer
+finally
+    popfirst!(LOAD_PATH)
+end
 
 println(Base.stderr, "Core notebook support loaded")
 

--- a/scripts/terminalserver/terminalserver.jl
+++ b/scripts/terminalserver/terminalserver.jl
@@ -6,8 +6,11 @@ let distributed = Base.PkgId(Base.UUID("8ba89e20-285c-5b6f-9357-94700520ee1b"), 
         Distributed.remotecall_eval(Main, 1:Distributed.nprocs(), :(popfirst!(LOAD_PATH)))
     else
         pushfirst!(LOAD_PATH, joinpath(@__DIR__, "..", "packages"))
-        using VSCodeServer
-        popfirst!(LOAD_PATH)
+        try
+            using VSCodeServer
+        finally
+            popfirst!(LOAD_PATH)
+        end
     end
 end
 

--- a/scripts/terminalserver/terminalserver.jl
+++ b/scripts/terminalserver/terminalserver.jl
@@ -2,8 +2,11 @@
 let distributed = Base.PkgId(Base.UUID("8ba89e20-285c-5b6f-9357-94700520ee1b"), "Distributed")
     if haskey(Base.loaded_modules, distributed) && (Distributed = Base.loaded_modules[distributed]).nprocs() > 1
         Distributed.remotecall_eval(Main, 1:Distributed.nprocs(), :(pushfirst!(LOAD_PATH, joinpath($(@__DIR__), "..", "packages"))))
-        using VSCodeServer
-        Distributed.remotecall_eval(Main, 1:Distributed.nprocs(), :(popfirst!(LOAD_PATH)))
+        try
+            using VSCodeServer
+        finally
+            Distributed.remotecall_eval(Main, 1:Distributed.nprocs(), :(popfirst!(LOAD_PATH)))
+        end
     else
         pushfirst!(LOAD_PATH, joinpath(@__DIR__, "..", "packages"))
         try

--- a/scripts/testserver/testserver_main.jl
+++ b/scripts/testserver/testserver_main.jl
@@ -1,8 +1,11 @@
 @info "Starting the Julia Test Server"
 
 pushfirst!(LOAD_PATH, joinpath(@__DIR__, "..", "packages"))
-using VSCodeTestServer
-popfirst!(LOAD_PATH)
+try
+    using VSCodeTestServer
+finally
+    popfirst!(LOAD_PATH)
+end
 
 include("../error_handler.jl")
 

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -260,7 +260,7 @@ async function startREPL(preserveFocus: boolean, showTerminal: boolean = true) {
 function juliaConnector(pipename: string, start = false) {
     const connect = `VSCodeServer.serve(raw"${pipename}"; is_dev = "DEBUG_MODE=true" in Base.ARGS, crashreporting_pipename = raw"${telemetry.getCrashReportingPipename()}");nothing # re-establishing connection with VSCode`
     if (start) {
-        return `pushfirst!(LOAD_PATH, raw"${path.join(g_context.extensionPath, 'scripts', 'packages')}");using VSCodeServer;popfirst!(LOAD_PATH);` + connect
+        return `pushfirst!(LOAD_PATH, raw"${path.join(g_context.extensionPath, 'scripts', 'packages')}");try using VSCodeServer; finally popfirst!(LOAD_PATH) end;` + connect
     } else {
         return connect
     }


### PR DESCRIPTION
Avoids #3542 from happening again.

I just editted this in Github so this will definately need squashing.