### PR TITLE
CI: Run CI on Julia 1.11, and migrate to `julia-actions/install-juliaup`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        julia_version: ['1.0', '1.1', '1.2', '1.3', '1.4', '1.5', '1.6', '1.7', '1.8', '1.9', '1.10']
+        julia_version: ['1.0', '1.1', '1.2', '1.3', '1.4', '1.5', '1.6', '1.7', '1.8', '1.9', '1.10', '1.11']
     steps:
       - uses: actions/checkout@v4
         with:
@@ -52,9 +52,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 16.x
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/install-juliaup@v1
         with:
-          version: ${{matrix.julia_version}}
+          julia-version: ${{matrix.julia_version}}
       - run: npm ci
       - run: npm run compile
       - run: xvfb-run -a npm test
@@ -69,14 +69,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        julia_version: ['1.0', '1.1', '1.2', '1.3', '1.4', '1.5', '1.6', '1.7', '1.8', '1.9', '1.10']
+        julia_version: ['1.0', '1.1', '1.2', '1.3', '1.4', '1.5', '1.6', '1.7', '1.8', '1.9', '1.10', '1.11']
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/install-juliaup@v1
         with:
-          version: ${{matrix.julia_version}}
+          julia-version: ${{matrix.julia_version}}
       - name: 'Run the Julia tests'
         run: |
           julia -e 'using InteractiveUtils; versioninfo()'


### PR DESCRIPTION
Alternative to #3584.

Fixes #.

- [ ] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
