### PR TITLE
Codelens Support in `julia` Files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import { LanguageClient, LanguageClientOptions, RevealOutputChannelOn, ServerOpt
 import * as debugViewProvider from './debugger/debugConfig'
 import { JuliaDebugFeature } from './debugger/debugFeature'
 import * as documentation from './docbrowser/documentation'
+import { CodelensProvider } from './interactive/codelens'
 import { ProfilerFeature } from './interactive/profiler'
 import * as repl from './interactive/repl'
 import { WorkspaceFeature } from './interactive/workspace'
@@ -71,6 +72,7 @@ export async function activate(context: vscode.ExtensionContext) {
                 decreaseIndentPattern: decreaseIndentPattern
             }
         })
+        vscode.languages.registerCodeLensProvider('julia', new CodelensProvider())
 
         const profilerFeature = new ProfilerFeature(context)
         context.subscriptions.push(profilerFeature)

--- a/src/interactive/codelens.ts
+++ b/src/interactive/codelens.ts
@@ -1,0 +1,54 @@
+import * as vscode from 'vscode';
+
+export class CodelensProvider implements vscode.CodeLensProvider {
+
+    private codeLenses: vscode.CodeLens[] = [];
+    private cellDelimiters: string[] = [];
+    private regex: RegExp;
+    private _onDidChangeCodeLenses: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
+    public readonly onDidChangeCodeLenses: vscode.Event<void> = this._onDidChangeCodeLenses.event;
+
+    constructor() {
+        vscode.workspace.onDidChangeConfiguration((_) => {
+            this._onDidChangeCodeLenses.fire();
+        });
+    }
+
+    public provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
+        this.cellDelimiters = vscode.workspace.getConfiguration("julia").get<string[]>("cellDelimiters"); // ['^##(?!#)', '^#(\\s?)%%', '^#-']
+        if (this.cellDelimiters === undefined || this.cellDelimiters.length === 0) {
+            return [];
+        }
+        this.regex = new RegExp(this.cellDelimiters.join("|"), "gm");
+        this.codeLenses = [];
+        const regex = new RegExp(this.regex);
+        const text = document.getText();
+        let matches;
+        while ((matches = regex.exec(text)) !== null) {
+            const line = document.lineAt(document.positionAt(matches.index).line);
+            const indexOf = line.text.indexOf(matches[0]);
+            const position = new vscode.Position(line.lineNumber, indexOf);
+            const range = document.getWordRangeAtPosition(position, new RegExp(this.regex));
+            if (range) {
+                this.codeLenses.push(
+                    new vscode.CodeLens(range, {
+                        title: "Run Cell",
+                        tooltip: "Execute the cell in the Julia REPL",
+                        command: "julia.executeCell",
+                        arguments: [false],
+                    }),
+                    new vscode.CodeLens(range, {
+                        title: "Run Above",
+                        tooltip: "Execute all cells above in the Julia REPL",
+                        command: "julia.executeCell", // TODO: Add a new command for this
+                    }),
+                )
+            }
+        }
+        return this.codeLenses;
+    }
+
+    public resolveCodeLens(codeLens: vscode.CodeLens, token: vscode.CancellationToken) {
+        return codeLens;
+    }
+}


### PR DESCRIPTION
This PR attempts to support CodeLens for `julia` files (#858), enabling users to explore and execute code cells directly in the editor.

<img width="404" alt="image" src="https://github.com/julia-vscode/julia-vscode/assets/32028289/a051c0fa-dc81-4651-ab87-72384ba088c6">

The initial commit only demonstrates the availability of CodeLens for `julia` files. To implement the complete functionality, there are two more tasks to be done.

1. Currently, the `julia.executeCell` command is used to execute code cells. However, the range of the code cell is reliant on the pointer position, where the trigger of CodeLens actions may not enclose the current pointer position.
https://github.com/julia-vscode/julia-vscode/blob/9b009459727161f9292d2890d6c5433ec6932960/src/interactive/repl.ts#L856-L857

To address this issue, I propose two separate approaches:
   - **Workaround**: Modify the `julia.executeCell` command to execute either the code cell enclosing the pointer position or the code cell enclosing the CodeLens trigger position.
   - **General solution**: Strip and refactor all source code related to code cell execution to a more general approach used in the vscode-R extension (https://github.com/REditorSupport/vscode-R/blob/master/src/rmarkdown/chunks.ts). The new approach will statically analyze delimiters of all code cells and then dynamically locate the active code cell based on the executed CodeLens or pointer position. Though this approach may require more computation resources, it may provide a more robust and flexible solution for code cell execution.

I would like to hear the community's opinion on this issue. Either way, I'm willing to implement the solution.

2. To introduce a new command `julia.executeAboveCells` to execute all code cells above the current pointer position if the second solution above is adopted, which is also a common feature in Jupyter notebooks and vscode-R extension.

- [ ] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.


