### PR TITLE
fix: make backtrace pruning work on 1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Add Julia 1.11 support ([#3583](https://github.com/julia-vscode/julia-vscode/pull/3583))
 * `LoadError`s are not unconditionally unwrapped when displayed ([#3592](https://github.com/julia-vscode/julia-vscode/pull/3592))
 * Internals are now more reliably excluded from stacktraces ([#3593](https://github.com/julia-vscode/julia-vscode/pull/3593))
+* Stacktraces printing now works on Julia 1.12 ([#3595](https://github.com/julia-vscode/julia-vscode/pull/3595))
 
 ### Changed
 * Items in the environment selector are now sorted more naturally and Pluto-internal environments are filtered out ([#3594](https://github.com/julia-vscode/julia-vscode/pull/3594))

--- a/scripts/packages/VSCodeServer/src/misc.jl
+++ b/scripts/packages/VSCodeServer/src/misc.jl
@@ -34,7 +34,7 @@ function find_first_trace_entry(bt::Vector{<:Union{Base.InterpreterIP,Ptr{Cvoid}
         st = Base.StackTraces.lookup(ip)
         ind = findfirst(st) do frame
             linfo = frame.linfo
-            if linfo isa Core.CodeInfo
+            if linfo isa Core.CodeInfo && hasproperty(linfo, :linetable)
                 linetable = linfo.linetable
                 if isa(linetable, Vector) && length(linetable) ≥ 1
                     lin = first(linetable)


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/3580.

- [x] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
