### PR TITLE
Add a testitemBlock semantic token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1509,6 +1509,12 @@
                     "highContrastLight": "#4063dd32"
                 }
             }
+        ],
+        "semanticTokenTypes": [
+            {
+              "id": "testitemBlock",
+              "description": "A testitem"
+            }
         ]
     },
     "scripts": {


### PR DESCRIPTION
Something is not yet working, though... I would have expected that with the edit in the `package.json` that the client would send the new token type as part of `SemanticTokensClientCapabilities.tokenTypes`, but it doesn't...