### PR TITLE
Fix optional arguments of @profview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the Julia extension will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+- `@profview` and `@profview_allocs` now support the optional keyword arguments of `Profile.print`, such as `recur = :flat` ([#3666](https://github.com/julia-vscode/julia-vscode/pull/3666)).
+
 ## [1.104.0] - 2024-07-29
 ### Fixed
 - The integrated REPL now once again starts with the user defined environment ([#3660](https://github.com/julia-vscode/julia-vscode/pull/3660))

--- a/scripts/packages/VSCodeServer/src/profiler.jl
+++ b/scripts/packages/VSCodeServer/src/profiler.jl
@@ -30,7 +30,7 @@ function view_profile(data = Profile.fetch(); C=false, kwargs...)
         d[string(thread)] = make_tree(
             ProfileFrame(
                 "root", "", "", 0, graph.count, missing, 0x0, missing, ProfileFrame[]
-            ), graph; C=C, kwargs...)
+            ), graph; C=C)
     end
 
     JSONRPC.send(conn_endpoint[], repl_showprofileresult_notification_type, (; trace=d, typ="Thread"))


### PR DESCRIPTION
Stopped passing additional keywords to make_tree when calling @profview. 

Fixes
```jl
@profview f(x) recur=:flat
```

- [x] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
