### PR TITLE
Use stable VS Code API to edit notebook metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - `@profview` and `@profview_allocs` now support the optional keyword arguments of `Profile.print`, such as `recur = :flat` ([#3666](https://github.com/julia-vscode/julia-vscode/pull/3666)).
 - The integrated REPL now respects a user-set active project (e.g. in `additionalArgs` and `startup.jl`) ([#3670](https://github.com/julia-vscode/julia-vscode/pull/3669))
+- Changes to how Jupyter Notebook Metadata is updated ([#3690](https://github.com/julia-vscode/julia-vscode/pull/3690))
 
 ## [1.104.0] - 2024-07-29
 ### Fixed


### PR DESCRIPTION
For https://github.com/microsoft/vscode/issues/227419

- [N/A] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.

@davidanthoff Given that the Notebook API in VS Code is now stable, we can start using that instead of the private extension specific API added.
The plan is to get this merged, and once you have shipped a new version of the Julia extension we can then remove the other internal API `vscodeIpynbApi.setNotebookMetadata` (perhaps in another month or two, giving enough time for Julia extension to adopt and publish the changes)