### PR TITLE
Pass `config` field to Plotly.newPlot call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Added
 - Added `juliaAdditionalArgs` option to Julia debug launch configuration ([#3699](https://github.com/julia-vscode/julia-vscode/pull/3699)).
+- Added passing of `config` field when making a Plotly plot in the plot pane ([#3734](https://github.com/julia-vscode/julia-vscode/pull/3734)).
 ### Fixed
 - `@profview` and `@profview_allocs` now support the optional keyword arguments of `Profile.print`, such as `recur = :flat` ([#3666](https://github.com/julia-vscode/julia-vscode/pull/3666)).
 - The integrated REPL now respects a user-set active project (e.g. in `additionalArgs` and `startup.jl`) ([#3670](https://github.com/julia-vscode/julia-vscode/pull/3669))

--- a/src/interactive/plots.ts
+++ b/src/interactive/plots.ts
@@ -787,7 +787,7 @@ export function displayPlot(params: { kind: string, data: string }, kernel?: Jul
                 Plotly.relayout('plot-element', update)
             }
             const spec = ${payload};
-            Plotly.newPlot('plot-element', spec.data, spec.layout);
+            Plotly.newPlot('plot-element', spec.data, spec.layout, spec.config);
             if (!(spec.layout.width || spec.layout.height)) {
                 onResize()
                 window.addEventListener('resize', onResize);

--- a/src/interactive/plots.ts
+++ b/src/interactive/plots.ts
@@ -101,8 +101,9 @@ class PlotNavigatorProvider implements vscode.WebviewViewProvider {
         if (this?.view?.show === undefined) {
             // this forces the webview to be resolved, but changes focus:
             await vscode.commands.executeCommand('julia-plot-navigator.focus')
+        } else {
+            this.view.show(true)
         }
-        this.view.show(true)
     }
 
     setPlotsInfo(set_func) {


### PR DESCRIPTION
As discussed on slack, verified works locally.

Fixes https://github.com/JuliaPlots/PlotlyJS.jl/issues/444

