### PR TITLE
Update plotly.js to 2.35.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The integrated REPL now respects a user-set active project (e.g. in `additionalArgs` and `startup.jl`) ([#3670](https://github.com/julia-vscode/julia-vscode/pull/3669))
 - Changes to how Jupyter Notebook Metadata is updated ([#3690](https://github.com/julia-vscode/julia-vscode/pull/3690))
 - Fix a bug where non-supported schemes were sent to the LS ([#3700](https://github.com/julia-vscode/julia-vscode/pull/3700))
+### Changed
+- Plotly javascript library updated to 2.35.2 ([#3750](https://github.com/julia-vscode/julia-vscode/pull/3750)).
 
 ## [1.104.0] - 2024-07-29
 ### Fixed

--- a/src/scripts/updateDeps.ts
+++ b/src/scripts/updateDeps.ts
@@ -39,6 +39,7 @@ async function main() {
     await our_download('https://cdn.jsdelivr.net/npm/vega@4', 'libs/vega-4/vega.min.js')
     await our_download('https://cdn.jsdelivr.net/npm/vega@5', 'libs/vega-5/vega.min.js')
     await our_download('https://cdn.jsdelivr.net/npm/vega-embed@6', 'libs/vega-embed/vega-embed.min.js')
+    await our_download('https://cdn.jsdelivr.net/npm/plotly.js@2/dist/plotly.min.js', 'libs/plotly/plotly.min.js')
 
     await our_download('https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js', 'libs/webfont/webfont.js')
 


### PR DESCRIPTION
The bundled *plotly.js* is now 3 years old (last updated by #2376).
While the plots made for the new versions of plotly still could be displayed in principle, some new features (e.g. shape labels, tick labels) are not displayed.
This PR brings it to 2.35.2.
The *plotly.min.js* is taken as is from https://cdn.plot.ly/plotly-2.35.2.min.js.

Also added `plotly.min.js` support to *updateDeps.ts* scripts to make these updates automatic.