### PR TITLE
Limit log output during debug runs for the LS

### DIFF
--- a/scripts/languageserver/main.jl
+++ b/scripts/languageserver/main.jl
@@ -135,7 +135,7 @@ try
     end
 
     if debug_mode
-        ENV["JULIA_DEBUG"] = "all"
+        ENV["JULIA_DEBUG"] = "Main,CancellationTokens,CSTParser,JuliaFormatter,JSONRPC,JuliaSyntax,JuliaWorkspaces,LanguageServer,StaticLint,SymbolServer,Salsa,TestItemDetection"
     end
 
     if detached_mode


### PR DESCRIPTION
Fixes #.

- [ ] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
