### PR TITLE
Tolerate "Endpoint is closed" exception thrown by JSONRPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The integrated REPL now respects a user-set active project (e.g. in `additionalArgs` and `startup.jl`) ([#3670](https://github.com/julia-vscode/julia-vscode/pull/3669))
 - Changes to how Jupyter Notebook Metadata is updated ([#3690](https://github.com/julia-vscode/julia-vscode/pull/3690))
 - Fix a bug where non-supported schemes were sent to the LS ([#3700](https://github.com/julia-vscode/julia-vscode/pull/3700))
+- Don't exit VSCodeServer when JSONRPC reports endpoint is closed ([#3674](https://github.com/julia-vscode/julia-vscode/pull/3674))
 
 ## [1.104.0] - 2024-07-29
 ### Fixed

--- a/scripts/error_handler.jl
+++ b/scripts/error_handler.jl
@@ -4,6 +4,8 @@ import InteractiveUtils
 is_disconnected_exception(err) = false
 is_disconnected_exception(err::InvalidStateException) = err.state === :closed
 is_disconnected_exception(err::Base.IOError) = true
+# thrown by JSONRPC when the endpoint is :closed
+is_disconnected_exception(err::ErrorException) = err.msg == "Endpoint is not running, the current state is closed."
 is_disconnected_exception(err::CompositeException) = all(is_disconnected_exception, err.exceptions)
 
 function global_err_handler(e, bt, vscode_pipe_name, cloudRole)


### PR DESCRIPTION
Treat the "Endpoint is closed" exception thrown by JSONRPC as a disconnected exception and don't exit.

Fixes #3674.

I did not have a chance to test it yet

- [ ] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
