### PR TITLE
Allow saving for Makie png/html plots and improve clipboard behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The integrated REPL now respects a user-set active project (e.g. in `additionalArgs` and `startup.jl`) ([#3670](https://github.com/julia-vscode/julia-vscode/pull/3669))
 - Changes to how Jupyter Notebook Metadata is updated ([#3690](https://github.com/julia-vscode/julia-vscode/pull/3690))
 - Fix a bug where non-supported schemes were sent to the LS ([#3700](https://github.com/julia-vscode/julia-vscode/pull/3700))
+- Fix saving from plot pane for text/html plots with a single img tag (e.g. Makie) and decrease "copy plot to clipboard" failure rate due to missing focus ([#3780](https://github.com/julia-vscode/julia-vscode/pull/3780))
 ### Changed
 - Plotly javascript library updated to 2.35.2 ([#3750](https://github.com/julia-vscode/julia-vscode/pull/3750)).
 - Test item runner migrated to TestItemControllers.jl

--- a/scripts/plots/main_plot_webview.js
+++ b/scripts/plots/main_plot_webview.js
@@ -261,7 +261,11 @@ window.addEventListener('message', ({ data }) => {
         handlePlotSaveRequest(data.body.index)
         break
     case REQUEST_COPY_PLOT_TYPE:
-        handlePlotCopyRequest()
+        // according to https://stackoverflow.com/questions/77465342/how-do-i-ensure-that-the-website-has-focus-so-the-copy-to-clipboard-can-happen
+        // `setTimeout` avoids that the focus check in handlePlotCopyRequest fails because
+        // the browser doesn't give the document focus back quickly enough after the user clicks the button
+        // triggering the clipboard interaction (which is only allowed with focus)
+        setTimeout(handlePlotCopyRequest, 0);
         break
     default:
         console.error(new Error('Unknown plot request!'))

--- a/scripts/plots/main_plot_webview.js
+++ b/scripts/plots/main_plot_webview.js
@@ -71,7 +71,7 @@ const COPY_SUCCESS_MESSAGE_TYPE = 'copySuccess'
  * @param {number} index
  */
 function handlePlotSaveRequest(index) {
-    const plot = getPlotElement()
+    let plot = getPlotElement()
     if (isPlotly()) {
         Plotly.Snapshot.toImage(plot, { format: 'svg' }).once('success', (url) => {
             const svg = decodeURIComponent(url).replace(/data:image\/svg\+xml,/, '')
@@ -83,6 +83,13 @@ function handlePlotSaveRequest(index) {
 
         postMessageToHost(SAVE_PLOT_MESSAGE_TYPE, { svg, index })
     } else {
+        // e.g. Makie may display png images via a HTML mime type. If the plot pane content is a div (so we didn't have one of the image MIME types
+        // that we wrap in <img> ourselves) we can check if there's a single <img> in there, and if so, continue the plot saving logic with that.
+        const innerPlot = getSingleImgFromHtmlContent(plot);
+        if (innerPlot !== null){
+            plot = innerPlot;
+        }
+
         const { src } = plot
 
         const svg = src.includes('image/svg')
@@ -97,6 +104,16 @@ function handlePlotSaveRequest(index) {
 
         postMessageToHost(SAVE_PLOT_MESSAGE_TYPE, { svg, png, gif, index })
     }
+}
+
+function getSingleImgFromHtmlContent(el){
+    if (el.tagName.toLowerCase() === "div") {
+        const child = el.children.length === 1 ? el.children[0] : undefined;
+        if (child && child.tagName.toLowerCase() === "img") {
+            return child;
+        }
+    }
+    return null
 }
 
 function handlePlotCopyRequest() {

--- a/scripts/plots/main_plot_webview.js
+++ b/scripts/plots/main_plot_webview.js
@@ -265,7 +265,7 @@ window.addEventListener('message', ({ data }) => {
         // `setTimeout` avoids that the focus check in handlePlotCopyRequest fails because
         // the browser doesn't give the document focus back quickly enough after the user clicks the button
         // triggering the clipboard interaction (which is only allowed with focus)
-        setTimeout(handlePlotCopyRequest, 0);
+        setTimeout(handlePlotCopyRequest, 0.05);
         break
     default:
         console.error(new Error('Unknown plot request!'))

--- a/src/interactive/plots.ts
+++ b/src/interactive/plots.ts
@@ -498,7 +498,9 @@ export function displayPlot(params: { kind: string, data: string }, kernel?: Jul
         showPlotPane()
     }
     else if (kind === 'juliavscode/html') {
-        g_currentPlotIndex = g_plots.push(payload) - 1
+        // the wrapper doesn't do anything visually, just lets us pick up the plot pane content via the id later
+        const wrapped = `<div id="plot-element" style="position: absolute; max-width: 100%; max-height: 100vh; top: 0; left: 0;">${payload}</div>`
+        g_currentPlotIndex = g_plots.push(wrapped) - 1
         showPlotPane()
     }
     else if (kind === 'application/vnd.vegalite.v2+json') {


### PR DESCRIPTION
The "save plot" button was not working for Makie plots ever since Makie started to show them via html MIME types, as the png MIME type doesn't show them at the intended pixel density. This PR wraps html content in an id'ed div so the plot detection code can pick that up and extract a possible single `<img>` tag. With that, the existing code works for the Makie case as well.

Also, I had trouble with the "copy plot to clipboard" functionality for a long time, so while I was at it, I looked into improving that as well. It seems that the focus check for clipboard access often fails because of a race condition inherent in this system, so apparently adding a small timeout improves that https://stackoverflow.com/questions/77465342/how-do-i-ensure-that-the-website-has-focus-so-the-copy-to-clipboard-can-happen. Anecdotally, this feels much better on my system. With the 0.05 timeout I seem to almost never get the "not focused" error while before I was getting that all the time. But would probably be good for others to test this, too, because the error is already nondeterministic, so the "fix" kind of is as well.

I didn't see these two functions in tests, but maybe I overlooked where the behavior is currently tested. If so, I could add tests there.