### PR TITLE
feat: add a configurable julia executable path for language server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added `juliaAdditionalArgs` option to Julia debug launch configuration ([#3699](https://github.com/julia-vscode/julia-vscode/pull/3699)).
 - Added passing of `config` field when making a Plotly plot in the plot pane ([#3734](https://github.com/julia-vscode/julia-vscode/pull/3734)).
+- Added `julia.languageServerExecutablePath` setting, which allows specifying a Julia executable path specifically for the LanguageServer runtime ([#3793](https://github.com/julia-vscode/julia-vscode/pull/3793)).
 ### Fixed
 - `@profview` and `@profview_allocs` now support the optional keyword arguments of `Profile.print`, such as `recur = :flat` ([#3666](https://github.com/julia-vscode/julia-vscode/pull/3666)).
 - The integrated REPL now respects a user-set active project (e.g. in `additionalArgs` and `startup.jl`) ([#3670](https://github.com/julia-vscode/julia-vscode/pull/3669))

--- a/package.json
+++ b/package.json
@@ -1264,6 +1264,12 @@
                     "default": true,
                     "description": "Show top-level modules in the workspace.",
                     "scope": "application"
+                },
+                "julia.languageServerExecutablePath": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Points to the julia executable used to launch the language server process. This overwrites julia.executablePath for the language server launch if present.",
+                    "scope": "machine-overridable"
                 }
             }
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -232,7 +232,7 @@ async function startLanguageServer(juliaExecutablesFeature: JuliaExecutablesFeat
     g_startupNotification.show()
 
     let juliaLSExecutable: JuliaExecutable | null = null
-    const juliaExecutable = await juliaExecutablesFeature.getActiveJuliaExecutableAsync()
+    const juliaExecutable = await juliaExecutablesFeature.getActiveLaunguageServerJuliaExecutableAsync()
 
     if(await juliaExecutablesFeature.isJuliaup()) {
         if (Boolean(process.env.DEBUG_MODE)) {

--- a/src/juliaexepath.ts
+++ b/src/juliaexepath.ts
@@ -329,6 +329,8 @@ export class JuliaExecutablesFeature {
                 this.diagnosticsOutput.appendLine('Juliaup not found, locating Julia by other means.')
 
                 const configPath = this.getExecutablePath()
+                this.diagnosticsOutput.appendLine(`The current configuration value for 'julia.executablePath' is '${configPath}'.`)
+
                 if (!configPath) {
                     for (const p of this.getSearchPaths()) {
                         if (await this.tryAndSetNewJuliaExePathAsync(p)) {
@@ -339,6 +341,14 @@ export class JuliaExecutablesFeature {
                 else {
                     await this.tryAndSetNewJuliaExePathAsync(configPath)
                 }
+
+                const LSConfigPath = this.getLanguageServerExecutablePath()
+                this.diagnosticsOutput.appendLine(`The current configuration value for 'julia.languageServerExecutablePath' is '${LSConfigPath}'.`)
+
+                if (LSConfigPath) {
+                    await this.tryAndSetNewLanguageServerJuliaExePathAsync(LSConfigPath)
+                }
+
             }
             // Even when Juliaup reports a version, we still want the configuration setting
             // to have higher priority
@@ -354,7 +364,7 @@ export class JuliaExecutablesFeature {
                 }
 
                 const LSConfigPath = this.getLanguageServerExecutablePath()
-                this.diagnosticsOutput.appendLine(`The current configuration value for 'julia.languageServerExecutablePath' is '${configPath}'.`)
+                this.diagnosticsOutput.appendLine(`The current configuration value for 'julia.languageServerExecutablePath' is '${LSConfigPath}'.`)
 
                 if (LSConfigPath) {
                     await this.tryAndSetNewLanguageServerJuliaExePathAsync(LSConfigPath)

--- a/src/juliaexepath.ts
+++ b/src/juliaexepath.ts
@@ -66,14 +66,19 @@ export class JuliaExecutable {
 
 export class JuliaExecutablesFeature {
     private actualJuliaExePath: JuliaExecutable | undefined
+    private actualLanguageServerJuliaExePath: JuliaExecutable | undefined
     private cachedJuliaExePaths: JuliaExecutable[] | undefined
     private usingJuliaup: boolean | null = null
 
     constructor(private context: vscode.ExtensionContext, private diagnosticsOutput: JuliaGlobalDiagnosticOutputFeature) {
         this.context.subscriptions.push(
             onDidChangeConfig(event => {
-                if (event.affectsConfiguration('julia.executablePath')) {
+                if (
+                    event.affectsConfiguration('julia.executablePath') ||
+                    event.affectsConfiguration('julia.languageServerExecutablePath')
+                ) {
                     this.actualJuliaExePath = undefined
+                    this.actualLanguageServerJuliaExePath = undefined
                     this.cachedJuliaExePaths = undefined
                     this.usingJuliaup = null
                 }
@@ -137,6 +142,20 @@ export class JuliaExecutablesFeature {
             this.actualJuliaExePath = newJuliaExecutable
             setCurrentJuliaVersion(this.actualJuliaExePath.version)
             traceEvent('configured-new-julia-binary')
+
+            return true
+        }
+        else {
+            return false
+        }
+    }
+
+    async tryAndSetNewLanguageServerJuliaExePathAsync(newPath: string) {
+        const newJuliaExecutable = await this.tryJuliaExePathAsync(newPath)
+
+        if (newJuliaExecutable) {
+            this.actualLanguageServerJuliaExePath = newJuliaExecutable
+            traceEvent('configured-new-ls-julia-binary')
 
             return true
         }
@@ -333,6 +352,13 @@ export class JuliaExecutablesFeature {
                 if (configPath) {
                     await this.tryAndSetNewJuliaExePathAsync(configPath)
                 }
+
+                const LSConfigPath = this.getLanguageServerExecutablePath()
+                this.diagnosticsOutput.appendLine(`The current configuration value for 'julia.languageServerExecutablePath' is '${configPath}'.`)
+
+                if (LSConfigPath) {
+                    await this.tryAndSetNewLanguageServerJuliaExePathAsync(LSConfigPath)
+                }
             }
 
             if(this.actualJuliaExePath) {
@@ -346,6 +372,15 @@ export class JuliaExecutablesFeature {
         return this.actualJuliaExePath
     }
 
+    public async getActiveLaunguageServerJuliaExecutableAsync() {
+        const actualJuliaExePath = await this.getActiveJuliaExecutableAsync()
+        if (this.actualLanguageServerJuliaExePath === undefined ){
+            return actualJuliaExePath
+        } else {
+            return this.actualLanguageServerJuliaExePath
+        }
+    }
+
     public async isJuliaup() {
         if(this.usingJuliaup===null) {
             await this.tryJuliaup()
@@ -356,6 +391,10 @@ export class JuliaExecutablesFeature {
 
     getExecutablePath() {
         const jlpath = vscode.workspace.getConfiguration('julia').get<string>('executablePath')
+        return jlpath === '' ? undefined : jlpath
+    }
+    getLanguageServerExecutablePath() {
+        const jlpath = vscode.workspace.getConfiguration('julia').get<string>('languageServerExecutablePath')
         return jlpath === '' ? undefined : jlpath
     }
 }


### PR DESCRIPTION
This addresses a use case where a user might want to set a different julia executable path for language server specifically.
One example is that the user might want to always launch julia repl with a specific sysimage, but they want the language server not to use that sysimage, but just plain julia.

- [x] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.

Docs https://github.com/julia-vscode/docs/pull/92
