### PR TITLE
Fix @profview to correctly include interactive threads

### DIFF
--- a/scripts/packages/VSCodeServer/src/profiler.jl
+++ b/scripts/packages/VSCodeServer/src/profiler.jl
@@ -27,7 +27,14 @@ function view_profile(data = Profile.fetch(); C=false, kwargs...)
     data_u64 = convert(Vector{UInt64}, data)
     for thread in threads
         graph = stackframetree(data_u64, lidict; thread=thread, kwargs...)
-        d[string(thread)] = make_tree(
+        threadname = if thread == "all"
+            "All"
+        elseif thread <= Threads.nthreads(:interactive)
+            "Interactive: $(thread)"
+        else
+            "Worker: $(thread - Threads.nthreads(:interactive))"
+        end
+        d[threadname] = make_tree(
             ProfileFrame(
                 "root", "", "", 0, graph.count, missing, 0x0, missing, ProfileFrame[]
             ), graph; C=C)

--- a/scripts/packages/VSCodeServer/src/profiler.jl
+++ b/scripts/packages/VSCodeServer/src/profiler.jl
@@ -13,7 +13,7 @@ function view_profile(data = Profile.fetch(); C=false, kwargs...)
     d = Dict{String,ProfileFrame}()
 
     if VERSION >= v"1.8.0-DEV.460"
-        threads = ["all", 1:Threads.nthreads()...]
+        threads = ["all", 1:(Threads.nthreads(:interactive)+Threads.nthreads(:default))...]
     else
         threads = ["all"]
     end
@@ -39,7 +39,7 @@ end
 function stackframetree(data_u64, lidict; thread=nothing, combine=true, recur=:off)
     root = combine ? Profile.StackFrameTree{StackTraces.StackFrame}() : Profile.StackFrameTree{UInt64}()
     if VERSION >= v"1.8.0-DEV.460"
-        thread = thread == "all" ? (1:Threads.nthreads()) : thread
+        thread = thread == "all" ? (1:(Threads.nthreads(:interactive)+Threads.nthreads(:default))) : thread
         root, _ = Profile.tree!(root, data_u64, lidict, true, recur, thread)
     else
         root = Profile.tree!(root, data_u64, lidict, true, recur)


### PR DESCRIPTION
@profview does not show information from all worker threads because it fails to count the total number of threads correctly, incorrectly only counting the number of worker threads. However, since Julia orders interactive threads before worker threads, we miss out on the last worker thread (assuming one interactive thread). Since Julia will by default have 1 interactive thread starting with v1.12, it's important to fix this before that releases.

Fixes #3820.

I've made the minimal possible change here and tested that this works on my own machine. I've also made a small GUI change: the dropdown on the profiler now lists "All", "Interactive: x", "Worker: y" instead of just numbering the threads. I've made the choice that worker threads start at 1, instead of `nthreads(:interactive) + 1`, but this can of course be changed.

- [X] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.

I don't think this requires a documentation update, it should be self-explanatory.