### PR TITLE
feat: support variable substitution for `environmentPath` setting

### DIFF
--- a/src/jlpkgenv.ts
+++ b/src/jlpkgenv.ts
@@ -20,6 +20,14 @@ let g_resolved_path_of_environment: string = null
 
 let g_juliaExecutablesFeature: JuliaExecutablesFeature = null
 
+function getEnvironmentPathConfig() {
+    const section = vscode.workspace.getConfiguration('julia')
+    const rawConfigValue = section.get<string>('environmentPath')
+    const workspaceFolderPath =
+        vscode.workspace.workspaceFolders?.[0]?.uri?.fsPath // Use the first workspace folder if it exists
+    return rawConfigValue.replace('${workspaceFolder}', workspaceFolderPath)
+}
+
 export async function getProjectFilePaths(envpath: string) {
     return {
         project_toml_path: (await fs.exists(path.join(envpath, 'JuliaProject.toml'))) ?
@@ -37,7 +45,7 @@ export async function switchEnvToPath(envpath: string, notifyLS: boolean) {
 
     const section = vscode.workspace.getConfiguration('julia')
 
-    const currentConfigValue = section.get<string>('environmentPath')
+    const currentConfigValue = getEnvironmentPathConfig()
 
     if (g_path_of_current_environment !== await getDefaultEnvPath()) {
         if (currentConfigValue !== g_path_of_current_environment) {
@@ -223,8 +231,7 @@ async function getDefaultEnvPath() {
 
 async function getEnvPath() {
     if (g_path_of_current_environment === null) {
-        const section = vscode.workspace.getConfiguration('julia')
-        const envPathConfig = section.get<string>('environmentPath')
+        const envPathConfig = getEnvironmentPathConfig()
         if (envPathConfig) {
             if (await fs.exists(absEnvPath(resolvePath(envPathConfig)))) {
                 g_path_of_current_environment = envPathConfig


### PR DESCRIPTION
I was mainly concerned with supporting `${workspaceFolder}`, but you can find the substitution rules for many other patterns here:

https://github.com/default-writer/filetestonsave/blob/main/src/extension.ts

Note, the tooltip help for the `environmentPath` setting already states that `${workspaceFolder}` is supported
which is **not** the case.  So this at least makes this tooltip (shown below) slightly more honest:

![image](https://github.com/user-attachments/assets/1baa278f-bea2-47bf-9bb0-7e120a3b3e2b)
