### PR TITLE
Highlight docstring in .jl files using "string.docstring.julia"

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,13 @@
                 "embeddedLanguages": {
                     "meta.embedded.block.julia": "julia"
                 }
+            },
+            {
+                "scopeName": "source.docstring.julia",
+                "path": "./syntaxes/juliadocstring.json",
+                "injectTo": [
+                    "source.julia"
+                ]
             }
         ],
         "commands": [

--- a/syntaxes/juliadocstring.json
+++ b/syntaxes/juliadocstring.json
@@ -1,0 +1,32 @@
+{
+  "name": "Julia Docstring Code Block Highlighter",
+  "scopeName": "source.docstring.julia",
+  "injectionSelector": "L:string.docstring.julia",
+  "fileTypes": [
+    "jl"
+  ],
+  "patterns": [
+    {
+      "include": "#julia-code-block"
+    }
+  ],
+  "repository": {
+    "julia-code-block": {
+      "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(julia|jl(doctest)?|julia-repl))((;|\\s)([^`~]*))?$",
+      "name": "docstring.julia.codeblock",
+      "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+      "patterns": [
+        {
+          "begin": "(^|\\G)(\\s*)(.*)",
+          "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+          "contentName": "meta.embedded.block.julia",
+          "patterns": [
+            {
+              "include": "source.julia"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Hello!

This is a rehash of [juliacodeblock.json](https://github.com/julia-vscode/julia-vscode/blob/main/syntaxes/juliacodeblock.json) but injecting in `L:string.docstring.julia`.

From my limited testing, it seems to work correctly with no leaks to the main source. Obviously, nested docstring in the codeblock does not work, in that case the syntax highlighting seems to fail completely.

<img width="467" height="755" alt="image" src="https://github.com/user-attachments/assets/f60d4b36-774f-4594-bbb2-cdc5531d93fa" />

If there is any additional testing I can do on my side, I'll be glad to do so!