### PR TITLE
feat: add progress logging support for notebooks

### DIFF
--- a/scripts/notebook/notebook.jl
+++ b/scripts/notebook/notebook.jl
@@ -11,13 +11,17 @@ let
         @info "Processing command line arguments..."
     end
 
-    args = [popfirst!(Base.ARGS) for _ in 1:3]
+    args = [popfirst!(Base.ARGS) for _ in 1:min(length(Base.ARGS), 4)]
 
     conn_pipename, debugger_pipename, telemetry_pipename = args[1:3]
+
+    use_progress = "USE_PROGRESS=true" in args
 
     Base.with_logger(outputchannel_logger) do
         @info "Command line arguments processed"
     end
+
+    VSCodeServer.toggle_progress_notification(nothing, (;enable=use_progress))
 
     ccall(:jl_exit_on_sigint, Nothing, (Cint,), false)
 

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -34,6 +34,8 @@ import { randomUUID } from 'crypto'
 import { promisify } from 'node:util'
 import child_process from 'node:child_process'
 import { Uri } from 'vscode'
+import { ProgressReporter, ProgressUpdate } from '../progress'
+
 const exec = promisify(child_process.exec)
 
 let g_context: vscode.ExtensionContext = null
@@ -520,13 +522,7 @@ const notifyTypeOpenFile = new rpc.NotificationType<{ path: string; line: number
 )
 const notifyTypeCheckRevise = new rpc.NotificationType<boolean>('norevise')
 
-interface Progress {
-    id: { value: number }
-    name: string
-    fraction: number
-    done: boolean
-}
-const notifyTypeProgress = new rpc.NotificationType<Progress>('repl/updateProgress')
+const notifyTypeProgress = new rpc.NotificationType<ProgressUpdate>('repl/updateProgress')
 
 const g_onInit = new vscode.EventEmitter<{ connection: rpc.MessageConnection; juliaExecutable?: JuliaExecutable }>()
 export const onInit = g_onInit.event
@@ -574,94 +570,6 @@ function startREPLMsgServer(pipename: string, juliaExecutable?: JuliaExecutable)
     server.listen(pipename)
 
     return connected
-}
-
-const g_progress_dict = {}
-
-async function updateProgress(progress: Progress) {
-    if (g_progress_dict[progress.id.value]) {
-        const p = g_progress_dict[progress.id.value]
-        const increment = progress.done ? 100 : (progress.fraction - p.last_fraction) * 100
-
-        p.progress.report({
-            increment: increment,
-            message: progressMessage(progress, p.started),
-        })
-        p.last_fraction = progress.fraction
-
-        if (progress.done) {
-            p.resolve()
-            delete g_progress_dict[progress.id.value]
-        }
-    } else {
-        vscode.window.withProgress(
-            {
-                location: vscode.ProgressLocation.Window,
-                title: 'Julia',
-                cancellable: true,
-            },
-            (prog, token) => {
-                return new Promise((resolve) => {
-                    g_progress_dict[progress.id.value] = {
-                        progress: prog,
-                        last_fraction: progress.fraction,
-                        started: new Date(),
-                        resolve: resolve,
-                    }
-                    token.onCancellationRequested(() => {
-                        interrupt()
-                    })
-                    prog.report({
-                        message: progressMessage(progress),
-                    })
-                })
-            }
-        )
-    }
-}
-
-function progressMessage(prog: Progress, started = null) {
-    let message = prog.name
-    const parenthezise = message.trim().length > 0
-    if (isFinite(prog.fraction) && 0 <= prog.fraction && prog.fraction <= 1) {
-        if (parenthezise) {
-            message += ' ('
-        }
-        message += `${(prog.fraction * 100).toFixed(1)}%`
-        if (started !== null) {
-            const elapsed = (new Date().valueOf() - started) / 1000
-            const remaining = (1 / prog.fraction - 1) * elapsed
-            if (isFinite(remaining)) {
-                message += ` - ${formattedTimePeriod(remaining)} remaining`
-            }
-        }
-        if (parenthezise) {
-            message += ')'
-        }
-    }
-    return message
-}
-
-function formattedTimePeriod(t) {
-    const seconds = Math.floor(t % 60)
-    const minutes = Math.floor((t / 60) % 60)
-    const hours = Math.floor(t / 60 / 60)
-    let out = ''
-    if (hours > 0) {
-        out += `${hours}h, `
-    }
-    if (minutes > 0) {
-        out += `${minutes}min, `
-    }
-    out += `${seconds}s`
-    return out
-}
-
-function clearProgress() {
-    for (const id in g_progress_dict) {
-        g_progress_dict[id].resolve()
-        delete g_progress_dict[id]
-    }
 }
 
 interface InlayHintConfig {
@@ -1229,6 +1137,8 @@ async function activateFromDir(uri: vscode.Uri) {
     }
 }
 
+const replProgress = new ProgressReporter(() => interrupt())
+
 async function searchUpFile(target: string, from: string): Promise<string> {
     const parentDir = path.dirname(from)
     if (parentDir === from) {
@@ -1365,7 +1275,9 @@ export function activate(
                 connection.onNotification(notifyTypeOpenFile, ({ path, line, preserveFocus }) =>
                     openFile(path, line, undefined, preserveFocus)
                 )
-                connection.onNotification(notifyTypeProgress, updateProgress)
+                connection.onNotification(notifyTypeProgress, (progress) => {
+                    void replProgress.handleProgress(progress)
+                })
                 setContext('julia.isEvaluating', false)
                 setContext('julia.hasREPL', true)
             })
@@ -1378,22 +1290,16 @@ export function activate(
             results.removeAll()
             clearDiagnostics()
             clearInlayHints()
-            clearProgress()
-
+            replProgress.clear()
             setContext('julia.isEvaluating', false)
             setContext('julia.hasREPL', false)
         }),
         onStartEval(() => {
-            updateProgress({
-                name: 'Evaluating…',
-                id: { value: -1 },
-                fraction: -1,
-                done: false,
-            })
+            replProgress.startIndeterminate()
             setContext('julia.isEvaluating', true)
         }),
         onFinishEval(() => {
-            clearProgress()
+            replProgress.clear()
             setContext('julia.isEvaluating', false)
         }),
         onEvent(vscode.workspace.onDidChangeConfiguration, async (event) => {

--- a/src/notebook/notebookFeature.ts
+++ b/src/notebook/notebookFeature.ts
@@ -182,6 +182,13 @@ export class JuliaNotebookFeature {
         }
     }
 
+    private interruptActiveNotebook() {
+        const activeNotebook = vscode.window.activeNotebookEditor?.notebook
+        if (activeNotebook) {
+            void this.interrupt(activeNotebook)
+        }
+    }
+
     private onDidOpenNotebookDocument(e: vscode.NotebookDocument) {
         this.init()
 

--- a/src/notebook/notebookKernel.ts
+++ b/src/notebook/notebookKernel.ts
@@ -20,6 +20,7 @@ import { getCrashReportingPipename, handleNewCrashReportFromException } from '..
 import { generatePipeName, getCustomEnvironmentVariables, inferJuliaNumThreads } from '../utils'
 import { JuliaNotebookFeature } from './notebookFeature'
 import { DebugConfigTreeProvider } from '../debugger/debugConfig'
+import { ProgressReporter, ProgressUpdate } from '../progress'
 
 const notifyTypeDisplay = new NotificationType<{
     items: { mimetype: string; data: string }[]
@@ -28,6 +29,7 @@ const notifyTypeStreamoutput = new NotificationType<{
     name: string
     data: string
 }>('streamoutput')
+const notifyTypeProgressUpdate = new NotificationType<ProgressUpdate>('repl/updateProgress')
 const requestTypeRunCell = new RequestType<
     { filename: string; line: number; column: number; code: string },
     { success: boolean; error: { message: string; name: string; stack: string } },
@@ -60,6 +62,11 @@ export class JuliaKernel {
 
     private _tokenSource = new vscode.CancellationTokenSource()
 
+    private progressReporter: ProgressReporter
+    private statusBarItem: vscode.StatusBarItem
+    private isActive = false
+    private statusProgressStarts = new Map<number, Date>()
+
     private debuggerPipename: string | null
     public activeDebugSession: vscode.DebugSession | null
     public stopDebugSessionAfterExecution: boolean
@@ -73,11 +80,44 @@ export class JuliaKernel {
         private notebookFeature: JuliaNotebookFeature,
         private compiledProvider: DebugConfigTreeProvider
     ) {
+        this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 101)
+        this.progressReporter = new ProgressReporter(() => this.interrupt(), {
+            statusBarItem: this.statusBarItem,
+            statusBarPrefix: 'Notebook',
+            // No command: clicking notebook progress does nothing.
+            useWindowProgress: false,
+        })
+        this._localDisposables.push(this.statusBarItem)
+
+        // Track active notebook to gate status bar updates.
+        const setActive = () => {
+            const active = vscode.window.activeNotebookEditor?.notebook?.uri.toString()
+            const mine = this.notebook.uri.toString()
+            const wasActive = this.isActive
+            this.isActive = active === mine
+
+            if (!this.isActive && wasActive) {
+                this.progressReporter.clear()
+            }
+        }
+
+        setActive()
+        this._localDisposables.push(vscode.window.onDidChangeActiveNotebookEditor(setActive))
+
+        this._localDisposables.push(
+            vscode.workspace.onDidChangeConfiguration((event) => {
+                if (event.affectsConfiguration('julia.useProgressFrontend')) {
+                    this.sendProgressToggle()
+                }
+            })
+        )
+
         this.run(this._tokenSource.token)
     }
 
     public dispose() {
         this.stop()
+        this.progressReporter.clear()
         this._localDisposables.forEach((d) => d.dispose())
     }
 
@@ -135,6 +175,10 @@ export class JuliaKernel {
                     const runStartTime = Date.now()
                     this._currentExecutionRequest.start(runStartTime)
 
+                    if (this.isActive) {
+                        this.progressReporter.startIndeterminate()
+                    }
+
                     const result = await this._msgConnection.sendRequest(requestTypeRunCell, {
                         filename: cellPath,
                         line: 0,
@@ -154,6 +198,8 @@ export class JuliaKernel {
 
                     const runEndTime = Date.now()
                     this._currentExecutionRequest.end(result.success, runEndTime)
+
+                    this.progressReporter.clear()
                 }
                 this._currentExecutionRequest = null
 
@@ -239,6 +285,19 @@ export class JuliaKernel {
         }
     }
 
+    private sendProgressToggle() {
+        if (!this._msgConnection) {
+            return
+        }
+
+        const enable = vscode.workspace.getConfiguration('julia').get<boolean>('useProgressFrontend')
+        try {
+            this._msgConnection.sendNotification('repl/toggleProgress', { enable })
+        } catch (err) {
+            console.warn(err)
+        }
+    }
+
     private async run(token: CancellationToken) {
         try {
             const connectedPromise = new Subject()
@@ -305,9 +364,26 @@ export class JuliaKernel {
                     }
                 })
 
+                this._msgConnection.onNotification(notifyTypeProgressUpdate, (progress) => {
+                    if (!this.statusProgressStarts.has(progress.id.value)) {
+                        this.statusProgressStarts.set(progress.id.value, new Date())
+                    }
+
+                    if (this.isActive) {
+                        const started = this.statusProgressStarts.get(progress.id.value)
+                        void this.progressReporter.handleProgress(progress, started)
+                    }
+
+                    if (progress.done) {
+                        this.statusProgressStarts.delete(progress.id.value)
+                    }
+                })
+
                 this._msgConnection.listen()
 
                 this._onConnected.fire(null)
+
+                this.sendProgressToggle()
 
                 connectedPromise.notify()
             })
@@ -326,6 +402,8 @@ export class JuliaKernel {
             this.outputChannel.appendLine(`Post 'const cwdPath = await this.getCwdPathForNotebook()'`)
 
             const nthreads = inferJuliaNumThreads()
+
+            const useProgressFrontend = vscode.workspace.getConfiguration('julia').get<boolean>('useProgressFrontend')
 
             const args = ['--color=yes', `--project=${pkgenvpath}`, '--history-file=no']
 
@@ -357,6 +435,7 @@ export class JuliaKernel {
                     pn,
                     this.debuggerPipename,
                     getCrashReportingPipename(),
+                    `USE_PROGRESS=${useProgressFrontend}`,
                 ],
                 {
                     env,
@@ -380,6 +459,8 @@ export class JuliaKernel {
             this._kernelProcess.on('close', async (code) => {
                 tokenSource.cancel()
                 processExecutionRequests.notify()
+
+                this.progressReporter.clear()
 
                 this._onCellRunFinished.fire()
                 this._onStopped.fire(undefined)

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -1,0 +1,195 @@
+import * as vscode from 'vscode'
+
+export interface ProgressUpdate {
+    id: { value: number }
+    name: string
+    fraction: number
+    done: boolean
+}
+
+interface ProgressEntry {
+    progress: vscode.Progress<{ message?: string; increment?: number }> | null
+    lastFraction: number
+    started: Date
+    resolve: () => void
+    lastMessage?: string
+    updatedAt?: number
+}
+
+export interface ProgressReporterOptions {
+    statusBarItem?: vscode.StatusBarItem
+    statusBarPrefix?: string
+    statusBarCommand?: string
+    useWindowProgress?: boolean
+}
+
+function formattedTimePeriod(t: number): string {
+    const seconds = Math.floor(t % 60)
+    const minutes = Math.floor((t / 60) % 60)
+    const hours = Math.floor(t / 60 / 60)
+    let out = ''
+    if (hours > 0) {
+        out += `${hours}h, `
+    }
+    if (minutes > 0) {
+        out += `${minutes}min, `
+    }
+    out += `${seconds}s`
+    return out
+}
+
+function progressMessage(prog: ProgressUpdate, started: Date | null = null): string {
+    let message = prog.name
+    const parenthesize = message.trim().length > 0
+    if (isFinite(prog.fraction) && 0 <= prog.fraction && prog.fraction <= 1) {
+        if (parenthesize) {
+            message += ' ('
+        }
+        message += `${(prog.fraction * 100).toFixed(1)}%`
+        if (started !== null) {
+            const elapsed = (new Date().valueOf() - started.valueOf()) / 1000
+            const remaining = (1 / prog.fraction - 1) * elapsed
+            if (isFinite(remaining)) {
+                message += ` - ${formattedTimePeriod(remaining)} remaining`
+            }
+        }
+        if (parenthesize) {
+            message += ')'
+        }
+    }
+    return message
+}
+
+export class ProgressReporter {
+    private readonly progressById = new Map<number, ProgressEntry>()
+    private readonly statusBarItem?: vscode.StatusBarItem
+    private readonly statusBarPrefix: string
+    private readonly statusBarCommand?: string
+    private readonly useWindowProgress: boolean
+
+    constructor(
+        private readonly onCancel: () => void,
+        options?: ProgressReporterOptions
+    ) {
+        this.statusBarItem = options?.statusBarItem
+        this.statusBarPrefix = options?.statusBarPrefix ?? 'Julia'
+        this.statusBarCommand = options?.statusBarCommand
+        this.useWindowProgress = options?.useWindowProgress ?? true
+    }
+
+    private renderStatusBar(): void {
+        if (!this.statusBarItem) {
+            return
+        }
+
+        if (this.progressById.size === 0) {
+            this.statusBarItem.hide()
+            return
+        }
+
+        const latest = Array.from(this.progressById.values()).reduce<ProgressEntry | undefined>((acc, entry) => {
+            if (!acc) {
+                return entry
+            }
+            return (entry.updatedAt ?? 0) > (acc.updatedAt ?? 0) ? entry : acc
+        }, undefined)
+
+        const message = latest?.lastMessage ?? ''
+        const suffix = message.length > 0 ? `: ${message}` : ''
+        this.statusBarItem.text = `$(sync~spin) ${this.statusBarPrefix}${suffix}`
+        this.statusBarItem.tooltip = this.statusBarCommand ? 'Interrupt' : undefined
+        this.statusBarItem.command = this.statusBarCommand
+        this.statusBarItem.show()
+    }
+
+    public async handleProgress(progress: ProgressUpdate, startedAt?: Date): Promise<void> {
+        const existing = this.progressById.get(progress.id.value)
+        if (existing) {
+            const increment = progress.done ? 100 : (progress.fraction - existing.lastFraction) * 100
+            existing.progress?.report({
+                increment,
+                message: progressMessage(progress, existing.started),
+            })
+            existing.lastFraction = progress.fraction
+            existing.lastMessage = progressMessage(progress, existing.started)
+            existing.updatedAt = Date.now()
+
+            if (progress.done) {
+                existing.resolve()
+                this.progressById.delete(progress.id.value)
+            }
+
+            this.renderStatusBar()
+            return
+        }
+
+        // When a dedicated status bar is provided and window progress is disabled, keep the
+        // reporting lightweight and status-bar-only to avoid duplicate VS Code progress items.
+        if (this.statusBarItem && !this.useWindowProgress) {
+            const started = startedAt ?? new Date()
+            const message = progressMessage(progress, started)
+            this.progressById.set(progress.id.value, {
+                progress: null,
+                lastFraction: progress.fraction,
+                started,
+                resolve: () => {},
+                lastMessage: message,
+                updatedAt: Date.now(),
+            })
+
+            if (progress.done) {
+                this.progressById.delete(progress.id.value)
+            }
+
+            this.renderStatusBar()
+            return
+        }
+
+        await vscode.window.withProgress(
+            {
+                location: vscode.ProgressLocation.Window,
+                title: 'Julia',
+                cancellable: true,
+            },
+            (prog, token) => {
+                return new Promise<void>((resolve) => {
+                    const started = startedAt ?? new Date()
+                    const message = progressMessage(progress, started)
+                    this.progressById.set(progress.id.value, {
+                        progress: prog,
+                        lastFraction: progress.fraction,
+                        started,
+                        resolve,
+                        lastMessage: message,
+                        updatedAt: Date.now(),
+                    })
+                    token.onCancellationRequested(() => this.onCancel())
+                    prog.report({
+                        message,
+                    })
+                    this.renderStatusBar()
+                })
+            }
+        )
+        this.renderStatusBar()
+    }
+
+    public startIndeterminate(name = 'Evaluating…', id = -1): void {
+        void this.handleProgress({
+            name,
+            id: { value: id },
+            fraction: -1,
+            done: false,
+        })
+    }
+
+    public clear(): void {
+        for (const [, entry] of this.progressById) {
+            entry.resolve()
+        }
+        this.progressById.clear()
+        if (this.statusBarItem) {
+            this.statusBarItem.hide()
+        }
+    }
+}


### PR DESCRIPTION
A feature I've been wanting is a ProgressLogging frontend for progress messages emitted inside *notebooks*. Currently, as far as I know, there's no way to do this without changing the logger in your notebook. I've had a go at changing this.

---

This PR introduces progress reporting for Julia notebooks, surfacing progress updates directly in the VS Code status bar. Notebook progress is displayed in a separate status bar item (e.g., $(sync~spin) Notebook: Training (45%)) instead of conflicting with the status used by the REPL.

The status bar item is gated by the active notebook editor. It automatically hides when switching away from the notebook and reappears when switching back. Progress start times are tracked internally per progress ID. This ensures that "Time Remaining" calculations remain accurate even if the user switches tabs and comes back later.

Care was taken to ensure the REPL progress experience remains unchanged. The REPL continues to use the standard VS Code window progress (notification area) with its existing interrupt/cancel behaviour.

Due to the complexity of notebook interrupts, I have not tried to create similar functionality of the cancel button for notebooks.

---

This is just a first go at adding this but it seems to be in a position where it is useful for my personal usage. Happy to work on this further for test/docs/changes as desired. 

Happy to hear what you think!