### PR TITLE
Don't exit(1) REPL on errors in `connectREPL` command.

### DIFF
--- a/scripts/error_handler.jl
+++ b/scripts/error_handler.jl
@@ -6,7 +6,7 @@ is_disconnected_exception(err::InvalidStateException) = err.state === :closed
 is_disconnected_exception(err::Base.IOError) = true
 is_disconnected_exception(err::CompositeException) = all(is_disconnected_exception, err.exceptions)
 
-function global_err_handler(e, bt, vscode_pipe_name, cloudRole)
+function global_err_handler(e, bt, vscode_pipe_name, cloudRole; should_exit = true)
     if is_disconnected_exception(e)
         @debug "Disconnect." ex=(e, bt)
         return
@@ -74,6 +74,8 @@ function global_err_handler(e, bt, vscode_pipe_name, cloudRole)
             close(pipe_to_vscode)
         end
     finally
-        exit(1)
+        if should_exit
+            exit(1)
+        end
     end
 end

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -351,7 +351,7 @@ async function startREPLWithVersion(versionName?: string) {
 }
 
 function juliaConnector(pipename: string, debugPipename: string, start = false) {
-    const connect = `VSCodeServer.serve(raw"${pipename}", raw"${debugPipename}"; is_dev = "DEBUG_MODE=true" in Base.ARGS, error_handler = (err, bt) -> VSCodeServer.global_err_handler(err, bt, raw"${telemetry.getCrashReportingPipename()}", "REPL"));nothing # re-establishing connection with VSCode`
+    const connect = `VSCodeServer.serve(raw"${pipename}", raw"${debugPipename}"; is_dev = "DEBUG_MODE=true" in Base.ARGS, error_handler = (err, bt) -> VSCodeServer.global_err_handler(err, bt, raw"${telemetry.getCrashReportingPipename()}", "REPL", should_exit=false));nothing # re-establishing connection with VSCode`
     if (start) {
         return (
             `include(raw"${path.join(g_context.extensionPath, 'scripts', 'terminalserver', 'load_vscodeserver.jl')}");` +


### PR DESCRIPTION
Fixes #3929.

- [ ] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
    - NOTE: Not needed, I think?