### PR TITLE
Revert a change to the error handler

### DIFF
--- a/scripts/error_handler.jl
+++ b/scripts/error_handler.jl
@@ -4,9 +4,6 @@ import InteractiveUtils
 is_disconnected_exception(err) = false
 is_disconnected_exception(err::InvalidStateException) = err.state === :closed
 is_disconnected_exception(err::Base.IOError) = true
-# thrown by JSONRPC when the endpoint is not open anymore. 
-# FIXME: adjust this once JSONRPC throws its own error type
-is_disconnected_exception(err::ErrorException) = startswith(err.msg, "Endpoint is not running, the current state is")
 is_disconnected_exception(err::CompositeException) = all(is_disconnected_exception, err.exceptions)
 
 function global_err_handler(e, bt, vscode_pipe_name, cloudRole; should_exit = true)


### PR DESCRIPTION
Reverts https://github.com/julia-vscode/julia-vscode/pull/3752.

I think that is too broad of a fix. I understand that we don't want disconnect errors in the REPL, but this error handler is used all over the place in other parts of the extension where we most definitely want the old behavior.

I think the proper fix here is to handle this somewhere in the REPL specific code, probably around https://github.com/julia-vscode/julia-vscode/blob/c555225bc252ec5dd3f7b063dd9be90538b0d989/scripts/packages/VSCodeServer/src/VSCodeServer.jl#L158-L166. The check could be there and then when there is a disconnect it should not call the error handler at al..

CC @alyst and @pfitzseb 