### PR TITLE
fix: move REPL disconnect handling to server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Correctly set up handlers for REPL-sent events, so that the plot pane and other integrations work again ([#3939](https://github.com/julia-vscode/julia-vscode/pull/3939))
 
+### Changed
+- The REPL now prints a message when it loses connection to the editor ([#3937](https://github.com/julia-vscode/julia-vscode/pull/3937))
+
 ## [1.165.0] - 2025-12-15
 ### Fixed
 - Fix a bug that caused Julia test detection to fail ([#3935](https://github.com/julia-vscode/julia-vscode/pull/3935))

--- a/scripts/error_handler.jl
+++ b/scripts/error_handler.jl
@@ -1,25 +1,11 @@
 using Sockets
 import InteractiveUtils
 
-is_disconnected_exception(err) = false
-is_disconnected_exception(err::InvalidStateException) = err.state === :closed
-is_disconnected_exception(err::Base.IOError) = true
-# thrown by JSONRPC when the endpoint is not open anymore. 
-# FIXME: adjust this once JSONRPC throws its own error type
-is_disconnected_exception(err::ErrorException) = startswith(err.msg, "Endpoint is not running, the current state is")
-is_disconnected_exception(err::CompositeException) = all(is_disconnected_exception, err.exceptions)
-
 function global_err_handler(e, bt, vscode_pipe_name, cloudRole; should_exit = true)
-    if is_disconnected_exception(e)
-        @debug "Disconnect." ex=(e, bt)
-        return
-    end
-
     @error "Some Julia code in the VS Code extension crashed"
     Base.display_error(e, bt)
     flush(stdout)
     flush(stderr)
-
 
     try
         st = stacktrace(bt)

--- a/scripts/packages/VSCodeServer/src/VSCodeServer.jl
+++ b/scripts/packages/VSCodeServer/src/VSCodeServer.jl
@@ -178,12 +178,7 @@ function serve(conn_pipename, debug_pipename; is_dev=false, error_handler=nothin
         end
     catch err
         if is_disconnected_exception(err)
-            if !isopen(conn)
-                # expected error
-                @debug "remote closed the connection"
-            else
-                @error "REPL got disconnected from the editor!"
-            end
+            println(stderr, "\n\n\x1b[30;41m * \x1b[0m Lost connection to the editor. You can use the 'Julia: Connect External REPL' command to reconnect. \x1b[30;41m * \x1b[0m\n\n")
         else
             try
                 error_handler(err, catch_backtrace())

--- a/scripts/packages/VSCodeServer/src/VSCodeServer.jl
+++ b/scripts/packages/VSCodeServer/src/VSCodeServer.jl
@@ -98,6 +98,14 @@ include("debugger.jl")
 include("notebookdisplay.jl")
 include("serve_notebook.jl")
 
+is_disconnected_exception(err) = false
+is_disconnected_exception(err::InvalidStateException) = err.state === :closed
+is_disconnected_exception(err::Base.IOError) = true
+# thrown by JSONRPC when the endpoint is not open anymore.
+# FIXME: adjust this once JSONRPC throws its own error type
+is_disconnected_exception(err::ErrorException) = startswith(err.msg, "Endpoint is not running, the current state is")
+is_disconnected_exception(err::CompositeException) = all(is_disconnected_exception, err.exceptions)
+
 function dispatch_msg(conn_endpoint, msg_dispatcher, msg, is_dev)
     if is_dev
         try
@@ -169,9 +177,13 @@ function serve(conn_pipename, debug_pipename; is_dev=false, error_handler=nothin
             end
         end
     catch err
-        if !isopen(conn) && is_disconnected_exception(err)
-            # expected error
-            @debug "remote closed the connection"
+        if is_disconnected_exception(err)
+            if !isopen(conn)
+                # expected error
+                @debug "remote closed the connection"
+            else
+                @error "REPL got disconnected from the editor!"
+            end
         else
             try
                 error_handler(err, catch_backtrace())


### PR DESCRIPTION
More thorough alternative to https://github.com/julia-vscode/julia-vscode/pull/3936.