### PR TITLE
fix: Allow PATH lookup for languageServerExecutablePath

### DIFF
--- a/src/executables.ts
+++ b/src/executables.ts
@@ -401,11 +401,23 @@ export class ExecutableFeature {
                 '`julia.languageServerExecutablePath` is ' +
                 (pathConfig ? `set to '${pathConfig}'` : 'not set')
         )
+
         if (pathConfig) {
             const exe = await this.juliaExecutableFromPathConfig(pathConfig, outputPrefix)
             if (exe) {
                 this.outputChannel.appendLine(outputPrefix + `using ${exe.command} as LS executable`)
                 return exe
+            }
+
+            const version = await this.tryGetJuliaVersion(pathConfig, [], outputPrefix)
+
+            if (version) {
+                const exe = new JuliaExecutable(pathConfig, version)
+                this.outputChannel.appendLine(outputPrefix + `using '${exe.command}' (v${exe.version}) as executable`)
+
+                return exe
+            } else {
+                this.outputChannel.appendLine(outputPrefix + `'${pathConfig}' can not be started`)
             }
         }
 


### PR DESCRIPTION
The 'getLsExecutable' method did not resolve an executable from the PATH when 'languageServerExecutablePath' was set to a command name (e.g., "julia"). It only attempted to resolve the value as a file path.

This change adds the logic to also try resolving the setting as a command from the PATH, mirroring the more flexible behavior of the 'getExecutable' method. This improves support for environments where Julia is managed by tools like Nix and is available on the PATH, but not via juliaup or a direct absolute path.

Fixes #.

- [ ] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
