### PR TITLE
fix: use correct cell delimiter in default settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the Julia extension will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+- Fixed a typo in default cell delimiter setting ([#3955](https://github.com/julia-vscode/julia-vscode/pull/3955))
+
 ## [1.167.0] - 2025-12-19
 ### Changed
 - Re-enabled the REPL keep-alive on Windows ([#3941](https://github.com/julia-vscode/julia-vscode/pull/3941))

--- a/package.json
+++ b/package.json
@@ -1104,8 +1104,8 @@
                         "^\\s?#\\s#+",
                         "^##(?!#)",
                         "^#(\\s?)%%",
-                        "^#-",
-                        "^#+"
+                        "^##(\\s?)-",
+                        "^##(\\s?)\\+"
                     ],
                     "description": "Cell delimiter regular expressions for Julia files."
                 },


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/3944.

- [x] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
