### PR TITLE
feat: add juliaup channel to REPL title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the Julia extension will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Changed
+- The Julia REPL terminal now contains the juliaup channel in the title if applicable ([#3998](https://github.com/julia-vscode/julia-vscode/pull/3998))
+
 ## [1.176.0] - 2026-01-18
 ### Fixed
 - Only check for `julia.exe` on Windows systems, to prevent issues with WSL setups picking the wrong Julia executable ([#3990](https://github.com/julia-vscode/julia-vscode/pull/3990))

--- a/src/executables.ts
+++ b/src/executables.ts
@@ -246,7 +246,7 @@ export class JuliaExecutable {
     public command: string
     public version: string
     public args: string[]
-    public juliaupChannel: JuliaupChannel
+    public juliaupChannel?: JuliaupChannel
 
     private _rootFolder: string
 


### PR DESCRIPTION
With `julia +release`:
<img width="192" height="56" alt="image" src="https://github.com/user-attachments/assets/a4842dca-625b-4e57-ab51-e130ab95b882" />

With `julia +1.12` (channel name is substring of version, so we don't show it):
<img width="192" height="56" alt="image" src="https://github.com/user-attachments/assets/2b82f13e-1bc0-4447-9000-8ff0661dff0f" />
