### PR TITLE
add missing ` in environmentPath description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1043,7 +1043,7 @@
                         "null"
                     ],
                     "default": null,
-                    "markdownDescription": "Path to a julia environment. VS Code needs to be reloaded for changes to take effect. Explicitly supports substitution for the `${userHome}`, `${workspaceFolder}`, `${workspaceFolderBasename}`, `${workspaceFolder:<FOLDER_NAME>}`, `${pathSeparator}`, `${env:<ENVIRONMENT_VARIABLE>}`, `${config:<CONFIG_VARIABLE>} tokens.",
+                    "markdownDescription": "Path to a julia environment. VS Code needs to be reloaded for changes to take effect. Explicitly supports substitution for the `${userHome}`, `${workspaceFolder}`, `${workspaceFolderBasename}`, `${workspaceFolder:<FOLDER_NAME>}`, `${pathSeparator}`, `${env:<ENVIRONMENT_VARIABLE>}`, `${config:<CONFIG_VARIABLE>}` tokens.",
                     "scope": "window"
                 },
                 "julia.symbolCacheDownload": {


### PR DESCRIPTION
Fixes
<img width="1591" height="141" alt="image" src="https://github.com/user-attachments/assets/8bd42ff0-3ff6-45f7-afed-b2334e4724bf" />
