### PR TITLE
docs: Fix REPL crash on debugger disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [1.181.0] - 2026-02-07
 ### Fixed
 - Ensured that spaces in usernames don't cause issue when checking for `juliaup` ([#4018](https://github.com/julia-vscode/julia-vscode/pull/4018))
+- Fix REPL crash on debugger disconnect ([DebugAdapter.jl#113](https://github.com/julia-vscode/DebugAdapter.jl/pull/113))
 
 ## [1.180.0] - 2026-02-06
 ### Fixed


### PR DESCRIPTION
Changelog of julia-vscode/DebugAdapter.jl#113

- [x] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
