### PR TITLE
Add `lidict` optional argument to `view_profile`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fixed a race condition where user REPL configuration (e.g. `auto_insert_closing_bracket`) set in `startup.jl` via `atreplinit` could be overwritten ([#4063](https://github.com/julia-vscode/julia-vscode/pull/4063))
 
+### Changed
+- `view_profile` now accepts a second optional argument for `lidict`, which should allow plotting profiles retrieved from other sessions or machines ([#4080](https://github.com/julia-vscode/julia-vscode/pull/4080))
+
 ## [1.196.0] - 2026-03-16
 ### Fixed
 - Code evaluation is now more robust against unexpected errors ([#4056](https://github.com/julia-vscode/julia-vscode/pull/4056))

--- a/scripts/packages/VSCodeServer/src/profiler.jl
+++ b/scripts/packages/VSCodeServer/src/profiler.jl
@@ -11,7 +11,7 @@ const ProfileFrameFlag = (
 
 const all_threads_name = "all"
 
-function view_profile(data = Profile.fetch(); C=false, kwargs...)
+function view_profile(data = Profile.fetch(), lidict = Profile.getdict(unique(data)); C=false, kwargs...)
     d = Dict{String,ProfileFrame}()
 
     if VERSION >= v"1.8.0-DEV.460"
@@ -26,7 +26,6 @@ function view_profile(data = Profile.fetch(); C=false, kwargs...)
         return
     end
 
-    lidict = Profile.getdict(unique(data))
     data_u64 = convert(Vector{UInt64}, data)
     for thread in threads
         graph = stackframetree(data_u64, lidict; thread=thread, kwargs...)


### PR DESCRIPTION
Many times, I find myself in need to plot the flame graph of a profile performed in another machine.

Problem is that I can't use `view_profile` as it is because the pointers in `data` are not valid anymore and the `lidict` from `Profile.getdict` is wrong.

This PR refactors `view_profile` to optionally accept the `lidict` info.
