### PR TITLE
WIP: tweak containers for more responsive plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Fixed
+- Plots (PNG, GIF, SVG) are now responsive and scale to fill the available plot pane space instead of rendering at a fixed size ([#4081](https://github.com/julia-vscode/julia-vscode/pull/4081))
 - Fixed a race condition where user REPL configuration (e.g. `auto_insert_closing_bracket`) set in `startup.jl` via `atreplinit` could be overwritten ([#4063](https://github.com/julia-vscode/julia-vscode/pull/4063))
 
 ### Changed

--- a/src/interactive/plots.ts
+++ b/src/interactive/plots.ts
@@ -443,7 +443,7 @@ function wrapImagelike(srcString: string) {
     let svgTag = ''
     if (isSvg) {
         svgTag = decodeURIComponent(srcString).replace(/^data.*<\?xml version="1\.0" encoding="utf-8"\?>\n/i, '')
-        svgTag = `<div id="plot-element">${svgTag}</div>`
+        svgTag = `<div id="plot-element" style="width: 100vw; height: 100vh;">${svgTag}</div>`
     }
 
     return wrapHtml(
@@ -516,9 +516,7 @@ export function displayPlot(params: { kind: string; data: string; id?: string; t
             // which could break the HTML
             plotPaneContent = wrapImagelike(`data:image/svg+xml,${encodeURIComponent(payload)}`)
         } else {
-            // otherwise we just show the svg directly as it's not straightforward to scale it
-            // correctly if it's not in an img tag
-            plotPaneContent = payload
+            plotPaneContent = wrapHtml(`<div id="plot-element" style="width: 100vw; height: 100vh;">${payload}</div>`)
         }
 
         addOrUpdatePlot(plotPaneContent, id)

--- a/src/interactive/plots.ts
+++ b/src/interactive/plots.ts
@@ -449,7 +449,7 @@ function wrapImagelike(srcString: string) {
     return wrapHtml(
         isSvg
             ? svgTag
-            : `<img id= "plot-element" style = "max-height: 100vh; max-width: 100vw; display:block;" src = "${srcString}" >`
+            : `<img id= "plot-element" style = "width: 100vw; height: 100vh; object-fit: contain; display:block;" src = "${srcString}" >`
     )
 }
 


### PR DESCRIPTION
## Summary
- **Raster images (PNG/GIF):** Use `width: 100vw; height: 100vh; object-fit: contain` instead of `max-width`/`max-height` so images scale up to fill the pane while preserving aspect ratio.
- **SVG plots:** Give the `#plot-element` container explicit viewport dimensions so the existing CSS rule (`#plot-element > svg { width/height: 100% }`) fills the available space. SVG's built-in `preserveAspectRatio` handles proportional scaling. SVGs without `xmlns` are now also properly wrapped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)