### PR TITLE
Fix telemetry bugs

### DIFF
--- a/src/docbrowser/documentation.ts
+++ b/src/docbrowser/documentation.ts
@@ -65,11 +65,13 @@ export function activate(context: vscode.ExtensionContext, languageClientFeature
     const provider = new DocumentationViewProvider(context, languageClientFeature)
 
     context.subscriptions.push(
-        registerCommand('language-julia.show-documentation-pane', () => provider.showDocumentationPane()),
-        registerCommand('language-julia.show-documentation', () => provider.showDocumentation()),
-        registerCommand('language-julia.browse-back-documentation', () => provider.browseBack()),
-        registerCommand('language-julia.browse-forward-documentation', () => provider.browseForward()),
-        registerCommand('language-julia.search-word', (params) => provider.findHelp(params)),
+        registerCommand('language-julia.show-documentation-pane', async () => await provider.showDocumentationPane()),
+        registerCommand('language-julia.show-documentation', async () => await provider.showDocumentation()),
+        registerCommand('language-julia.browse-back-documentation', async () => provider.browseBack()),
+        registerCommand('language-julia.browse-forward-documentation', async () => provider.browseForward()),
+        registerCommand('language-julia.search-word', async (params: { searchTerm: string }) =>
+            provider.findHelp(params)
+        ),
         vscode.window.registerWebviewViewProvider('julia-documentation', provider)
     )
 }

--- a/src/executables.ts
+++ b/src/executables.ts
@@ -383,7 +383,7 @@ export class ExecutableFeature {
                     vscode.commands.executeCommand('language-julia.restartLanguageServer')
                 }
             }),
-            registerCommand('language-julia.showExecutableOutput', () => {
+            registerCommand('language-julia.showExecutableOutput', async () => {
                 this.outputChannel.show()
             })
         )

--- a/src/interactive/codecells.ts
+++ b/src/interactive/codecells.ts
@@ -376,14 +376,17 @@ class CodeCellExecutionFeature extends JuliaCellManager {
         this.updateSaveOnEval()
         this.updateInlineResultsForCellEvaluation()
         this.context.subscriptions.push(
-            registerCommand('language-julia.moveCellUp', this.moveCell.bind(this, 'up')),
-            registerCommand('language-julia.moveCellDown', this.moveCell.bind(this, 'down')),
-            registerCommand('language-julia.selectCell', this.selectCell.bind(this)),
-            registerCommand('language-julia.executeCell', this.executeCell.bind(this)),
-            registerCommand('language-julia.executeCellAndMove', this.executeCellAndMove.bind(this, 'down')),
-            registerCommand('language-julia.executeCurrentAndBelowCells', this.executeCurrentAndBelowCells.bind(this)),
-            registerCommand('language-julia.executeAboveCells', this.executeAboveCells.bind(this)),
-            registerCommand('language-julia.debugCell', this.debugCell.bind(this))
+            registerCommand('language-julia.moveCellUp', async () => this.moveCell('up')),
+            registerCommand('language-julia.moveCellDown', async () => this.moveCell('down')),
+            registerCommand('language-julia.selectCell', async () => this.selectCell()),
+            registerCommand('language-julia.executeCell', async () => await this.executeCell()),
+            registerCommand('language-julia.executeCellAndMove', async () => await this.executeCellAndMove('down')),
+            registerCommand(
+                'language-julia.executeCurrentAndBelowCells',
+                async () => await this.executeCurrentAndBelowCells()
+            ),
+            registerCommand('language-julia.executeAboveCells', async () => await this.executeAboveCells()),
+            registerCommand('language-julia.debugCell', async () => await this.debugCell())
         )
 
         this.context.subscriptions.push(

--- a/src/interactive/modules.ts
+++ b/src/interactive/modules.ts
@@ -3,7 +3,7 @@ import * as rpc from 'vscode-jsonrpc'
 import { TextDocumentIdentifier } from 'vscode-languageclient/node'
 import { LanguageClientFeature, supportedSchemes } from '../languageClient'
 import * as telemetry from '../telemetry'
-import { onEvent, registerCommand, wrapCrashReporting } from '../utils'
+import { onEvent, registerCommand, wrapCrashReportingAsync } from '../utils'
 import { VersionedTextDocumentPositionParams } from './misc'
 import { onExit, onInit } from './repl'
 
@@ -47,9 +47,9 @@ export function activate(context: vscode.ExtensionContext, languageClientFeature
     statusBarItem.tooltip = 'Choose Current Module'
 
     onInit(
-        wrapCrashReporting(({ connection: conn }) => {
+        wrapCrashReportingAsync(async ({ connection: conn }) => {
             g_connection = conn
-            updateStatusBarItem()
+            await updateStatusBarItem()
         })
     )
     onExit(() => {

--- a/src/interactive/plots.ts
+++ b/src/interactive/plots.ts
@@ -21,16 +21,19 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(
         registerCommand('language-julia.save-plot', requestExportPlot),
-        registerCommand('language-julia.show-plotpane', showPlotPane),
+        registerCommand('language-julia.show-plotpane', async () => showPlotPane()),
         registerCommand('language-julia.plotpane-enable', enablePlotPane),
         registerCommand('language-julia.plotpane-disable', disablePlotPane),
-        registerCommand('language-julia.plotpane-previous', plotPanePrev),
-        registerCommand('language-julia.plotpane-next', plotPaneNext),
-        registerCommand('language-julia.plotpane-first', plotPaneFirst),
-        registerCommand('language-julia.plotpane-last', plotPaneLast),
-        registerCommand('language-julia.plotpane-delete', plotPaneDel),
-        registerCommand('language-julia.plotpane-delete-all', plotPaneDelAll),
-        registerCommand('language-julia.show-plot-navigator', () => g_plotNavigatorProvider.showPlotNavigator()),
+        registerCommand('language-julia.plotpane-previous', async () => plotPanePrev()),
+        registerCommand('language-julia.plotpane-next', async () => plotPaneNext()),
+        registerCommand('language-julia.plotpane-first', async () => plotPaneFirst()),
+        registerCommand('language-julia.plotpane-last', async () => plotPaneLast()),
+        registerCommand('language-julia.plotpane-delete', async () => plotPaneDel()),
+        registerCommand('language-julia.plotpane-delete-all', async () => plotPaneDelAll()),
+        registerCommand(
+            'language-julia.show-plot-navigator',
+            async () => await g_plotNavigatorProvider.showPlotNavigator()
+        ),
         vscode.window.registerWebviewViewProvider('julia-plot-navigator', g_plotNavigatorProvider)
     )
 }
@@ -312,14 +315,14 @@ function makeTitle() {
     return plotTitle
 }
 
-function enablePlotPane() {
+async function enablePlotPane() {
     const conf = vscode.workspace.getConfiguration('julia')
-    conf.update('usePlotPane', true, vscode.ConfigurationTarget.Global)
+    await conf.update('usePlotPane', true, vscode.ConfigurationTarget.Global)
 }
 
-function disablePlotPane() {
+async function disablePlotPane() {
     const conf = vscode.workspace.getConfiguration('julia')
-    conf.update('usePlotPane', false, vscode.ConfigurationTarget.Global)
+    await conf.update('usePlotPane', false, vscode.ConfigurationTarget.Global)
 }
 
 function updatePlotPane(lazy = false) {
@@ -921,8 +924,8 @@ function displayCustom(payload, id, title?: string) {
 /**
  * Send export request(message) to the plot pane.
  */
-function requestExportPlot() {
-    g_plotPanel.webview.postMessage({
+async function requestExportPlot() {
+    await g_plotPanel.webview.postMessage({
         type: 'requestSavePlot',
         body: { index: g_currentPlotIndex },
     })

--- a/src/interactive/profiler.ts
+++ b/src/interactive/profiler.ts
@@ -65,23 +65,23 @@ export class ProfilerFeature {
         this.context = context
 
         this.context.subscriptions.push(
-            registerCommand('language-julia.openProfiler', () => {
-                this.show()
+            registerCommand('language-julia.openProfiler', async () => {
+                await this.show()
             }),
-            registerCommand('language-julia.nextProfile', () => {
-                this.next()
+            registerCommand('language-julia.nextProfile', async () => {
+                await this.next()
             }),
-            registerCommand('language-julia.previousProfile', () => {
-                this.previous()
+            registerCommand('language-julia.previousProfile', async () => {
+                await this.previous()
             }),
-            registerCommand('language-julia.deleteProfile', () => {
-                this.delete()
+            registerCommand('language-julia.deleteProfile', async () => {
+                await this.delete()
             }),
-            registerCommand('language-julia.deleteAllProfiles', () => {
-                this.deleteAll()
+            registerCommand('language-julia.deleteAllProfiles', async () => {
+                await this.deleteAll()
             }),
-            registerCommand('language-julia.saveProfileToFile', () => {
-                this.saveToFile()
+            registerCommand('language-julia.saveProfileToFile', async () => {
+                await this.saveToFile()
             }),
             onEvent(vscode.window.onDidChangeVisibleTextEditors, (editors) => this.refreshInlineTrace(editors))
         )
@@ -409,7 +409,7 @@ export class ProfilerFeature {
         }
         const jsProfileScript = await readFile(this.profileViewerJSPath())
         const jsProfileDataUrl = 'data:text/javascript;base64,' + btoa(jsProfileScript.toString())
-        writeFile(
+        await writeFile(
             savePath.fsPath,
             `
         <!DOCTYPE html>
@@ -450,30 +450,30 @@ export class ProfilerFeature {
         )
     }
 
-    previous() {
+    async previous() {
         if (this.currentProfileIndex > 0) {
             this.currentProfileIndex -= 1
-            this.show()
+            await this.show()
         }
     }
 
-    next() {
+    async next() {
         if (this.currentProfileIndex < this.profiles.length - 1) {
             this.currentProfileIndex += 1
-            this.show()
+            await this.show()
         }
     }
 
-    delete() {
+    async delete() {
         this.profiles.splice(this.currentProfileIndex, 1)
         this.currentProfileIndex = Math.min(this.currentProfileIndex + 1, this.profiles.length - 1)
-        this.show()
+        await this.show()
     }
 
-    deleteAll() {
+    async deleteAll() {
         this.profiles = []
         this.currentProfileIndex = 0
-        this.show()
+        await this.show()
     }
 
     get profileCount() {

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -521,7 +521,11 @@ function startREPLMsgServer(pipename: string, juliaExecutable?: JuliaExecutable)
 
     const server = net.createServer((socket: net.Socket) => {
         socket.on('close', (hadError) => {
-            g_connection?.dispose()
+            try {
+                g_connection?.dispose()
+            } catch {
+                // ignore errors during dispose, as we're closing the connection anyway
+            }
             g_connection = undefined
 
             g_onExit.fire(hadError)

--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -19,8 +19,8 @@ import {
     onEvent,
     registerCommand,
     setContext,
-    wrapCrashReporting,
     parseVSCodeVariables,
+    wrapCrashReporting,
 } from '../utils'
 import * as completions from './completions'
 import { VersionedTextDocumentPositionParams } from './misc'
@@ -33,6 +33,7 @@ import { promise as fastq } from 'fastq'
 import { randomUUID } from 'crypto'
 import { promisify } from 'node:util'
 import child_process from 'node:child_process'
+import { Uri } from 'vscode'
 const exec = promisify(child_process.exec)
 
 let g_context: vscode.ExtensionContext = null
@@ -49,12 +50,12 @@ let g_terminal_is_persistent: boolean = false
 
 let g_ExecutableFeature: ExecutableFeature
 
-function startREPLCommand() {
-    startREPL(false, true)
+async function startREPLCommand() {
+    await startREPL(false, true)
 }
 
-function startREPLWithVersionCommand(versionName?: string) {
-    startREPLWithVersion(versionName)
+async function startREPLWithVersionCommand(versionName?: string) {
+    await startREPLWithVersion(versionName)
 }
 
 async function confirmKill() {
@@ -431,9 +432,9 @@ async function _connectREPL(juliaIsConnectedPromise) {
     }
 }
 
-function disconnectREPL() {
+async function disconnectREPL() {
     if (g_terminal) {
-        vscode.window.showWarningMessage('Cannot disconnect from integrated REPL.')
+        await vscode.window.showWarningMessage('Cannot disconnect from integrated REPL.')
     } else {
         if (isConnected()) {
             g_connection.end()
@@ -783,18 +784,16 @@ function clearDiagnostics() {
     g_trace_diagnostics.forEach((_, source) => _clearDiagnostic(source))
 }
 
-function clearDiagnosticsByProvider() {
+async function clearDiagnosticsByProvider() {
     const sources = Array(...g_trace_diagnostics.keys())
-    vscode.window
-        .showQuickPick(sources, {
-            // canPickMany: true, // not work nicely with keyboard shortcuts
-            title: 'Select sources of diagnostics to filter them out.',
-        })
-        .then((source) => {
-            if (source) {
-                _clearDiagnostic(source)
-            }
-        })
+    const source = await vscode.window.showQuickPick(sources, {
+        // canPickMany: true, // not work nicely with keyboard shortcuts
+        title: 'Select sources of diagnostics to filter them out.',
+    })
+
+    if (source) {
+        _clearDiagnostic(source)
+    }
 }
 
 function _clearDiagnostic(source: string) {
@@ -1067,7 +1066,7 @@ async function executeCodeCopyPaste(text: string, individualLine: boolean) {
     }
 }
 
-function executeSelectionCopyPaste() {
+async function executeSelectionCopyPaste() {
     const editor = vscode.window.activeTextEditor
     if (!editor) {
         return
@@ -1090,7 +1089,7 @@ function executeSelectionCopyPaste() {
             }
         }
     }
-    executeCodeCopyPaste(text, selection.isEmpty)
+    await executeCodeCopyPaste(text, selection.isEmpty)
 }
 
 export async function executeInREPL(
@@ -1435,17 +1434,20 @@ export function activate(
         registerCommand('language-julia.disconnectREPL', disconnectREPL),
         registerCommand('language-julia.selectBlock', selectJuliaBlock),
         registerCommand('language-julia.executeCodeBlockOrSelection', evaluateBlockOrSelection),
-        registerCommand('language-julia.executeCodeBlockOrSelectionAndMove', () => evaluateBlockOrSelection(true)),
+        registerCommand(
+            'language-julia.executeCodeBlockOrSelectionAndMove',
+            async () => await evaluateBlockOrSelection(true)
+        ),
         registerCommand('language-julia.executeActiveFile', () => executeFile()),
-        registerCommand('language-julia.executeFile', (uri) => executeFile(uri)),
+        registerCommand('language-julia.executeFile', async (uri: string | Uri) => await executeFile(uri)),
         registerCommand('language-julia.interrupt', interrupt),
         registerCommand('language-julia.executeJuliaCodeInREPL', executeSelectionCopyPaste), // copy-paste selection into REPL. doesn't require LS to be started
         registerCommand('language-julia.cdHere', cdToHere),
         registerCommand('language-julia.activateHere', activateHere),
         registerCommand('language-julia.activateFromDir', activateFromDir),
-        registerCommand('language-julia.clearRuntimeDiagnostics', clearDiagnostics),
+        registerCommand('language-julia.clearRuntimeDiagnostics', async () => clearDiagnostics()),
         registerCommand('language-julia.clearRuntimeDiagnosticsByProvider', clearDiagnosticsByProvider),
-        registerCommand('language-julia.clearInlayHints', clearInlayHints)
+        registerCommand('language-julia.clearInlayHints', async () => clearInlayHints())
     )
 
     const terminalConfig = vscode.workspace.getConfiguration('terminal.integrated')

--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -192,29 +192,29 @@ export function activate(context: vscode.ExtensionContext) {
         ),
 
         // public commands
-        registerCommand('language-julia.clearAllInlineResults', removeAll),
-        registerCommand('language-julia.clearAllInlineResultsInEditor', () =>
+        registerCommand('language-julia.clearAllInlineResults', async () => removeAll()),
+        registerCommand('language-julia.clearAllInlineResultsInEditor', async () =>
             removeAll(vscode.window.activeTextEditor)
         ),
-        registerCommand('language-julia.clearCurrentInlineResult', () => {
+        registerCommand('language-julia.clearCurrentInlineResult', async () => {
             if (vscode.window.activeTextEditor) {
                 removeCurrent(vscode.window.activeTextEditor)
             }
         }),
 
         // internal commands
-        registerCommand('language-julia.openFile', (locationArg: { path: string; line: number }) => {
-            openFile(locationArg.path, locationArg.line)
+        registerCommand('language-julia.openFile', async (locationArg: { path: string; line: number }) => {
+            await openFile(locationArg.path, locationArg.line)
         }),
         registerCommand('language-julia.gotoFirstFrame', gotoFirstFrame),
-        registerCommand('language-julia.gotoPreviousFrame', (frameArg: { frame: Frame }) => {
-            gotoPreviousFrame(frameArg.frame)
+        registerCommand('language-julia.gotoPreviousFrame', async (frameArg: { frame: Frame }) => {
+            await gotoPreviousFrame(frameArg.frame)
         }),
-        registerCommand('language-julia.gotoNextFrame', (frameArg: { frame: Frame }) => {
-            gotoNextFrame(frameArg.frame)
+        registerCommand('language-julia.gotoNextFrame', async (frameArg: { frame: Frame }) => {
+            await gotoNextFrame(frameArg.frame)
         }),
         registerCommand('language-julia.gotoLastFrame', gotoLastFrame),
-        registerCommand('language-julia.clearStackTrace', clearStackTrace)
+        registerCommand('language-julia.clearStackTrace', async () => clearStackTrace())
     )
     setContext('julia.supportedLanguageIds', supportedLanguageIds)
 }

--- a/src/interactive/workspace.ts
+++ b/src/interactive/workspace.ts
@@ -251,10 +251,19 @@ export class WorkspaceFeature {
             onInit(wrapCrashReporting(({ connection: conn }) => this.openREPL(conn))),
             onExit(() => this.closeREPL()),
             // commands
-            registerCommand('language-julia.showInVSCode', (node: VariableNode) => this.showInVSCode(node)),
-            registerCommand('language-julia.workspaceGoToFile', (node: VariableNode) => this.openLocation(node)),
-            registerCommand('language-julia.showModules', () => this._REPLTreeDataProvider.toggleModules(true)),
-            registerCommand('language-julia.hideModules', () => this._REPLTreeDataProvider.toggleModules(false))
+            registerCommand('language-julia.showInVSCode', async (node: VariableNode) => await this.showInVSCode(node)),
+            registerCommand(
+                'language-julia.workspaceGoToFile',
+                async (node: VariableNode) => await this.openLocation(node)
+            ),
+            registerCommand(
+                'language-julia.showModules',
+                async () => await this._REPLTreeDataProvider.toggleModules(true)
+            ),
+            registerCommand(
+                'language-julia.hideModules',
+                async () => await this._REPLTreeDataProvider.toggleModules(false)
+            )
         )
     }
 
@@ -426,14 +435,14 @@ export class REPLTreeDataProvider implements vscode.TreeDataProvider<AbstractWor
         }
     }
 
-    toggleModules(show: boolean) {
+    async toggleModules(show: boolean) {
         this.workspaceFeature._REPLNode.toggleModules(show)
-        this.workspaceFeature._REPLNode.updateReplVariables()
-        this.workspaceFeature._NotebookNodes.forEach((node) => {
+        await this.workspaceFeature._REPLNode.updateReplVariables()
+        for (const node of this.workspaceFeature._NotebookNodes) {
             node.toggleModules(show)
-            node.updateReplVariables()
-        })
-        vscode.workspace
+            await node.updateReplVariables()
+        }
+        await vscode.workspace
             .getConfiguration('julia')
             .update('workspace.showModules', show, vscode.ConfigurationTarget.Global)
     }

--- a/src/languageClient.ts
+++ b/src/languageClient.ts
@@ -113,11 +113,12 @@ export class LanguageClientFeature {
         private executable: ExecutableFeature
     ) {
         this.context.subscriptions.push(
-            registerCommand('language-julia.refreshLanguageServer', () => this.refreshLanguageServer()),
-            registerCommand('language-julia.restartLanguageServer', (env?: string) =>
-                this.restartLanguageServer(env, true)
+            registerCommand('language-julia.refreshLanguageServer', async () => await this.refreshLanguageServer()),
+            registerCommand(
+                'language-julia.restartLanguageServer',
+                async (env?: string) => await this.restartLanguageServer(env, true)
             ),
-            registerCommand('language-julia.showLanguageServerOutput', () => {
+            registerCommand('language-julia.showLanguageServerOutput', async () => {
                 this.outputChannel.show(true)
             }),
             onEvent(vscode.workspace.onDidChangeConfiguration, (event: vscode.ConfigurationChangeEvent) => {

--- a/src/notebook/notebookFeature.ts
+++ b/src/notebook/notebookFeature.ts
@@ -59,8 +59,16 @@ export class JuliaNotebookFeature {
         onEvent(vscode.window.onDidChangeVisibleNotebookEditors, this.init.bind(this), this, this.disposables)
 
         context.subscriptions.push(
-            registerCommand('language-julia.stopKernel', (node) => this.stopKernel(node)),
-            registerCommand('language-julia.restartKernel', (node) => this.restartKernel(node)),
+            registerCommand(
+                'language-julia.stopKernel',
+                async (node: NotebookNode | { notebookEditor: { notebookUri: vscode.Uri } }) =>
+                    await this.stopKernel(node)
+            ),
+            registerCommand(
+                'language-julia.restartKernel',
+                async (node: NotebookNode | { notebookEditor: { notebookUri: vscode.Uri } }) =>
+                    await this.restartKernel(node)
+            ),
             // vscode.commands.registerCommand('language-julia.toggleDebugging', () => {
             //     if (vscode.window.activeNotebookEditor) {
             //         const { notebook: notebookDocument } = vscode.window.activeNotebookEditor;

--- a/src/packagedevtools.ts
+++ b/src/packagedevtools.ts
@@ -9,7 +9,7 @@ export class JuliaPackageDevFeature {
         private ExecutableFeature: ExecutableFeature
     ) {
         this.context.subscriptions.push(
-            registerCommand('language-julia.tagNewPackageVersion', () => this.tagNewPackageVersion())
+            registerCommand('language-julia.tagNewPackageVersion', async () => await this.tagNewPackageVersion())
         )
     }
 

--- a/src/smallcommands.ts
+++ b/src/smallcommands.ts
@@ -3,9 +3,9 @@ import * as path from 'path'
 import * as vscode from 'vscode'
 import { registerCommand } from './utils'
 
-function toggleLinter() {
+async function toggleLinter() {
     const cval = vscode.workspace.getConfiguration('julia').get('lint.run', false)
-    vscode.workspace.getConfiguration('julia').update('lint.run', !cval, vscode.ConfigurationTarget.Global)
+    await vscode.workspace.getConfiguration('julia').update('lint.run', !cval, vscode.ConfigurationTarget.Global)
 }
 
 // function lintPackage() {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -155,8 +155,7 @@ export function handleNewCrashReport(name: string, message: string, stacktrace: 
     }
 }
 
-export function handleNewCrashReportFromException(exception: unknown, cloudRole: string) {
-    const error = exception instanceof Error ? exception : new Error(String(exception))
+export function handleNewCrashReportFromException(error: Error, cloudRole: string) {
     crashReporterQueue.push({
         exception: error,
         tagOverrides: {

--- a/src/testing/testFeature.ts
+++ b/src/testing/testFeature.ts
@@ -548,8 +548,8 @@ export class TestFeature {
         this.controller = vscode.tests.createTestController('juliaTests', 'Julia Tests')
 
         context.subscriptions.push(
-            registerCommand('language-julia.stopTestProcess', (node: TestProcessNode) => node.stop()),
-            registerCommand('language-julia.stopTestController', (node: TestControllerNode) => node.stop())
+            registerCommand('language-julia.stopTestProcess', async (node: TestProcessNode) => await node.stop()),
+            registerCommand('language-julia.stopTestController', async (node: TestControllerNode) => await node.stop())
         )
 
         // vscode.debug.onDidStartDebugSession((session: vscode.DebugSession) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -65,21 +65,27 @@ export function inferJuliaNumThreads(): string | undefined {
  * Same as `vscode.commands.registerCommand`, but with added middleware.
  * Currently sends any uncaught errors in the command to crash reporting.
  */
-export function registerCommand(cmd: string, f) {
-    return vscode.commands.registerCommand(cmd, wrapCrashReporting(f))
+export function registerCommand(cmd: string, f: (...args: unknown[]) => Promise<unknown>) {
+    return vscode.commands.registerCommand(cmd, wrapCrashReportingAsync(f))
 }
 
-export function wrapCrashReporting(f) {
-    const fWrapped = (...args) => {
+export function wrapCrashReportingAsync(f: (...args: unknown[]) => Promise<unknown>) {
+    const fWrapped = async (...args: unknown[]) => {
         try {
-            const result = f(...args)
-            if (result && typeof result.then === 'function') {
-                return result.then(undefined, (err) => {
-                    handleNewCrashReportFromException(err, 'Extension')
-                    throw err
-                })
-            }
-            return result
+            return await f(...args)
+        } catch (err) {
+            handleNewCrashReportFromException(err, 'Extension')
+            throw err
+        }
+    }
+
+    return fWrapped
+}
+
+export function wrapCrashReporting(f: (...args: unknown[]) => unknown) {
+    const fWrapped = (...args: unknown[]) => {
+        try {
+            return f(...args)
         } catch (err) {
             handleNewCrashReportFromException(err, 'Extension')
             throw err

--- a/src/weave.ts
+++ b/src/weave.ts
@@ -20,11 +20,13 @@ export class WeaveFeature {
         private context: vscode.ExtensionContext,
         private executableFeature: ExecutableFeature
     ) {
-        context.subscriptions.push(registerCommand('language-julia.weave-open-preview', this.openPreview.bind(this)))
         context.subscriptions.push(
-            registerCommand('language-julia.weave-open-preview-side', this.openPreviewSide.bind(this))
+            registerCommand('language-julia.weave-open-preview', async () => await this.openPreview())
         )
-        context.subscriptions.push(registerCommand('language-julia.weave-save', this.save.bind(this)))
+        context.subscriptions.push(
+            registerCommand('language-julia.weave-open-preview-side', async () => await this.openPreviewSide())
+        )
+        context.subscriptions.push(registerCommand('language-julia.weave-save', async () => await this.save()))
     }
 
     private async runWeave(column: number, activeTextEditor: vscode.TextEditor, selectedFormat?: string) {


### PR DESCRIPTION
Three fixes:

One trivial try catch to surpress an error.

And then a lot of cleanup around `async` wrapping. A lot of these cases were ok before because functions happened to return a promise (even though not marked as `async`), but this makes it all more explicit, and there were at least a handful of cases were we ended up with unhandled promises also.

And I also narrowed the telemetry handler back to what it originally was, we had a crash report about the new form.