### PR TITLE
fix: run repl hook installation in serve()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the Julia extension will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+- Fixed an issue where REPL hooks were not properly installed for external REPLs, causing e.g. the integrated plot viewer to silently fail ([#4093](https://github.com/julia-vscode/julia-vscode/pull/4093))
+
 ## [1.210.0] - 2026-04-20
 ### Fixed
 - Fixed an issue where the extension would not activate if Julia is not installed, breaking the auto-installation flow ([#4082](https://github.com/julia-vscode/julia-vscode/pull/4082))

--- a/scripts/packages/VSCodeServer/src/VSCodeServer.jl
+++ b/scripts/packages/VSCodeServer/src/VSCodeServer.jl
@@ -64,13 +64,6 @@ const DEBUG_PIPENAME = Ref{String}()
 function __init__()
     FALLBACK_CONSOLE_LOGGER_REF[] = Logging.ConsoleLogger()
     DEBUG_SESSION[] = Channel{DebugAdapter.DebugSession}(1)
-    atreplinit() do repl
-        @async try
-            hook_repl(repl)
-        catch err
-            Base.display_error(err, catch_backtrace())
-        end
-    end
 
     push!(Base.package_callbacks, on_pkg_load)
 
@@ -128,6 +121,13 @@ end
 function serve(conn_pipename, debug_pipename; is_dev=false, error_handler=nothing)
     @debug "start serve" time=round(Int, time()*10)
     conn = connect(conn_pipename)
+
+    @debug "hook repl" time=round(Int, time()*10)
+    @async try
+        hook_repl(Base.active_repl)
+    catch err
+        Base.display_error(err, catch_backtrace())
+    end
 
     @debug "eval backend" time=round(Int, time()*10)
     conn_endpoint[] = JSONRPC.JSONRPCEndpoint(conn, conn)


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/4092.