### PR TITLE
Revert "fix: run repl hook installation in serve()"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@ All notable changes to the Julia extension will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
-## [1.213.0] - 2026-04-27
-### Fixed
-- Fixed an issue where REPL hooks were not properly installed for external REPLs, causing e.g. the integrated plot viewer to silently fail ([#4093](https://github.com/julia-vscode/julia-vscode/pull/4093))
 
 ## [1.210.0] - 2026-04-20
 ### Fixed

--- a/scripts/packages/VSCodeServer/src/VSCodeServer.jl
+++ b/scripts/packages/VSCodeServer/src/VSCodeServer.jl
@@ -64,6 +64,13 @@ const DEBUG_PIPENAME = Ref{String}()
 function __init__()
     FALLBACK_CONSOLE_LOGGER_REF[] = Logging.ConsoleLogger()
     DEBUG_SESSION[] = Channel{DebugAdapter.DebugSession}(1)
+    atreplinit() do repl
+        @async try
+            hook_repl(repl)
+        catch err
+            Base.display_error(err, catch_backtrace())
+        end
+    end
 
     push!(Base.package_callbacks, on_pkg_load)
 
@@ -121,13 +128,6 @@ end
 function serve(conn_pipename, debug_pipename; is_dev=false, error_handler=nothing)
     @debug "start serve" time=round(Int, time()*10)
     conn = connect(conn_pipename)
-
-    @debug "hook repl" time=round(Int, time()*10)
-    @async try
-        hook_repl(Base.active_repl)
-    catch err
-        Base.display_error(err, catch_backtrace())
-    end
 
     @debug "eval backend" time=round(Int, time()*10)
     conn_endpoint[] = JSONRPC.JSONRPCEndpoint(conn, conn)


### PR DESCRIPTION
That PR broke things when one just regularily launches a REPL. I believe `Base.active_repl` is not available when `serve` is called for the regular REPL launch.

For now I just quickly want to get back to a working extension, presumably the proper way to fix this is to use the old behavior (which this PR restores) for the regular REPL launch case, and the new for a connect scenario?