### PR TITLE
Compat Julia 1.8: @profview calls undefined threadpooltids and threadpool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Fixed
-- Fix `@profview` error in Julia v1.8.5: `threadpooltids` and `threadpool` are undefined but called. Add those functions in `__init__`. ([#4100](https://github.com/julia-vscode/julia-vscode/pull/4100))
+- Fix `@profview` error in Julia v1.8.5: `threadpooltids` and `threadpool` are undefined but called. Numeric order of thread dropdown menu in profiler view panel. ([#4100](https://github.com/julia-vscode/julia-vscode/pull/4100))
 - The REPL is now more robust against crashes when communication with the IDE is disrupted ([#4098](https://github.com/julia-vscode/julia-vscode/pull/4098))
 
 ## [1.215.0] - 2026-04-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Fixed
+- Fix `@profview` error in Julia v1.8.5: `threadpooltids` and `threadpool` are undefined but called. Add those functions in `__init__`. ([#4100](https://github.com/julia-vscode/julia-vscode/pull/4100))
 - The REPL is now more robust against crashes when communication with the IDE is disrupted ([#4098](https://github.com/julia-vscode/julia-vscode/pull/4098))
 
 ## [1.215.0] - 2026-04-28

--- a/scripts/packages/VSCodeServer/src/VSCodeServer.jl
+++ b/scripts/packages/VSCodeServer/src/VSCodeServer.jl
@@ -274,31 +274,4 @@ end
 
 _precompile_()
 
-function __init__()
-    # patch at runtime to avoid precompilation issues
-    @static if v"1.8.0-DEV.460" <= VERSION < v"1.9"
-        # Compat: @profview calls threadpooltids and threadpool, but they are not defined in Julia v1.8
-        if !isdefined(Threads, :threadpooltids)
-            Core.eval(Base.Threads, :(function threadpooltids(x)
-                # Get the thread IDs in the current thread pool
-                if x === :default
-                    return Threads.nthreads() == 1 ? [1] : collect(1:Threads.nthreads())
-                else
-                    return Int[]
-                end
-            end))
-        end
-        if !isdefined(Threads, :threadpool)
-            Core.eval(Base.Threads, :(function threadpool(tid)
-                # Get the thread pool for a given thread ID
-                if tid <= Threads.nthreads()
-                    return :default
-                else
-                    error("invalid tid")
-                end
-            end))
-        end
-    end
-end
-
 end  # module

--- a/scripts/packages/VSCodeServer/src/VSCodeServer.jl
+++ b/scripts/packages/VSCodeServer/src/VSCodeServer.jl
@@ -274,4 +274,31 @@ end
 
 _precompile_()
 
+function __init__()
+    # patch at runtime to avoid precompilation issues
+    @static if v"1.8.0-DEV.460" <= VERSION < v"1.9"
+        # Compat: @profview calls threadpooltids and threadpool, but they are not defined in Julia v1.8
+        if !isdefined(Threads, :threadpooltids)
+            Core.eval(Base.Threads, :(function threadpooltids(x)
+                # Get the thread IDs in the current thread pool
+                if x === :default
+                    return Threads.nthreads() == 1 ? [1] : collect(1:Threads.nthreads())
+                else
+                    return Int[]
+                end
+            end))
+        end
+        if !isdefined(Threads, :threadpool)
+            Core.eval(Base.Threads, :(function threadpool(tid)
+                # Get the thread pool for a given thread ID
+                if tid <= Threads.nthreads()
+                    return :default
+                else
+                    error("invalid tid")
+                end
+            end))
+        end
+    end
+end
+
 end  # module

--- a/scripts/packages/VSCodeServer/src/profiler.jl
+++ b/scripts/packages/VSCodeServer/src/profiler.jl
@@ -15,10 +15,16 @@ function view_profile(data = Profile.fetch(), lidict = Profile.getdict(unique(da
     d = Dict{String,ProfileFrame}()
 
     if VERSION >= v"1.8.0-DEV.460"
-        all_tids = sort([Threads.threadpooltids(:interactive)..., Threads.threadpooltids(:default)...])
+        all_tids = if isdefined(Threads, :threadpooltids)
+            sort([Threads.threadpooltids(:interactive)..., Threads.threadpooltids(:default)...])
+        else
+            Int[1:Threads.nthreads()...]
+        end
         threads = [nothing, all_tids...]
+        max_thread_chars = length(string(all_tids[end]))  # thread name padding
     else
         threads = [nothing]
+        max_thread_chars = 0
     end
 
     if isempty(data)
@@ -27,12 +33,17 @@ function view_profile(data = Profile.fetch(), lidict = Profile.getdict(unique(da
     end
 
     data_u64 = convert(Vector{UInt64}, data)
+
     for thread in threads
         graph = stackframetree(data_u64, lidict; thread=thread, kwargs...)
         threadname = if thread === nothing
             all_threads_name
+        elseif isdefined(Threads, :threadpool)
+            n_spaces = max_thread_chars - length(string(thread))  # n_spaces for numeric ordering
+            "$(" "^n_spaces)$(thread) ($(Threads.threadpool(thread)))"
         else
-            "$(thread) ($(Threads.threadpool(thread)))"
+            n_spaces = max_thread_chars - length(string(thread))  # n_spaces for numeric ordering
+            "$(" "^n_spaces)$(thread)"
         end
         d[threadname] = make_tree(
             ProfileFrame(


### PR DESCRIPTION
Fixes `@profview` error in Julia v1.8.5: threadpooltids and threadpool are undefined but called. Add those functions in `__init__`

- [x] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs.
