### PR TITLE
feat: declare julia and juliamarkdown language contributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the Julia extension will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Added
+- Declare the `julia` and `juliamarkdown` languages explicitly via `contributes.languages` so the extension works on VS Code API-compatible hosts (e.g. Eclipse Theia) that do not implicitly register languages from grammar contributions ([#4121](https://github.com/julia-vscode/julia-vscode/pull/4121))
+
 ### Fixed
 - Client disconnect handling in the REPL is now more thorough ([#4114](https://github.com/julia-vscode/julia-vscode/pull/4114))
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,28 @@
     ],
     "main": "./dist/extension",
     "contributes": {
+        "languages": [
+            {
+                "id": "julia",
+                "aliases": [
+                    "Julia",
+                    "julia"
+                ],
+                "extensions": [
+                    ".jl"
+                ]
+            },
+            {
+                "id": "juliamarkdown",
+                "aliases": [
+                    "Julia Markdown",
+                    "juliamarkdown"
+                ],
+                "extensions": [
+                    ".jmd"
+                ]
+            }
+        ],
         "grammars": [
             {
                 "language": "julia",


### PR DESCRIPTION
This declares the `julia` and `juliamarkdown` languages explicitly via `contributes.languages`.

### Why

The `grammars` contributions reference `"language": "julia"` and `"language": "juliamarkdown"`, but those language IDs are never declared via `contributes.languages`. VS Code implicitly registers a language from a grammar's `language` field, so everything works there.

Other hosts that implement the VS Code extension API (e.g. Eclipse Theia, used by some downstream Julia IDEs) do **not** do that implicit registration. On those hosts the extension's `vscode.languages.setLanguageConfiguration("julia", ...)` call in `activate()` throws `Cannot set configuration for unknown language julia`, and Julia files are not recognized.

Declaring the two languages explicitly — with their aliases and file extensions — is a no-op in VS Code (it just makes explicit what VS Code infers today) and lets the extension run unchanged on VS Code API-compatible hosts.

- [ ] End-user documentation check. If this PR requires end-user documentation, please add that at https://github.com/julia-vscode/docs. — N/A: no user-facing behavior change in VS Code.

---

_Disclosure: this change and description were drafted with AI assistance (Claude) and were reviewed and submitted by me._
