### PR TITLE
chore: add bundle/compile-test tasks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,7 +31,7 @@
             "outFiles": [
                 "${workspaceFolder}/out/test/**/*.js"
             ],
-            "preLaunchTask": "npm: test-compile"
+            "preLaunchTask": "npm: compile-tests"
         },
         {
             "name": "Run LS",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -40,6 +40,20 @@
                 "group": "watch",
                 "reveal": "never"
             }
+        },
+        {
+            "type": "npm",
+            "script": "bundle",
+            "group": "build",
+            "problemMatcher": "$esbuild",
+            "label": "npm: bundle"
+        },
+        {
+            "type": "npm",
+            "script": "compile-tests",
+            "group": "build",
+            "problemMatcher": "$tsc",
+            "label": "npm: compile-tests"
         }
     ]
 }


### PR DESCRIPTION
so we don't have to rely on VS Code picking them up from package.json.