### PR TITLE
fix: only show LS crash status bar item on a crash loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Signature-help parameter labels are emitted as UTF-16 offset ranges, so unnamed method arguments no longer show an internal `#unused#` placeholder ([JuliaWorkspaces.jl#142](https://github.com/julia-vscode/JuliaWorkspaces.jl/pull/142))
 - Signature help is now offered for keyword-only methods (e.g. `bar(; x)`) at the first argument position, where positional-arity filtering previously discarded them ([JuliaWorkspaces.jl#144](https://github.com/julia-vscode/JuliaWorkspaces.jl/pull/144))
 - Fixed a server crash when an `inlayHint` request specified a range past the end of the document ([LanguageServer.jl#1400](https://github.com/julia-vscode/LanguageServer.jl/pull/1400))
+- The "Julia Language Server Crashed" status bar item no longer appears for transient crashes that the client recovers from by restarting the server automatically; it is now only shown once the server enters a crash loop and will not be restarted. Language features also keep working after such an automatic restart instead of requiring a manual server restart ([#4137](https://github.com/julia-vscode/julia-vscode/pull/4137))
 
 ## [1.219.0] - 2026-06-17
 ### Added

--- a/src/languageClient.ts
+++ b/src/languageClient.ts
@@ -3,8 +3,13 @@ import * as os from 'os'
 import * as path from 'path'
 import * as vscode from 'vscode'
 import {
+    CloseAction,
+    CloseHandlerResult,
+    ErrorHandler,
+    ErrorHandlerResult,
     LanguageClient,
     LanguageClientOptions,
+    Message,
     RevealOutputChannelOn,
     ServerOptions,
     State,
@@ -45,6 +50,50 @@ export function isLanguageServerError(err: unknown): boolean {
         }
     }
     return false
+}
+
+/**
+ * Wraps the client's default error handler and remembers whether the last
+ * connection close resulted in an auto-restart. The client fires a public
+ * `Stopped` state change on every unexpected connection close, even when it
+ * is about to restart the server itself, so the state change alone cannot
+ * distinguish a transient crash from a crash loop the client has given up on.
+ * The `closed()` decision is made before the state change fires, which lets
+ * the state change handler consult `consumeRestartPending()`.
+ */
+export class RestartTrackingErrorHandler implements ErrorHandler {
+    private delegate: ErrorHandler
+    private restartPending: boolean = false
+
+    constructor(private createDelegate: () => ErrorHandler) {}
+
+    error(
+        error: Error,
+        message: Message | undefined,
+        count: number | undefined
+    ): ErrorHandlerResult | Promise<ErrorHandlerResult> {
+        this.delegate ??= this.createDelegate()
+        return this.delegate.error(error, message, count)
+    }
+
+    async closed(): Promise<CloseHandlerResult> {
+        this.delegate ??= this.createDelegate()
+        const result = await this.delegate.closed()
+        if (result.action === CloseAction.Restart) {
+            this.restartPending = true
+        }
+        return result
+    }
+
+    /**
+     * Returns whether the last connection close is followed by an
+     * auto-restart, and resets the flag.
+     */
+    consumeRestartPending(): boolean {
+        const pending = this.restartPending
+        this.restartPending = false
+        return pending
+    }
 }
 
 export class LanguageClientFeature {
@@ -291,12 +340,19 @@ export class LanguageClientFeature {
             selector.push({ language: 'toml', scheme: scheme, pattern: '**/.JuliaLint.toml' })
         }
 
+        // The default error handler restarts the server on a crash, unless it
+        // crashed 5 times within the last 3 minutes. The wrapper records that
+        // decision so the state change handler below can tell a transient
+        // crash apart from a crash loop.
+        const errorHandler = new RestartTrackingErrorHandler(() => languageClient.createDefaultErrorHandler())
+
         const clientOptions: LanguageClientOptions = {
             documentSelector: selector,
             revealOutputChannelOn: RevealOutputChannelOn.Never,
             traceOutputChannel: this.traceOutputChannel,
             outputChannel: this.outputChannel,
             initializationOptions: { julialangTestItemIdentification: true },
+            errorHandler,
         }
 
         // Create the language client and start the client.
@@ -312,10 +368,17 @@ export class LanguageClientFeature {
                     this.setState('running')
                     break
                 case State.Stopped:
-                    if (!this._intentionalStop) {
-                        // The library auto-restarts up to 4 times in 3 minutes.
-                        // If it transitions to Stopped without us requesting it,
-                        // the library has given up.
+                    if (this._intentionalStop) {
+                        break
+                    }
+                    if (errorHandler.consumeRestartPending()) {
+                        // The client restarts the server itself after a
+                        // transient crash and reuses this client instance,
+                        // so keep it around and wait for the Starting event.
+                        this.setState('starting')
+                    } else {
+                        // The client has given up: the server entered a crash
+                        // loop or shut down after repeated connection errors.
                         this.setState('crashed')
                         this.setLanguageClient()
                     }

--- a/src/test/suite/languageClient.test.ts
+++ b/src/test/suite/languageClient.test.ts
@@ -1,0 +1,64 @@
+import * as assert from 'assert'
+import { CloseAction, ErrorAction, ErrorHandler } from 'vscode-languageclient/node'
+import { RestartTrackingErrorHandler } from '../../languageClient'
+
+function makeDelegate(closeActions: CloseAction[]): ErrorHandler {
+    let i = 0
+    return {
+        error: () => ({ action: ErrorAction.Continue }),
+        closed: () => ({ action: closeActions[Math.min(i++, closeActions.length - 1)] }),
+    }
+}
+
+suite('RestartTrackingErrorHandler', () => {
+    test('no restart pending before any connection close', () => {
+        const handler = new RestartTrackingErrorHandler(() => makeDelegate([CloseAction.Restart]))
+        assert.strictEqual(handler.consumeRestartPending(), false)
+    })
+
+    test('restart pending after delegate decides to auto-restart', async () => {
+        const handler = new RestartTrackingErrorHandler(() => makeDelegate([CloseAction.Restart]))
+        const result = await handler.closed()
+        assert.strictEqual(result.action, CloseAction.Restart)
+        assert.strictEqual(handler.consumeRestartPending(), true)
+    })
+
+    test('consuming the pending restart resets it', async () => {
+        const handler = new RestartTrackingErrorHandler(() => makeDelegate([CloseAction.Restart]))
+        await handler.closed()
+        assert.strictEqual(handler.consumeRestartPending(), true)
+        assert.strictEqual(handler.consumeRestartPending(), false)
+    })
+
+    test('no restart pending when delegate gives up', async () => {
+        const handler = new RestartTrackingErrorHandler(() => makeDelegate([CloseAction.DoNotRestart]))
+        const result = await handler.closed()
+        assert.strictEqual(result.action, CloseAction.DoNotRestart)
+        assert.strictEqual(handler.consumeRestartPending(), false)
+    })
+
+    test('crash loop: restarts stay pending until the delegate gives up', async () => {
+        const handler = new RestartTrackingErrorHandler(() =>
+            makeDelegate([
+                CloseAction.Restart,
+                CloseAction.Restart,
+                CloseAction.Restart,
+                CloseAction.Restart,
+                CloseAction.DoNotRestart,
+            ])
+        )
+        for (let crash = 0; crash < 4; crash++) {
+            await handler.closed()
+            assert.strictEqual(handler.consumeRestartPending(), true)
+        }
+        await handler.closed()
+        assert.strictEqual(handler.consumeRestartPending(), false)
+    })
+
+    test('delegates error decisions unchanged', async () => {
+        const handler = new RestartTrackingErrorHandler(() => makeDelegate([CloseAction.Restart]))
+        const result = await handler.error(new Error('boom'), undefined, 1)
+        assert.strictEqual(result.action, ErrorAction.Continue)
+        assert.strictEqual(handler.consumeRestartPending(), false)
+    })
+})


### PR DESCRIPTION
The language client fires a public Stopped state change on every unexpected server exit, including transient crashes it auto-restarts from itself. Treating any unintentional Stopped event as a crash showed the "Language Server Crashed" status bar item for single crashes and dropped the language client reference even though the client reuses it for the auto-restart, leaving all LS features broken after recovery.

Wrap the default error handler to record whether the connection close leads to an auto-restart, and only mark the server as crashed (and show the status bar item) when the client has given up restarting.