### PR TITLE
Use the configured Julia executable for test items instead of hardcoding the release channel

### DIFF
--- a/src/testing/testFeature.ts
+++ b/src/testing/testFeature.ts
@@ -120,41 +120,13 @@ export class JuliaTestController {
 
         let juliaExecutable: JuliaExecutable | null
 
-        if (process.env.DEBUG_MODE) {
-            try {
-                juliaExecutable = await this.executableFeature.getExecutable()
-            } catch (err) {
-                if (err instanceof JuliaNotFoundError) {
-                    return true
-                }
-                throw err
-            }
-        } else {
-            if (!(await this.executableFeature.hasJuliaup())) {
-                vscode.window.showErrorMessage(
-                    'You must install Julia using Juliaup to use the test item functionality.'
-                )
+        try {
+            juliaExecutable = await this.executableFeature.getExecutable()
+        } catch (err) {
+            if (err instanceof JuliaNotFoundError) {
                 return true
             }
-
-            let juliaup
-            try {
-                juliaup = await this.executableFeature.getJuliaupExecutable(false)
-            } catch (err) {
-                if (err instanceof JuliaNotFoundError) {
-                    return true
-                }
-                throw err
-            }
-
-            try {
-                juliaExecutable = new JuliaExecutable(await juliaup.getChannel('release'))
-            } catch {
-                vscode.window.showErrorMessage(
-                    'You must have the "release" channel in Juliaup installed to use the test item functionality.'
-                )
-                return true
-            }
+            throw err
         }
 
         const jlArgs = ['--startup-file=no', '--history-file=no', '--depwarn=no']


### PR DESCRIPTION
## What this does

`JuliaTestController.start()` currently has two paths for picking the Julia executable that runs the test item controller:

- With `DEBUG_MODE` set, it calls `executableFeature.getExecutable()`, which respects the user's configuration (`julia.executablePath`, then the selected juliaup channel, then the juliaup default, then `julia` on the `PATH`).
- In the normal path, it requires juliaup and then hardcodes `new JuliaExecutable(await juliaup.getChannel('release'))`, ignoring the configured executable entirely and refusing to run unless a `release` channel exists.

This PR unifies both paths on `getExecutable()`, keeping the existing `JuliaNotFoundError` handling. The `hasJuliaup()` check, the `getJuliaupExecutable` call, the `getChannel('release')` special case, and their two error message prompts become dead code and are removed.

## Why

The test runner should use the same Julia as the rest of the extension. The hardcoded `release` channel breaks `@testitem` running for anyone whose Julia isn't installed as a juliaup `release` channel: a custom `julia.executablePath`, a non-`release` channel selection, or a bundled/offline juliaup setup that has no `release` channel at all. `getExecutable()` already implements a robust fallback chain, so the special case is redundant.

## Behavior change

Previously, test items always ran on the juliaup `release` channel regardless of configuration. With this change they run on whatever Julia the user has configured/selected, same as the REPL and language server. If pinning test runs to `release` was intentional (e.g. to guarantee a controller-compatible Julia version), happy to adjust the approach — feedback welcome.