### PR TITLE
feat(VSCodeServer): gate `@debug` logs behind dev mode

### DIFF
--- a/scripts/packages/VSCodeServer/src/VSCodeServer.jl
+++ b/scripts/packages/VSCodeServer/src/VSCodeServer.jl
@@ -82,6 +82,19 @@ end
 
 const conn_endpoint = Ref{Union{Nothing,JSONRPC.JSONRPCEndpoint}}(nothing)
 
+# Set to `true` when the server is started in development mode; gates `@_debug`.
+const IS_DEV = Ref(false)
+
+# Like `@debug`, but only emits when the server runs in development mode.
+macro _debug(exs...)
+    logcall = Expr(:macrocall, GlobalRef(Base, Symbol("@debug")), __source__, exs...)
+    quote
+        if IS_DEV[]
+            $(esc(logcall))
+        end
+    end
+end
+
 include("../../../error_handler.jl")
 include("repl_protocol.jl")
 include("misc.jl")
@@ -138,7 +151,8 @@ function handle_serve_error(err, bt, error_handler)
 end
 
 function serve(conn_pipename, debug_pipename; is_dev=false, error_handler=nothing)
-    @debug "start serve" time=round(Int, time()*10)
+    IS_DEV[] = is_dev
+    @_debug "start serve" time=round(Int, time()*10)
 
     if isdefined(Base, :active_repl)
         try_hook_repl(Base.active_repl)
@@ -148,10 +162,10 @@ function serve(conn_pipename, debug_pipename; is_dev=false, error_handler=nothin
         end
     end
 
-    @debug "connect to pipe" time=round(Int, time()*10)
+    @_debug "connect to pipe" time=round(Int, time()*10)
     conn = connect(conn_pipename)
 
-    @debug "eval backend" time=round(Int, time()*10)
+    @_debug "eval backend" time=round(Int, time()*10)
     conn_endpoint[] = JSONRPC.JSONRPCEndpoint(conn, conn)
     if EVAL_BACKEND_TASK[] === nothing
         start_eval_backend()
@@ -159,13 +173,13 @@ function serve(conn_pipename, debug_pipename; is_dev=false, error_handler=nothin
 
     JSONRPC.start(conn_endpoint[])
 
-    @debug "debug backend" time=round(Int, time()*10)
+    @_debug "debug backend" time=round(Int, time()*10)
     DEBUG_PIPENAME[] = debug_pipename
     start_debug_backend(debug_pipename, error_handler)
 
-    @debug "send connected notif" time=round(Int, time()*10)
+    @_debug "send connected notif" time=round(Int, time()*10)
     JSONRPC.send_notification(conn_endpoint[], "connected", nothing)
-    @debug "connected notif sent" time=round(Int, time()*10)
+    @_debug "connected notif sent" time=round(Int, time()*10)
 
     @async try
         msg_dispatcher = JSONRPC.MsgDispatcher()
@@ -190,13 +204,13 @@ function serve(conn_pipename, debug_pipename; is_dev=false, error_handler=nothin
         msg_dispatcher[repl_gettabledata_request_type] = get_table_data_request
         msg_dispatcher[repl_clearlazytable_notification_type] = clear_lazy_table_notification
 
-        @debug "send queued notifs" time=round(Int, time()*10)
+        @_debug "send queued notifs" time=round(Int, time()*10)
         send_queued_notifications!()
 
-        @debug "entering message loop" time=round(Int, time()*10)
+        @_debug "entering message loop" time=round(Int, time()*10)
         @sync while conn_endpoint[] isa JSONRPC.JSONRPCEndpoint && isopen(conn)
             msg = JSONRPC.get_next_message(conn_endpoint[])
-            @debug "message: $(msg.method)" time=round(Int, time()*10)
+            @_debug "message: $(msg.method)" time=round(Int, time()*10)
 
             if msg.method == repl_runcode_request_type.method
                 @async try
@@ -208,12 +222,12 @@ function serve(conn_pipename, debug_pipename; is_dev=false, error_handler=nothin
                 dispatch_msg(conn_endpoint, msg_dispatcher, msg, is_dev)
             end
             yield()
-            @debug "message: $(msg.method) done" time=round(Int, time()*10)
+            @_debug "message: $(msg.method) done" time=round(Int, time()*10)
         end
     catch err
         handle_serve_error(err, catch_backtrace(), error_handler)
     finally
-        @debug "JSONRPC dispatcher task finished"
+        @_debug "JSONRPC dispatcher task finished"
     end
     yield()
     return

--- a/scripts/packages/VSCodeServer/src/completions.jl
+++ b/scripts/packages/VSCodeServer/src/completions.jl
@@ -14,7 +14,7 @@ function repl_getcompletions_request(_, params::GetCompletionsRequestParams, @no
         ret = Base.invokelatest(completions, line, lastindex(line), mod)
         ret[1], ret[2]
     catch err
-        @debug "completion error" exception=(err, catch_backtrace())
+        @_debug "completion error" exception=(err, catch_backtrace())
         # might error when e.g. type inference fails
         Completion[], 1:0
     end

--- a/scripts/packages/VSCodeServer/src/eval.jl
+++ b/scripts/packages/VSCodeServer/src/eval.jl
@@ -165,7 +165,7 @@ function repl_runcode_request(conn, params::ReplRunCodeRequestParams, @nospecial
         try
             JSONRPC.send_notification(conn_endpoint[], "repl/starteval", nothing)
         catch err
-            @debug "Could not send repl/starteval notification."
+            @_debug "Could not send repl/starteval notification."
         end
 
         f = () -> hideprompt() do
@@ -183,7 +183,7 @@ function repl_runcode_request(conn, params::ReplRunCodeRequestParams, @nospecial
                     LineEdit.write_prompt(stdout, mode)
                 catch err
                     print(stdout, prefix, prompt, suffix)
-                    @debug "getting prompt info failed" exception = (err, catch_backtrace())
+                    @_debug "getting prompt info failed" exception = (err, catch_backtrace())
                 end
 
                 for (i, line) in enumerate(eachline(IOBuffer(source_code)))
@@ -236,7 +236,7 @@ function repl_runcode_request(conn, params::ReplRunCodeRequestParams, @nospecial
                     try
                         JSONRPC.send_notification(conn_endpoint[], "repl/finisheval", nothing)
                     catch err
-                        @debug "Could not send repl/finisheval notification."
+                        @_debug "Could not send repl/finisheval notification."
                     end
                 end
 

--- a/scripts/packages/VSCodeServer/src/misc.jl
+++ b/scripts/packages/VSCodeServer/src/misc.jl
@@ -218,7 +218,7 @@ function send_queued_notifications!()
         try
             JSONRPC.send_notification(conn_endpoint[], type, content)
         catch err
-            @debug "Could not send enqueued notification" exception=(err, catch_backtrace())
+            @_debug "Could not send enqueued notification" exception=(err, catch_backtrace())
         end
     end
     JSONRPC.flush(conn_endpoint[])

--- a/scripts/packages/VSCodeServer/src/progress.jl
+++ b/scripts/packages/VSCodeServer/src/progress.jl
@@ -12,7 +12,7 @@ function Logging.handle_message(j::VSCodeLogger, level, message, _module,
             JSONRPC.send_notification(conn_endpoint[], "repl/updateProgress", progress)
             JSONRPC.flush(conn_endpoint[])
         catch err
-            @debug "Failed to send 'repl/updateProgress' message" exception=(err, catch_backtrace())
+            @_debug "Failed to send 'repl/updateProgress' message" exception=(err, catch_backtrace())
             return nothing
         finally
             unlock(logger_lock)

--- a/scripts/packages/VSCodeServer/src/repl.jl
+++ b/scripts/packages/VSCodeServer/src/repl.jl
@@ -159,14 +159,14 @@ function hook_repl(@nospecialize(repl))
     if HAS_REPL_TRANSFORM[]
         return
     end
-    @debug "installing REPL hook"  time=round(Int, time()*10)
+    @_debug "installing REPL hook"  time=round(Int, time()*10)
     # Wait for the REPL interface to be set up by `run_frontend` rather than
     # calling `setup_interface` ourselves. Doing it early would ignore user
     # options (e.g. `auto_insert_closing_bracket`) set in other `atreplinit`
     # hooks or startup.jl. Since `hook_repl` is already called inside `@async`,
     # we can simply poll here.
     for i in 1:100  # wait up to 10s
-        @debug "wait for REPL interface: $i" time=round(Int, time()*10)
+        @_debug "wait for REPL interface: $i" time=round(Int, time()*10)
         isdefined(repl, :interface) && break
         sleep(0.1)
     end
@@ -178,17 +178,17 @@ function hook_repl(@nospecialize(repl))
 
     if VERSION > v"1.5-"
         for i in 1:20 # repl backend should be set up after 10s -- fall back to the pre-ast-transform approach otherwise
-            @debug "wait for backend: $i" time=round(Int, time()*10)
+            @_debug "wait for backend: $i" time=round(Int, time()*10)
             has_repl_backend() && break
             sleep(0.5)
         end
         if has_repl_backend()
-            @debug "backend found"  time=round(Int, time()*10)
+            @_debug "backend found"  time=round(Int, time()*10)
             push!(Base.active_repl_backend.ast_transforms, ast -> transform_backend(ast, repl, main_mode))
             HAS_REPL_TRANSFORM[] = true
-            @debug "installing shell integration"  time=round(Int, time()*10)
+            @_debug "installing shell integration"  time=round(Int, time()*10)
             install_vscode_shell_integration(main_mode)
-            @debug "REPL AST transform installed"  time=round(Int, time()*10)
+            @_debug "REPL AST transform installed"  time=round(Int, time()*10)
             return
         end
     end
@@ -198,7 +198,7 @@ function hook_repl(@nospecialize(repl))
             $(evalrepl)($(active_module)(), $line, $repl, $main_mode)
         end
     end
-    @debug "legacy REPL hook installed"  time=round(Int, time()*10)
+    @_debug "legacy REPL hook installed"  time=round(Int, time()*10)
     HAS_REPL_TRANSFORM[] = true
     return nothing
 end
@@ -234,7 +234,7 @@ function evalrepl(m, line, repl, main_mode)
             JSONRPC.send_notification(conn_endpoint[], "repl/starteval", nothing)
             did_notify = true
         catch err
-            @debug "Could not send repl/starteval notification" exception = (err, catch_backtrace())
+            @_debug "Could not send repl/starteval notification" exception = (err, catch_backtrace())
         end
         r = run_with_backend() do
             fix_displays(; is_repl = true)
@@ -262,7 +262,7 @@ function evalrepl(m, line, repl, main_mode)
             try
                 JSONRPC.send_notification(conn_endpoint[], "repl/finisheval", nothing)
             catch err
-                @debug "Could not send repl/finisheval notification" exception = (err, catch_backtrace())
+                @_debug "Could not send repl/finisheval notification" exception = (err, catch_backtrace())
             end
         end
     end

--- a/scripts/packages/VSCodeServer/src/tables/tableviewer.jl
+++ b/scripts/packages/VSCodeServer/src/tables/tableviewer.jl
@@ -152,7 +152,7 @@ function on_pkg_load(pkg)
         global _get_label = (x, col) -> try
             return DataAPI.colmetadata(x, col, "label"; style = false)
         catch err
-            @debug "Could not get column label for $col" exception=(err, catch_backtrace())
+            @_debug "Could not get column label for $col" exception=(err, catch_backtrace())
             return nothing
         end
     elseif pkg.uuid == observables_uuid

--- a/scripts/packages/VSCodeServer/src/trees.jl
+++ b/scripts/packages/VSCodeServer/src/trees.jl
@@ -310,7 +310,7 @@ function getvariables(show_modules)
             #
             # printstyled("Internal Error: ", bold=true, color=Base.error_color())
             # Base.display_error(err, catch_backtrace())
-            @debug "failed to render tree item '$s'" exception=(err, catch_backtrace())
+            @_debug "failed to render tree item '$s'" exception=(err, catch_backtrace())
         end
     end
 


### PR DESCRIPTION
Introduce a `@_debug` macro that forwards to `Base.@debug` only when the server was started with `is_dev=true`, tracked via a module-level `IS_DEV` ref set at the top of `serve`. All internal `@debug` call sites are switched to `@_debug`; the caller's source location is preserved in the log record.

Fixes https://github.com/julia-vscode/julia-vscode/issues/4146.