### PR TITLE
Load bundled packages from their unmodified entry files

### DIFF
--- a/scripts/include_with_private_deps.jl
+++ b/scripts/include_with_private_deps.jl
@@ -1,0 +1,91 @@
+# Include the unmodified entry file of a bundled package (e.g. `Foo/src/Foo.jl`) into
+# `mod`, stripping the top level `module Foo ... end` wrapper and rewriting
+# `using`/`import` statements of bundled dependencies to relative imports so they
+# resolve to already loaded private copies instead of going through `Base.require`.
+# A dependency counts as bundled if a module with the same name is bound in `mod` or
+# in `parentmodule(mod)`. `include` calls are rewritten so that nested files get the
+# same treatment (except the module stripping). Usage:
+#
+#     module JSONRPC end
+#     include_with_private_deps(JSONRPC, "../../JSONRPC/src/JSONRPC.jl")
+#
+# `mod` must have the same name as the package's top level module. Not handled:
+# `using`/`import` inside nested `module` blocks and `include` calls that are not
+# syntactically visible at the top level (e.g. inside functions).
+function include_with_private_deps(mod::Module, path::AbstractString)
+    return Base.include(ex -> _strip_package_module(mod, ex), mod, path)
+end
+
+function _strip_package_module(mod::Module, ex)
+    # Unwrap a docstring attached to the module (the docstring is discarded).
+    if Meta.isexpr(ex, :macrocall, 4) &&
+            (ex.args[1] === GlobalRef(Core, Symbol("@doc")) || ex.args[1] === Symbol("@doc")) &&
+            Meta.isexpr(ex.args[4], :module)
+        ex = ex.args[4]
+    end
+    if Meta.isexpr(ex, :module, 3)
+        body = ex.args[3]::Expr
+        return Expr(:toplevel, map(x -> _rewrite_for_private_deps(mod, x), body.args)...)
+    end
+    return _rewrite_for_private_deps(mod, ex)
+end
+
+function _rewrite_for_private_deps(mod::Module, ex)
+    ex isa Expr || return ex
+    if ex.head === :using || ex.head === :import
+        return Expr(ex.head, map(a -> _rewrite_import_target(mod, a), ex.args)...)
+    elseif Meta.isexpr(ex, :call) && ex.args[1] === :include && 2 <= length(ex.args) <= 3
+        # include([mapexpr,] path) -> _include_rewritten([mapexpr,] mod, path)
+        return Expr(:call, _include_rewritten, ex.args[2:end-1]..., mod, ex.args[end])
+    elseif ex.head === :block || ex.head === :if || ex.head === :elseif || ex.head === :toplevel
+        return Expr(ex.head, map(x -> _rewrite_for_private_deps(mod, x), ex.args)...)
+    elseif Meta.isexpr(ex, :macrocall) && ex.args[1] === Symbol("@static")
+        return Expr(:macrocall, ex.args[1], ex.args[2],
+            map(x -> _rewrite_for_private_deps(mod, x), ex.args[3:end])...)
+    end
+    return ex
+end
+
+function _include_rewritten(mod::Module, path::AbstractString)
+    return Base.include(ex -> _rewrite_for_private_deps(mod, ex), mod, path)
+end
+function _include_rewritten(mapexpr, mod::Module, path::AbstractString)
+    return Base.include(ex -> _rewrite_for_private_deps(mod, mapexpr(ex)), mod, path)
+end
+
+# An argument of `using`/`import` is a plain module path (`import A.B`), a `:` clause
+# (`using A: b, c`) where only the first argument is the module path, or an `as`
+# clause (`import A as B`).
+function _rewrite_import_target(mod::Module, ex)
+    if Meta.isexpr(ex, :(:)) && !isempty(ex.args)
+        return Expr(:(:), _rewrite_module_path(mod, ex.args[1]), ex.args[2:end]...)
+    elseif Meta.isexpr(ex, :as, 2)
+        return Expr(:as, _rewrite_module_path(mod, ex.args[1]), ex.args[2])
+    else
+        return _rewrite_module_path(mod, ex)
+    end
+end
+
+function _rewrite_module_path(mod::Module, ex)
+    if Meta.isexpr(ex, :.) && !isempty(ex.args) && ex.args[1] isa Symbol && ex.args[1] !== :.
+        ndots = _private_dep_dots(mod, ex.args[1]::Symbol)
+        if ndots > 0
+            return Expr(:., fill(:., ndots)..., ex.args...)
+        end
+    end
+    return ex
+end
+
+# Leading dots needed to reach the private copy of the dependency `name`:
+# 1 (`using .Foo`) if bound in `mod` itself, 2 (`using ..Foo`) if bound in the parent
+# module, 0 if there is no private copy (leave the statement alone).
+function _private_dep_dots(mod::Module, name::Symbol)
+    if isdefined(mod, name) && getfield(mod, name) isa Module
+        return 1
+    end
+    parent = parentmodule(mod)
+    if parent !== mod && isdefined(parent, name) && getfield(parent, name) isa Module
+        return 2
+    end
+    return 0
+end

--- a/scripts/packages/VSCodeDebugger/src/VSCodeDebugger.jl
+++ b/scripts/packages/VSCodeDebugger/src/VSCodeDebugger.jl
@@ -3,29 +3,25 @@ module VSCodeDebugger
 import Sockets
 
 include("../../../error_handler.jl")
+include("../../../include_with_private_deps.jl")
 
-include("../../CodeTracking/src/CodeTracking.jl")
-include("../../JSON/src/JSON.jl")
+module CodeTracking end
+include_with_private_deps(CodeTracking, "../../CodeTracking/src/CodeTracking.jl")
 
-module JuliaInterpreter
-    using ..CodeTracking
+module JSON end
+include_with_private_deps(JSON, "../../JSON/src/JSON.jl")
 
-    @static if VERSION >= v"1.10.0"
-        include("../../JuliaInterpreter/src/packagedef.jl")
-    elseif VERSION >= v"1.6.0"
-        include("../../../packages-old/v1.9/JuliaInterpreter/src/packagedef.jl")
-    else
-        include("../../../packages-old/v1.5/JuliaInterpreter/src/packagedef.jl")
-    end
+module JuliaInterpreter end
+@static if VERSION >= v"1.10.0"
+    include_with_private_deps(JuliaInterpreter, "../../JuliaInterpreter/src/JuliaInterpreter.jl")
+elseif VERSION >= v"1.6.0"
+    include_with_private_deps(JuliaInterpreter, "../../../packages-old/v1.9/JuliaInterpreter/src/JuliaInterpreter.jl")
+else
+    include_with_private_deps(JuliaInterpreter, "../../../packages-old/v1.5/JuliaInterpreter/src/JuliaInterpreter.jl")
 end
 
-module DebugAdapter
-    import Pkg
-    import ..JuliaInterpreter
-    import ..JSON
-
-    include("../../DebugAdapter/src/packagedef.jl")
-end
+module DebugAdapter end
+include_with_private_deps(DebugAdapter, "../../DebugAdapter/src/DebugAdapter.jl")
 
 function startdebugger()
     client_pipename = ARGS[1]

--- a/scripts/packages/VSCodeServer/src/VSCodeServer.jl
+++ b/scripts/packages/VSCodeServer/src/VSCodeServer.jl
@@ -10,52 +10,40 @@ import Profile
 import Logging
 import InteractiveUtils
 
-include("../../JSON/src/JSON.jl")
-include("../../CancellationTokens/src/CancellationTokens.jl")
+include("../../../include_with_private_deps.jl")
 
+module JSON end
+include_with_private_deps(JSON, "../../JSON/src/JSON.jl")
+
+module CancellationTokens end
+include_with_private_deps(CancellationTokens, "../../CancellationTokens/src/CancellationTokens.jl")
+
+module CodeTracking end
 @static if VERSION >= v"1.10.0"
-    include("../../CodeTracking/src/CodeTracking.jl")
+    include_with_private_deps(CodeTracking, "../../CodeTracking/src/CodeTracking.jl")
 elseif VERSION >= v"1.6.0"
-    include("../../../packages-old/v1.9/CodeTracking/src/CodeTracking.jl")
+    include_with_private_deps(CodeTracking, "../../../packages-old/v1.9/CodeTracking/src/CodeTracking.jl")
 else
-    include("../../../packages-old/v1.5/CodeTracking/src/CodeTracking.jl")
+    include_with_private_deps(CodeTracking, "../../../packages-old/v1.5/CodeTracking/src/CodeTracking.jl")
 end
 
-module IJuliaCore
-using ..JSON
-using Printf
-import Base64
+module IJuliaCore end
+include_with_private_deps(IJuliaCore, "../../IJuliaCore/src/IJuliaCore.jl")
 
-include("../../IJuliaCore/src/packagedef.jl")
-end
+module JSONRPC end
+include_with_private_deps(JSONRPC, "../../JSONRPC/src/JSONRPC.jl")
 
-module JSONRPC
-import ..CancellationTokens
-import ..JSON
-import UUIDs, Sockets
-
-include("../../JSONRPC/src/packagedef.jl")
-end
-
-module JuliaInterpreter
-using ..CodeTracking
-
+module JuliaInterpreter end
 @static if VERSION >= v"1.10.0"
-    include("../../JuliaInterpreter/src/packagedef.jl")
+    include_with_private_deps(JuliaInterpreter, "../../JuliaInterpreter/src/JuliaInterpreter.jl")
 elseif VERSION >= v"1.6.0"
-    include("../../../packages-old/v1.9/JuliaInterpreter/src/packagedef.jl")
+    include_with_private_deps(JuliaInterpreter, "../../../packages-old/v1.9/JuliaInterpreter/src/JuliaInterpreter.jl")
 else
-    include("../../../packages-old/v1.5/JuliaInterpreter/src/packagedef.jl")
-end
+    include_with_private_deps(JuliaInterpreter, "../../../packages-old/v1.5/JuliaInterpreter/src/JuliaInterpreter.jl")
 end
 
-module DebugAdapter
-import Pkg
-import ..JuliaInterpreter
-import ..JSON
-
-include("../../DebugAdapter/src/packagedef.jl")
-end
+module DebugAdapter end
+include_with_private_deps(DebugAdapter, "../../DebugAdapter/src/DebugAdapter.jl")
 
 const FALLBACK_CONSOLE_LOGGER_REF = Ref{Logging.AbstractLogger}()
 const DEBUG_SESSION = Ref{Channel{DebugAdapter.DebugSession}}()


### PR DESCRIPTION
This adds `include_with_private_deps(mod, path)`, which includes a package's regular entry file into `mod` by stripping the top level `module` wrapper, rewriting `using`/`import` of bundled dependencies to relative imports (so they resolve to the private copies instead), and applying the same rewriting to nested `include`s. This removes the need for packages to adopt the `packagedef.jl` file structure. The second commit converts all bundled packages in VSCodeServer and VSCodeDebugger to this mechanism.

Closes fredrikekre/Runic.jl#209.