### PR TITLE
Shut down test controller on dispose; include ext/ in coverage task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - A test run that fails to start, or that is cancelled, now stops showing as running in the Test Explorer instead of spinning indefinitely.
 - The language server logs its startup and dynamic analysis process lifecycle to the output channel again, and failures of those processes are now reported as warnings. The `--debug=yes` switch works again, having been disabled unconditionally.
 - `include` calls inside `@testitem`, `@testmodule`, and `@testsnippet` bodies are no longer reported as duplicate includes when several test items include the same file, since each test item runs in its own module.
+- Test processes no longer outlive VS Code. The test item controller was killed outright when the extension shut down, which on Windows terminates it without giving it a chance to stop the test processes it had spawned. It is now asked to shut down and only killed if it has not exited within five seconds.
+- The "Run tests with coverage" task now reports coverage for package extensions: only the `src` folder was processed, so nothing under `ext` appeared in `lcov.info`.
 
 ## [1.231.0] - 2026-08-08
 ### Added

--- a/scripts/tasks/task_test.jl
+++ b/scripts/tasks/task_test.jl
@@ -13,7 +13,12 @@ push!(Base.LOAD_PATH, "@stdlib")
 
 import CoverageTools
 
-coverage = CoverageTools.process_folder()
+coverage = CoverageTools.process_folder("src")
+
+# Also include package extensions (see julia-vscode/julia-vscode#3696)
+if isdir("ext")
+    append!(coverage, CoverageTools.process_folder("ext"))
+end
 
 CoverageTools.LCOV.writefile("lcov.info", coverage)
 

--- a/src/testing/testControllerProtocol.ts
+++ b/src/testing/testControllerProtocol.ts
@@ -111,6 +111,9 @@ export const requestTypeTerminateTestProcess = new rpc.RequestType<TerminateTest
     'terminateTestProcess'
 )
 
+// Asks the controller to shut down gracefully (killing its child test processes). No params.
+export const notificationTypeShutdown = new rpc.NotificationType<void>('shutdown')
+
 // Notification types from the controller to the extension
 //
 // Every test item notification carries `testEnvId` alongside `testItemId`, and an item must be

--- a/src/testing/testFeature.ts
+++ b/src/testing/testFeature.ts
@@ -18,6 +18,7 @@ import {
     notficiationTypeTestItemStarted,
     notificationTypeAppendOutput,
     notificationTypeLaunchDebugger,
+    notificationTypeShutdown,
     notificationTypeTestProcessCreated,
     notificationTypeTestProcessOutput,
     notificationTypeTestProcessStatusChanged,
@@ -222,6 +223,47 @@ export class JuliaTestController {
         // `'exit'` clears `process`, and the tree node this is reached from outlives it, so a
         // second click would otherwise throw a `TypeError` and file it as a crash report.
         this.process?.kill()
+    }
+
+    /**
+     * Gracefully shut down the controller: send the `shutdown` notification (which makes the
+     * controller kill its child test processes and exit) and wait for the process to exit,
+     * falling back to killing it after a timeout. Never throws.
+     */
+    shutdown(timeoutMs = 5000): Promise<void> {
+        const process = this.process
+        if (!process) {
+            return Promise.resolve()
+        }
+
+        try {
+            if (this.connection) {
+                this.connection.sendNotification(notificationTypeShutdown)
+            }
+        } catch {
+            // Ignore, we fall back to killing the process below.
+        }
+
+        return new Promise<void>((resolve) => {
+            if (process.exitCode !== null || process.signalCode !== null) {
+                resolve()
+                return
+            }
+
+            const timer = setTimeout(() => {
+                try {
+                    process.kill()
+                } catch {
+                    // Ignore
+                }
+                resolve()
+            }, timeoutMs)
+
+            process.once('exit', () => {
+                clearTimeout(timer)
+                resolve()
+            })
+        })
     }
 
     private connection: rpc.MessageConnection
@@ -1452,7 +1494,13 @@ export class TestFeature implements TestControllerHost {
     }
 
     public dispose() {
-        this.juliaTestController?.kill()
+        // Ask the controller to shut down gracefully rather than killing it, so that its child
+        // test processes do not survive VS Code exiting (see julia-vscode/julia-vscode#3842).
+        // The notification is sent synchronously; waiting for the exit happens in the background.
+        const controller = this.juliaTestController
+        if (controller) {
+            void controller.shutdown().catch(() => {})
+        }
         this.juliaTestController = undefined
 
         this.testProcessLogViews.dispose()


### PR DESCRIPTION
Two small fixes:

**Coverage task includes `ext/`** — `scripts/tasks/task_test.jl` called `CoverageTools.process_folder()` (defaults to `src`), so package extensions never showed up in `lcov.info`. It now processes `src` and, if it exists, `ext` (results appended). Fixes #3696

**Test controller shutdown on dispose** — `TestFeature.dispose()` hard-kills the Julia test controller. On Windows Node's `kill()` is always a `TerminateProcess`, so the controller dies without running its cleanup and its child test processes are orphaned — the symptom of #3842. The controller side of the fix is already in the bundled `TestItemControllers`: a `shutdown` notification that cancels every run and terminates every test process before exiting. The extension just never sent it.

This adds `notificationTypeShutdown` (`"shutdown"`, no params) to `testControllerProtocol.ts` and a `JuliaTestController.shutdown()` that sends the notification if the connection is alive, then waits for the process `exit` with a 5s timeout, falling back to `process.kill()`. `TestFeature.dispose()` now calls it (fire and forget, non-throwing) instead of `kill()`. Sending and killing immediately would not work: `sendNotification` writes to the child's stdin asynchronously, so the kill can drop the notification before it is flushed.

The `language-julia.stopTestController` and `restartTestController` command paths are unchanged — they still kill, and could get the same treatment in a follow-up. Part of #3842.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
