### PR TITLE
Pass julialangDirectoryWatching to the language server

### DIFF
--- a/src/languageClient.ts
+++ b/src/languageClient.ts
@@ -380,7 +380,12 @@ export class LanguageClientFeature {
             revealOutputChannelOn: RevealOutputChannelOn.Never,
             traceOutputChannel: this.traceOutputChannel,
             outputChannel: this.outputChannel,
-            initializationOptions: { julialangTestItemIdentification: true },
+            // julialangDirectoryWatching: the VS Code watcher reports an atomic
+            // folder rename/delete as a single folder-path event, so the LS
+            // registers an extra `**` create/delete watcher. Passing 'on'
+            // explicitly makes that apply in every Code-OSS fork, whatever
+            // clientInfo.name it reports.
+            initializationOptions: { julialangTestItemIdentification: true, julialangDirectoryWatching: 'on' },
             errorHandler,
         }
 


### PR DESCRIPTION
One-line companion to julia-vscode/LanguageServer.jl#1463: pass `julialangDirectoryWatching: 'on'` in the LS `initializationOptions`.

The LS registers an extra `**` create/delete watcher so atomic folder renames/deletes are observed (the Code-OSS watcher reports them as a single folder-path event with no per-child events). Its default gate sniffs `clientInfo.name` for the Code-OSS family; passing the option explicitly makes the fix apply in **every** Code-OSS fork (VSCodium, Cursor, Windsurf, Positron, future forks) regardless of the app name they report.

No ordering dependency: the option is simply ignored by LS versions that predate #1463, and stock VS Code is covered by the name sniffing either way. Can merge before or after the submodule bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)