### PR TITLE
Don't crash on a null julia.debuggerDefaultCompiled

### DIFF
--- a/src/debugger/debugConfig.ts
+++ b/src/debugger/debugConfig.ts
@@ -216,8 +216,10 @@ export class DebugConfigTreeProvider implements vscode.TreeDataProvider<DebugCon
     applyDefaults() {
         this.reset()
 
-        const defaults: string[] = vscode.workspace.getConfiguration('julia').get('debuggerDefaultCompiled')
-        defaults.forEach((el) => this._compiledItems.add(el))
+        const defaults = vscode.workspace.getConfiguration('julia').get<string[]>('debuggerDefaultCompiled', [])
+        if (Array.isArray(defaults)) {
+            defaults.forEach((el) => this._compiledItems.add(el))
+        }
         this.refresh()
     }
 


### PR DESCRIPTION
## Crash signature

From the **insider-channel** Application Insights crash telemetry, last 30 days (extension 1.231.1):

```
TypeError: Cannot read properties of undefined (reading 'forEach')
  #0 Iz.applyDefaults @ src/debugger/debugConfig.ts:219
  #1 activate          @ src/debugger/debugConfig.ts:253
  #2 activate          @ src/extension.ts:86
  #3 processTicksAndRejections
```

1 event / 1 user.

## Root cause

```ts
const defaults: string[] = vscode.workspace.getConfiguration('julia').get('debuggerDefaultCompiled')
defaults.forEach((el) => this._compiledItems.add(el))
```

`get()` is called without a default value, so it returns `undefined` when the setting is explicitly
`null` in `settings.json` (the package.json default only applies when the key is absent, not when it
is present-but-null). The type annotation `: string[]` hides this from the compiler.

Because `applyDefaults` is called from `debugConfig.activate`, which is awaited by
`extension.ts:activate`, the throw aborts **extension activation** rather than degrading to "no
default compiled items".

## Fix

Pass `[]` as the `get` default and guard with `Array.isArray`, so a missing, null, or wrongly-typed
value is ignored instead of throwing.

## Testing

`npm run check-types` passes.
