### PR TITLE
Guard delayed debuggee process kill

### DIFF
--- a/src/debugger/debugFeature.ts
+++ b/src/debugger/debugFeature.ts
@@ -251,7 +251,14 @@ export class JuliaDebugFeature {
 
                                     if (processId) {
                                         setTimeout(() => {
-                                            process.kill(processId)
+                                            try {
+                                                process.kill(processId)
+                                            } catch (err) {
+                                                if ((err as NodeJS.ErrnoException).code !== 'ESRCH') {
+                                                    // Do not let errors escape from this un-awaited timeout callback.
+                                                    console.error(`Failed to terminate Julia debuggee process ${processId}:`, err)
+                                                }
+                                            }
                                         }, 500)
                                     }
                                 }

--- a/src/debugger/debugFeature.ts
+++ b/src/debugger/debugFeature.ts
@@ -256,7 +256,10 @@ export class JuliaDebugFeature {
                                             } catch (err) {
                                                 if ((err as NodeJS.ErrnoException).code !== 'ESRCH') {
                                                     // Do not let errors escape from this un-awaited timeout callback.
-                                                    console.error(`Failed to terminate Julia debuggee process ${processId}:`, err)
+                                                    console.error(
+                                                        `Failed to terminate Julia debuggee process ${processId}:`,
+                                                        err
+                                                    )
                                                 }
                                             }
                                         }, 500)


### PR DESCRIPTION
## Crash signature

`Error: kill ESRCH` from `process.kill` in the delayed `terminate` request timer in `src/debugger/debugFeature.ts` (`Timeout._onTimeout`). Insider telemetry reported 95 events across 7 users in the last 30 days.

## Root cause

The debug adapter tracker schedules a fire-and-forget `process.kill(processId)` 500 ms after receiving a `terminate` request. By the time the timer runs, the debuggee process may already have exited normally, causing Node to throw `ESRCH` from an un-awaited callback and surface it as an extension crash.

## Fix

Wrap the delayed `process.kill` in `try`/`catch`, silently treat `ESRCH` as success because the target process is already gone, and log unexpected kill failures without allowing them to escape the timer callback.

## Testing

- `npm run check-types`