### PR TITLE
Report formatting failures to the user, not as crashes

### DIFF
--- a/src/languageClient.ts
+++ b/src/languageClient.ts
@@ -28,6 +28,80 @@ const supportedLanguages = ['julia', 'juliamarkdown', 'markdown']
 export type LanguageServerState = 'stopped' | 'starting' | 'running' | 'crashed'
 
 /**
+ * LSP 3.17 `ErrorCodes.RequestFailed`. `vscode-languageserver-protocol` does not
+ * export a constant for it.
+ */
+const LSP_REQUEST_FAILED = -32803
+
+/**
+ * The last formatting failure reported for a document, so that format-on-save on
+ * a file with a syntax error warns once rather than on every keystroke-save
+ * cycle. Cleared when the document formats successfully, so a file that is fixed
+ * and then broken again warns again.
+ */
+const lastFormattingFailure = new Map<string, string>()
+
+/**
+ * Turn a failed formatting request into a message for the user instead of an
+ * extension fault.
+ *
+ * `vscode-languageclient`'s `handleFailedRequest` only swallows a small set of
+ * codes (`PendingResponseRejected`, `ConnectionInactive`, `RequestCancelled`,
+ * `ServerCancelled`, `ContentModified`); every other error — including
+ * `RequestFailed`, which is precisely the code a server is supposed to use for
+ * "understood, but I can't do that" — is logged and then **rethrown**. The
+ * rethrow lands in VS Code's format command, which attributes it to this
+ * extension and reports it as a crash. So the server cannot fix this on its own
+ * no matter which code it picks; the client has to intercept.
+ *
+ * The overwhelmingly common cause is a file that isn't valid Julia, which is the
+ * user's code rather than a bug, so we surface it as a warning and return `null`
+ * ("no edits").
+ */
+function handleFormattingError<T>(
+    outputChannel: vscode.OutputChannel,
+    document: vscode.TextDocument,
+    run: () => Promise<T>
+): Promise<T | null> {
+    const key = document.uri.toString()
+    return run().then(
+        (result) => {
+            lastFormattingFailure.delete(key)
+            return result
+        },
+        (err) => {
+            if (err instanceof ResponseError) {
+                outputChannel.appendLine(`Formatting failed: ${err.message}`)
+                if (isLanguageServerError(err)) {
+                    // The server went away mid-request; the crash, if any, is
+                    // reported separately.
+                    return null
+                }
+                // `RequestFailed` carries a message written for the user.
+                // Anything else is still a failed formatting request, and the
+                // user is better served by being told than by an error report,
+                // so show what we have and keep the detail in the log. A server
+                // error must never surface as an extension fault.
+                const summary =
+                    err.code === LSP_REQUEST_FAILED
+                        ? err.message.split('\n')[0]
+                        : `Could not format this document: ${err.message.split('\n')[0]}`
+                if (lastFormattingFailure.get(key) !== summary) {
+                    lastFormattingFailure.set(key, summary)
+                    vscode.window.showWarningMessage(summary, 'Open Logs').then((choice) => {
+                        if (choice === 'Open Logs') {
+                            vscode.commands.executeCommand('language-julia.showLanguageServerOutput')
+                        }
+                    })
+                }
+                return null
+            }
+            throw err
+        }
+    )
+}
+
+/**
  * Returns true if the error is a result of the language server connection
  * being unavailable (crashed, stopped, not ready). These errors should be
  * handled gracefully without sending extension crash telemetry, since the
@@ -387,6 +461,18 @@ export class LanguageClientFeature {
             // clientInfo.name it reports.
             initializationOptions: { julialangTestItemIdentification: true, julialangDirectoryWatching: 'on' },
             errorHandler,
+            middleware: {
+                // A formatting request that fails is a message for the user, not
+                // an extension fault. See `handleFormattingError`.
+                provideDocumentFormattingEdits: (document, options, token, next) =>
+                    handleFormattingError(this.outputChannel, document, () =>
+                        Promise.resolve(next(document, options, token))
+                    ),
+                provideDocumentRangeFormattingEdits: (document, range, options, token, next) =>
+                    handleFormattingError(this.outputChannel, document, () =>
+                        Promise.resolve(next(document, range, options, token))
+                    ),
+            },
         }
 
         // Create the language client and start the client.


### PR DESCRIPTION
## Crash signature

From the **insider-channel** Application Insights crash telemetry, last 30 days. The largest signature
in the whole corpus — **3645 events / 19 users**, roughly 70% of all reported extension crashes:

```
Error: Failed to format document: ErrorException("ParseError: …")
  #0 handleResponse       @ vscode-jsonrpc/lib/common/connection.js:565
  #1 handleMessage        @ vscode-jsonrpc/lib/common/connection.js:345
  #2 processMessageQueue  @ vscode-jsonrpc/lib/common/connection.js:362
  #3 Immediate.<anonymous>@ vscode-jsonrpc/lib/common/connection.js:334
```

## Root cause

Two independent problems produced one signature.

**1. The server offered to format Markdown.** Fixed server-side in
julia-vscode/LanguageServer.jl#1467 — see that PR for the detail. In short, a static formatting
capability applies to the client's whole document selector, which includes `markdown`, so the Julia
formatter was parsing prose as Julia *and* suppressing the real Markdown formatter.

**2. Any formatting failure became an extension fault — and the server cannot fix that alone.**

```js
// vscode-languageclient/lib/common/client.js
handleFailedRequest(type, token, error, defaultValue, ...) {
    if (error instanceof ResponseError) {
        if (error.code === ErrorCodes.PendingResponseRejected ||
            error.code === ErrorCodes.ConnectionInactive) { return defaultValue }
        if (error.code === LSPErrorCodes.RequestCancelled || … ServerCancelled) { … }
        else if (error.code === LSPErrorCodes.ContentModified) { … }
    }
    this.error(`Request ${type.method} failed.`, error, showNotification);
    throw error;          // <-- everything else, including RequestFailed
}
```

`formatting.js` passes that straight through to VS Code's format command, which attributes the throw to
this extension. So whichever code the server picks — including `RequestFailed` (`-32803`), the code LSP
defines precisely for "understood, but I can't do that" — the client still has to intercept it.

## Fix

Formatting middleware in `clientOptions` that catches `ResponseError` and:

- logs the full detail to the language server output channel;
- returns `null` silently for connection-teardown errors (`isLanguageServerError`), since a genuine
  server crash is already reported separately;
- otherwise shows a warning with an **Open Logs** action and returns `null` (no edits).

`RequestFailed` messages come from the server already written for a human (they name the file and say it
could not be parsed as Julia), so they are shown as-is; any other code gets a generic lead-in.

**De-duplicated per document.** Format-on-save on a file with a syntax error would otherwise warn on
every save, since a file being edited is transiently invalid all the time. The last warning per document
URI is remembered and not repeated; the entry is cleared on a successful format, so a file that is fixed
and later broken again does warn again.

## Testing

`npm run check-types` passes.

Behavioural verification is manual — the repo's test suite (`vscode-test`) has no existing harness for
language-client middleware, and adding one is out of scope for a crash fix. Paired with
julia-vscode/LanguageServer.jl#1467, which carries unit tests for the server-side half (27 assertions
covering the capability/registration logic and the new error code).
