### PR TITLE
Avoid unsigned cell search indices

### DIFF
--- a/src/interactive/codecells.ts
+++ b/src/interactive/codecells.ts
@@ -315,11 +315,11 @@ class JuliaCellManager implements vscode.Disposable {
         position: vscode.Position,
         searchStartIdx: number = 0
     ): number {
-        let low = searchStartIdx
+        let low = Math.max(0, searchStartIdx)
         let high = docCells.length - 1
         let result = -1
         while (low <= high) {
-            const mid = (low + high) >>> 1
+            const mid = (low + high) >> 1
             const cell = docCells[mid]
             if (position.isBeforeOrEqual(cell.cellRange.end)) {
                 result = mid


### PR DESCRIPTION
## Crash signature

Extension 1.231.1 reported:

```text
TypeError: Cannot read properties of undefined (reading 'cellRange')
  #0 M4._findSortedInfCellIndex  @ src/interactive/codecells.ts:324
  #1 M4.getSelectionsCellContext @ src/interactive/codecells.ts:289
  #2 M4.executeCellAndMove       @ src/interactive/codecells.ts:617
```

## Root cause

`getSelectionsCellContext` can pass the documented not-found value `-1` from `infIndex` back into `_findSortedInfCellIndex` as the search start. In a single-cell document with the cursor after the cell, that makes the binary search use `low = -1` and `high = 0`. The previous midpoint calculation used an unsigned right shift, so `(-1) >>> 1` became `2147483647`, producing an out-of-range `docCells[mid]` and a crash when reading `cell.cellRange`.

## Fix

Clamp `_findSortedInfCellIndex`'s `searchStartIdx` to a valid lower bound and compute the midpoint with an arithmetic shift instead of an unsigned shift. Keeping the guard inside the search helper protects all call sites, including future ones, from accidentally treating the `-1` sentinel as an array index.

## Testing

- `npm run check-types`

No unit test was added because the existing test suite does not have a suitable codecells-focused test file or harness to exercise `JuliaCellManager` without introducing new testing structure.
