### PR TITLE
Fix empty cell execution crash

### DIFF
--- a/src/interactive/codecells.ts
+++ b/src/interactive/codecells.ts
@@ -524,6 +524,9 @@ class CodeCellExecutionFeature extends JuliaCellManager {
     private async _executeCells(editor: vscode.TextEditor, cells: readonly JuliaCell[]): Promise<boolean> {
         const document = editor.document
         const codeRanges: vscode.Range[] = cells.map((cell) => cell.codeRange).filter((cr) => cr !== undefined)
+        if (codeRanges.length === 0) {
+            return false
+        }
         const cellPendings: results.Result[] = codeRanges.map((codeRange) =>
             results.addResult(editor, codeRange, this.PENDING_SIGN, '')
         )


### PR DESCRIPTION
## Crash signature

TypeError: Cannot read properties of undefined (reading 'start') in CodeCellExecutionFeature._executeCells at src/interactive/codecells.ts:531, reached from executeAboveCells. Insider telemetry saw 7 events / 4 users in 30 days on extension 1.231.1.

## Root cause

_executeCells filters the provided cells down to cells with a defined codeRange. If all selected/preceding cells are prose-only or comment-only, codeRanges is empty, but the code still dereferenced codeRanges[0].start while resolving the module.

## Fix

Return early before adding pending result decorations or resolving the module when there are no executable code ranges. This avoids the crash and leaves no pending decorations to clean up.

## Testing

- npm run check-types
- No unit test added: src/test contains no existing codecells.ts-focused test harness, and covering this private VS Code command path would require introducing new mocking/test infrastructure.
