### PR TITLE
Fix empty cell move crash

### DIFF
--- a/src/interactive/codecells.ts
+++ b/src/interactive/codecells.ts
@@ -473,6 +473,9 @@ class CodeCellExecutionFeature extends JuliaCellManager {
             direction === 'down'
                 ? this._getNextCell(cellContext, docCells)
                 : this._getPreviousCell(cellContext, docCells)
+        if (nextCell === undefined) {
+            return
+        }
         const newPosition = nextCell.codeRange?.start ?? nextCell.cellRange.start
         repl.validateMoveAndReveal(editor, newPosition, newPosition)
     }
@@ -615,10 +618,10 @@ class CodeCellExecutionFeature extends JuliaCellManager {
                   sup: cell,
               } satisfies CellContext)
             : this.getSelectionsCellContext(docCells)
-        this._moveCell(editor, cellContext, direction, docCells)
         if (cellContext.current.length === 0) {
             return false
         }
+        this._moveCell(editor, cellContext, direction, docCells)
         return await this._executeCells(editor, cellContext.current)
     }
 


### PR DESCRIPTION
## Crash signature

TypeError: Cannot read properties of undefined (reading 'codeRange') in `CodeCellExecutionFeature._moveCell` from `src/interactive/codecells.ts`, reached via `executeCellAndMove`.

## Root cause

`executeCellAndMove` called `_moveCell` before checking whether the current cell context was empty. For documents with no cells or no selection, `getSelectionsCellContext` returns no current, lower, or upper cell, so `_getNextCell`/`_getPreviousCell` return `undefined` and `_moveCell` dereferenced that result.

## Fix

- Return `false` from `executeCellAndMove` before trying to move when there are no cells to execute.
- Make `_moveCell` return without moving when there is no next/previous cell.

## Testing

- `npm run check-types`
- No unit test added: existing tests do not include a suitable `codecells.ts` harness or coverage area for interactive cell movement.
