### PR TITLE
Handle failed language client startup cleanup

### DIFF
--- a/src/languageClient.ts
+++ b/src/languageClient.ts
@@ -45,11 +45,22 @@ export function isLanguageServerError(err: unknown): boolean {
         }
     }
     if (err instanceof Error) {
-        if (err.message === 'Language client is not ready yet' || err.message === 'Client is not running') {
+        if (
+            err.message === 'Language client is not ready yet' ||
+            err.message === 'Client is not running' ||
+            err.message.startsWith("Client is not running and can't be stopped")
+        ) {
             return true
         }
     }
     return false
+}
+
+function formatErrorForOutput(err: unknown): string {
+    if (err instanceof Error) {
+        return err.stack ?? err.message
+    }
+    return String(err)
 }
 
 /**
@@ -453,11 +464,27 @@ export class LanguageClientFeature {
             }
         })
 
+        let startupCleanupError: unknown
+        const originalStop = languageClient.stop
+        languageClient.stop = async (...args) => {
+            try {
+                return await originalStop.apply(languageClient, args)
+            } catch (err) {
+                startupCleanupError = err
+            }
+        }
+
         try {
             this.statusBarItem.command = 'language-julia.showLanguageServerOutput'
             await languageClient.start()
             this.setLanguageClient(languageClient)
-        } catch {
+        } catch (err) {
+            this.outputChannel.appendLine('Could not start the Julia language server.')
+            this.outputChannel.appendLine(formatErrorForOutput(err))
+            if (startupCleanupError && !isLanguageServerError(startupCleanupError)) {
+                this.outputChannel.appendLine('The language client also failed while cleaning up the failed start.')
+                this.outputChannel.appendLine(formatErrorForOutput(startupCleanupError))
+            }
             vscode.window
                 .showErrorMessage(
                     'Could not start the Julia language server. Make sure the configuration setting julia.executablePath points to the Julia binary.',
@@ -469,8 +496,13 @@ export class LanguageClientFeature {
                     }
                 })
             this.setLanguageClient()
+            this.setState('crashed')
+        } finally {
+            languageClient.stop = originalStop
         }
-        this.statusBarItem.hide()
+        if (this._state !== 'crashed') {
+            this.statusBarItem.hide()
+        }
     }
 
     async restartLanguageServer(envPath?: string, autoInstall?: boolean) {

--- a/src/test/suite/languageClient.test.ts
+++ b/src/test/suite/languageClient.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert'
 import { CloseAction, ErrorAction, ErrorHandler } from 'vscode-languageclient/node'
-import { RestartTrackingErrorHandler } from '../../languageClient'
+import { RestartTrackingErrorHandler, isLanguageServerError } from '../../languageClient'
 
 function makeDelegate(closeActions: CloseAction[]): ErrorHandler {
     let i = 0
@@ -60,5 +60,22 @@ suite('RestartTrackingErrorHandler', () => {
         const result = await handler.error(new Error('boom'), undefined, 1)
         assert.strictEqual(result.action, ErrorAction.Continue)
         assert.strictEqual(handler.consumeRestartPending(), false)
+    })
+})
+
+suite('isLanguageServerError', () => {
+    test('handles languageclient cleanup errors with state suffixes', () => {
+        assert.strictEqual(
+            isLanguageServerError(
+                new Error("Client is not running and can't be stopped. It's current state is: startFailed")
+            ),
+            true
+        )
+        assert.strictEqual(
+            isLanguageServerError(
+                new Error("Client is not running and can't be stopped. It's current state is: starting")
+            ),
+            true
+        )
     })
 })


### PR DESCRIPTION
## Crash signature

696 events / 42 users in 30 days on extension 1.231.1:

- `Client is not running and can't be stopped. It's current state is: startFailed`
- `Client is not running and can't be stopped. It's current state is: starting`

The stack is entirely inside `vscode-languageclient` startup cleanup: `start()` -> `doInitialize()` -> `stop()` -> `shutdown()`.

## Root cause

When language server initialization fails, `vscode-languageclient` starts cleanup by calling `stop()` while the client may still be in `startFailed` or `starting`. That cleanup failure produces the secondary `Client is not running and can't be stopped` error, masking the primary initialization failure and allowing the extension to remain in the local `starting` state.

## Fix

- Wrap `languageClient.stop()` during `languageClient.start()` so startup cleanup failures are captured and cannot escape as unhandled secondary errors.
- Log the primary startup failure to the Julia Language Server output channel, only logging cleanup failures separately when they are not the known masking language-client error.
- Mark failed startup as `crashed`, matching the existing state used when the language client gives up.
- Treat `Client is not running and can't be stopped...` as a handled language-server/client lifecycle error even with its variable state suffix.

## Testing

- `npm run check-types` from `C:\Users\david\source\jlvsc-wt\c2-startfailed`
