### PR TITLE
Guard REPL teardown during evaluation

### DIFF
--- a/src/interactive/repl.ts
+++ b/src/interactive/repl.ts
@@ -539,6 +539,14 @@ interface RunCodeOptions {
 
 const requestTypeReplRunCode = new rpc.RequestType<RunCodeOptions, ReturnResult, void>('repl/runcode')
 
+function replUnavailableResult(): ReturnResult {
+    return {
+        inline: 'REPL unavailable',
+        all: 'The Julia REPL is no longer available.',
+        stackframe: [],
+    }
+}
+
 // interface DebugLaunchParams {
 //     code: string,
 //     filename: string
@@ -1086,8 +1094,9 @@ export async function evaluate(
             // interrupts killAndDrain the queue, but we still want to display the current item
             if (opts === g_currentEvalItem) {
                 result = await evalPromise
-            } else {
-                r.remove(true)
+            }
+            if (!result) {
+                r?.remove(true)
                 return false
             }
         }
@@ -1107,7 +1116,7 @@ export async function evaluate(
 
         return !isError
     } catch (err) {
-        r.remove(true)
+        r?.remove(true)
         throw err
     }
 }
@@ -1118,6 +1127,9 @@ async function executeCodeCopyPaste(text: string, individualLine: boolean) {
     }
 
     await startREPL(true, true)
+    if (!g_terminal) {
+        return
+    }
 
     let lines = text.split(/\r?\n/)
     lines = lines.filter((line) => line !== '')
@@ -1359,7 +1371,22 @@ function isMarkdownEditor(editor: vscode.TextEditor) {
 let g_currentEvalItem: RunCodeOptions
 async function sendEvalRequest(req: RunCodeOptions) {
     g_currentEvalItem = req
-    const r = await g_connection.sendRequest(requestTypeReplRunCode, req)
+    const connection = g_connection
+    if (!connection) {
+        g_evalQueue.killAndDrain()
+        return replUnavailableResult()
+    }
+
+    let r: ReturnResult
+    try {
+        r = await connection.sendRequest(requestTypeReplRunCode, req)
+    } catch (err) {
+        if (!g_connection) {
+            g_evalQueue.killAndDrain()
+            return replUnavailableResult()
+        }
+        throw err
+    }
 
     if (r.stackframe) {
         g_evalQueue.killAndDrain()


### PR DESCRIPTION
## Crash signature
- `g_connection` undefined in `sendEvalRequest` while fastq drains queued eval items (`sendRequest` dereference).
- `g_terminal` null in `executeCodeCopyPaste` after `startREPL` returns without creating or retaining a terminal.
- Inline `Result` decoration `r` null in `evaluate` catch cleanup, masking the original evaluation error.

## Root cause
All three paths assume REPL-related state is still present after asynchronous REPL startup, teardown, or queueing. The REPL can fail to start, be cancelled, or be disposed while evaluation/copy-paste work is in flight, leaving `g_connection`, `g_terminal`, or the local inline result unset.

## Fix
- Make inline-result cleanup null-safe with `r?.remove(true)` and preserve the original thrown error.
- Return cleanly from copy-paste execution when `startREPL` completes without an available terminal.
- Guard `sendEvalRequest` with a stable connection snapshot, drain queued work when the REPL connection is unavailable or torn down, and return a REPL-unavailable result instead of dereferencing undefined.

## Testing
- `npm run check-types`
