### PR TITLE
Handle missing Julia during env activation

### DIFF
--- a/src/jlpkgenv.ts
+++ b/src/jlpkgenv.ts
@@ -14,12 +14,32 @@ let g_current_environment: vscode.StatusBarItem = null
 let g_path_of_current_environment: string = null
 let g_path_of_default_environment: string = null
 let g_resolved_path_of_environment: string = null
+let g_default_environment_unknown_because_julia_not_found = false
 
 let g_ExecutableFeature: ExecutableFeature = null
 
 function getEnvironmentPathConfig() {
     const section = vscode.workspace.getConfiguration('julia')
     return parseVSCodeVariables(section.get('environmentPath') ?? '')
+}
+
+function getUnknownDefaultEnvPath() {
+    if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
+        return vscode.workspace.workspaceFolders[0].uri.fsPath
+    }
+
+    return os.homedir()
+}
+
+async function updateCurrentEnvironmentStatusText() {
+    if (
+        g_default_environment_unknown_because_julia_not_found &&
+        g_path_of_current_environment === g_path_of_default_environment
+    ) {
+        g_current_environment.text = 'Julia env: [Julia not found]'
+    } else {
+        g_current_environment.text = 'Julia env: ' + (await getEnvName())
+    }
 }
 
 export async function getProjectFilePaths(envpath: string) {
@@ -56,7 +76,7 @@ export async function switchEnvToPath(envpath: string) {
         section.update('environmentPath', undefined, vscode.ConfigurationTarget.Workspace)
     }
 
-    g_current_environment.text = 'Julia env: ' + (await getEnvName())
+    await updateCurrentEnvironmentStatusText()
 
     if (
         vscode.workspace.workspaceFolders !== undefined &&
@@ -239,7 +259,17 @@ async function getDefaultEnvPath() {
             }
         }
 
-        const juliaExecutable = await g_ExecutableFeature.getExecutable()
+        let juliaExecutable
+        try {
+            juliaExecutable = await g_ExecutableFeature.getExecutable()
+        } catch (err) {
+            if (err instanceof JuliaNotFoundError) {
+                g_path_of_default_environment = getUnknownDefaultEnvPath()
+                g_default_environment_unknown_because_julia_not_found = true
+                return g_path_of_default_environment
+            }
+            throw err
+        }
         const res = await execFile(
             juliaExecutable.command,
             [
@@ -257,6 +287,7 @@ async function getDefaultEnvPath() {
             }
         )
         g_path_of_default_environment = res.stdout.toString().trim()
+        g_default_environment_unknown_because_julia_not_found = false
     }
     return g_path_of_default_environment
 }


### PR DESCRIPTION
## Crash signature

Insider-channel Application Insights telemetry showed 136 events / ~25 users over 30 days in extension 1.231.1:

- `JuliaNotFoundError at XD.getExecutable` (90): `Julia not installed`
- `JuliaNotFoundError at XD.getJuliaupExecutableNoCache` (27): `juliaup not available`
- `JuliaNotFoundError at XD.getLsExecutable` (18): `Julia not installed`
- Older minified variants of the same family (1)

The representative stack was `jlpkgenv.activate` -> `getEnvPath` -> `getDefaultEnvPath` -> `ExecutableFeature.getExecutable()`.

## Root cause

`JuliaNotFoundError` documents missing Julia/juliaup or missing juliaup channels as expected user setup states that callers must catch before they reach crash reporting. `jlpkgenv.getDefaultEnvPath()` violated that contract by asking Julia for the default Pkg environment during extension activation and allowing `JuliaNotFoundError` to escape when Julia was not installed. Since `jlpkgenv.activate()` runs on activation, a normal no-Julia installation could become a telemetry crash instead of using the extension's existing "Julia: Not Installed" degradation path.

## Fix

`jlpkgenv.getDefaultEnvPath()` now catches `JuliaNotFoundError` at the source where missing Julia is expected, keeps activation alive with a workspace-folder/home fallback path, and records that the default environment is unknown because Julia was unavailable. The environment status item now shows `Julia env: [Julia not found]` for that fallback state, while `ExecutableFeature.getExecutable()` still sets the existing `Julia: Not Installed` status-bar item and writes the existing output-channel message. No global crash-report filtering was added.

Audit of executable lookup callers:

- Fixed: `jlpkgenv.getDefaultEnvPath()` (`activate` -> `getEnvPath` -> `getDefaultEnvPath` -> `getExecutable`) was the crash leak in activation.
- Covered by this fix: `debugger/debugFeature.ts` `language-julia.debug.getActiveJuliaEnvironment`, `juliaCommands.ts`, `languageClient.ts` environment path resolution, `notebook/notebookKernel.ts`, `interactive/repl.ts`, `tasks.ts`, and `weave.ts` call `jlpkgenv.getAbsEnvPath()` / `getResolvedEnvPathForLS()` and no longer receive `JuliaNotFoundError` from the default-env path.
- Already handled: `executables.ts` retrigger command, `languageClient.ts` `notifyServerEnvironmentPath` / LS startup, `juliaCommands.ts` command runner, `packagedevtools.ts`, `debugger/debugFeature.ts` debug adapter creation, `notebook/notebookFeature.ts`, `testing/testFeature.ts`, `interactive/repl.ts` REPL/version/link paths, and `weave.ts` already catch `JuliaNotFoundError` or intentionally return/skip.
- Not changed: `packagepath.ts` helpers are used behind callers that already catch (`openpackagedirectory.ts` catches and reports inability to read package directory; `jlpkgenv.changeJuliaEnvironment()` catches around depot discovery). `tasks.ts` task provider has an existing catch-all that returns no tasks. The public API methods in `extension.ts` are not registered commands/events and expose the lookup result to extension consumers rather than forwarding to crash reporting.

## Testing

- `npm run check-types`