### PR TITLE
Guard context commands against missing arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -834,7 +834,15 @@
                 },
                 {
                     "command": "language-julia.runAndDebugCell",
-                    "when": "notebookType == jupyter-notebook && isWorkspaceTrusted && notebookCellType == code && notebookKernel =~ /julialang/"
+                    "when": "false"
+                },
+                {
+                    "command": "language-julia.showInVSCode",
+                    "when": "false"
+                },
+                {
+                    "command": "language-julia.workspaceGoToFile",
+                    "when": "false"
                 },
                 {
                     "command": "language-julia.moveCellUp",

--- a/src/interactive/workspace.ts
+++ b/src/interactive/workspace.ts
@@ -391,10 +391,12 @@ export class WorkspaceFeature {
             onInit(wrapCrashReporting(({ connection: conn }) => this.openREPL(conn))),
             onExit(() => this.closeREPL()),
             // commands
-            registerCommand('language-julia.showInVSCode', async (node: VariableNode) => await this.showInVSCode(node)),
+            registerCommand('language-julia.showInVSCode', async (node: VariableNode | undefined) =>
+                await this.showInVSCode(node)
+            ),
             registerCommand(
                 'language-julia.workspaceGoToFile',
-                async (node: VariableNode) => await this.openLocation(node)
+                async (node: VariableNode | undefined) => await this.openLocation(node)
             ),
             registerCommand(
                 'language-julia.showModules',
@@ -417,11 +419,17 @@ export class WorkspaceFeature {
         this._REPLTreeDataProvider.refresh()
     }
 
-    async showInVSCode(node: VariableNode) {
+    async showInVSCode(node: VariableNode | undefined) {
+        if (!node) {
+            return
+        }
         await node.showInVSCode()
     }
 
-    async openLocation(node: VariableNode) {
+    async openLocation(node: VariableNode | undefined) {
+        if (!node) {
+            return
+        }
         openFile(node.workspaceVariable.location.file, node.workspaceVariable.location.line)
     }
 

--- a/src/interactive/workspace.ts
+++ b/src/interactive/workspace.ts
@@ -391,8 +391,9 @@ export class WorkspaceFeature {
             onInit(wrapCrashReporting(({ connection: conn }) => this.openREPL(conn))),
             onExit(() => this.closeREPL()),
             // commands
-            registerCommand('language-julia.showInVSCode', async (node: VariableNode | undefined) =>
-                await this.showInVSCode(node)
+            registerCommand(
+                'language-julia.showInVSCode',
+                async (node: VariableNode | undefined) => await this.showInVSCode(node)
             ),
             registerCommand(
                 'language-julia.workspaceGoToFile',

--- a/src/notebook/notebookFeature.ts
+++ b/src/notebook/notebookFeature.ts
@@ -86,6 +86,9 @@ export class JuliaNotebookFeature {
                 async (cell: vscode.NotebookCell | undefined) => {
                     if (cell) {
                         const kernel = this.kernels.get(cell.notebook)
+                        if (!kernel) {
+                            return
+                        }
                         if (!kernel.activeDebugSession) {
                             await kernel.toggleDebugging()
                             kernel.stopDebugSessionAfterExecution = true

--- a/src/testing/testFeature.ts
+++ b/src/testing/testFeature.ts
@@ -977,7 +977,11 @@ export class TestFeature implements TestControllerHost {
         this.workspaceFeature.setTestControllerHost(this)
 
         context.subscriptions.push(
-            registerCommand('language-julia.stopTestProcess', async (node: TestProcessNode) => await node.stop()),
+            registerCommand('language-julia.stopTestProcess', async (node: TestProcessNode | undefined) => {
+                if (node) {
+                    await node.stop()
+                }
+            }),
             registerCommand('language-julia.startTestController', async () => await this.startTestController()),
             registerCommand('language-julia.stopTestController', async () => await this.stopTestController()),
             registerCommand('language-julia.restartTestController', async () => await this.restartTestController()),


### PR DESCRIPTION
## Crash signature
- `language-julia.stopTestProcess`: `TypeError: Cannot read properties of undefined (reading 'stop')` when VS Code invokes the command without the test-process tree node argument.
- `language-julia.runAndDebugCell`: `TypeError: Cannot read properties of undefined (reading 'activeDebugSession')` when a cell is supplied but `this.kernels.get(cell.notebook)` has no Julia kernel to return.

## Root cause
Both commands are registered from context-specific UI, but command contributions can also make them invocable without the expected context. `stopTestProcess` was a missing-argument case. `runAndDebugCell` already guarded the optional cell argument, but not the optional kernel lookup result. In the same scan, I found `showInVSCode` and `workspaceGoToFile` had the identical tree-node-only/default-palette shape; other nearby node commands were already hidden from the Command Palette or delegate to existing undefined guards.

## Fix
- Add a no-op guard for the optional `TestProcessNode` before stopping a test process.
- Add a no-op guard for a missing Julia notebook kernel before accessing debug-session state.
- Use the declarative `contributes.menus.commandPalette` route for context-only commands: `stopTestProcess` was already hidden, `runAndDebugCell` is now hidden, and the same default-palette exposure was removed for `showInVSCode` and `workspaceGoToFile`.
- Add runtime no-op guards for `showInVSCode` and `workspaceGoToFile` as defense in depth.

## Testing
- `npm run check-types`