### PR TITLE
Ignore language client teardown errors

### DIFF
--- a/src/languageClient.ts
+++ b/src/languageClient.ts
@@ -15,17 +15,10 @@ import {
     State,
     StateChangeEvent,
 } from 'vscode-languageclient/node'
-import {
-    CancellationSenderStrategy,
-    CancellationStrategy,
-    ConnectionError,
-    ConnectionErrors,
-    ErrorCodes,
-    LSPErrorCodes,
-    ResponseError,
-} from 'vscode-languageserver-protocol'
+import { ResponseError } from 'vscode-languageserver-protocol'
 
 import * as jlpkgenv from './jlpkgenv'
+import { isLanguageServerError } from './languageServerErrors'
 import * as telemetry from './telemetry'
 import { ExecutableFeature, JuliaExecutable, JuliaNotFoundError } from './executables'
 import { getCustomEnvironmentVariables, onEvent, registerCommand } from './utils'
@@ -109,51 +102,6 @@ function handleFormattingError<T>(
     )
 }
 
-/**
- * Returns true if the error is a result of the language server connection
- * being unavailable (crashed, stopped, not ready). These errors should be
- * handled gracefully without sending extension crash telemetry, since the
- * LS crash itself is already reported separately.
- */
-export function isLanguageServerError(err: unknown): boolean {
-    if (err instanceof ResponseError) {
-        switch (err.code) {
-            case ErrorCodes.PendingResponseRejected:
-            case ErrorCodes.ConnectionInactive:
-            case LSPErrorCodes.RequestCancelled:
-            case LSPErrorCodes.ServerCancelled:
-            case LSPErrorCodes.ContentModified:
-                return true
-        }
-    }
-    if (err instanceof ConnectionError && err.code === ConnectionErrors.Disposed) {
-        return true
-    }
-    if (err instanceof Error) {
-        const errorCode = (err as Error & { code?: unknown }).code
-        if (errorCode === 'EPIPE' || errorCode === 'ERR_STREAM_DESTROYED') {
-            return true
-        }
-        if (
-            err.message === 'Connection is disposed' ||
-            err.message === 'Connection is disposed.' ||
-            err.message === 'Cannot call write after a stream was destroyed' ||
-            err.message === 'write EPIPE' ||
-            err.message === 'This socket has been ended by the other party'
-        ) {
-            return true
-        }
-        if (
-            err.message === 'Language client is not ready yet' ||
-            err.message === 'Client is not running' ||
-            err.message.startsWith("Client is not running and can't be stopped")
-        ) {
-            return true
-        }
-    }
-    return false
-}
-
 function formatErrorForOutput(err: unknown): string {
     if (err instanceof Error) {
         return err.stack ?? err.message
@@ -203,49 +151,6 @@ export class RestartTrackingErrorHandler implements ErrorHandler {
         this.restartPending = false
         return pending
     }
-}
-
-class JuliaLanguageClient extends LanguageClient {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    public override async sendRequest(type: any, ...params: any[]): Promise<any> {
-        try {
-            return await super.sendRequest(type, ...params)
-        } catch (err) {
-            if (isLanguageServerError(err)) {
-                return undefined
-            }
-            throw err
-        }
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    public override async sendNotification(type: any, params?: any): Promise<void> {
-        try {
-            await super.sendNotification(type, params)
-        } catch (err) {
-            if (!isLanguageServerError(err)) {
-                throw err
-            }
-        }
-    }
-}
-
-const languageServerCancellationStrategy: CancellationStrategy = {
-    receiver: CancellationStrategy.Message.receiver,
-    sender: {
-        async sendCancellation(conn, id) {
-            try {
-                await CancellationSenderStrategy.Message.sendCancellation(conn, id)
-            } catch (err) {
-                if (!isLanguageServerError(err)) {
-                    throw err
-                }
-            }
-        },
-        cleanup(id) {
-            CancellationSenderStrategy.Message.cleanup(id)
-        },
-    },
 }
 
 export class LanguageClientFeature {
@@ -554,11 +459,10 @@ export class LanguageClientFeature {
                         Promise.resolve(next(document, range, options, token))
                     ),
             },
-            connectionOptions: { cancellationStrategy: languageServerCancellationStrategy },
         }
 
         // Create the language client and start the client.
-        const languageClient = new JuliaLanguageClient('julia', 'Julia Language Server', serverOptions, clientOptions)
+        const languageClient = new LanguageClient('julia', 'Julia Language Server', serverOptions, clientOptions)
         languageClient.registerProposedFeatures()
 
         languageClient.onDidChangeState((event: StateChangeEvent) => {

--- a/src/languageClient.ts
+++ b/src/languageClient.ts
@@ -15,7 +15,15 @@ import {
     State,
     StateChangeEvent,
 } from 'vscode-languageclient/node'
-import { ErrorCodes, LSPErrorCodes, ResponseError } from 'vscode-languageserver-protocol'
+import {
+    CancellationSenderStrategy,
+    CancellationStrategy,
+    ConnectionError,
+    ConnectionErrors,
+    ErrorCodes,
+    LSPErrorCodes,
+    ResponseError,
+} from 'vscode-languageserver-protocol'
 
 import * as jlpkgenv from './jlpkgenv'
 import * as telemetry from './telemetry'
@@ -118,7 +126,23 @@ export function isLanguageServerError(err: unknown): boolean {
                 return true
         }
     }
+    if (err instanceof ConnectionError && err.code === ConnectionErrors.Disposed) {
+        return true
+    }
     if (err instanceof Error) {
+        const errorCode = (err as Error & { code?: unknown }).code
+        if (errorCode === 'EPIPE' || errorCode === 'ERR_STREAM_DESTROYED') {
+            return true
+        }
+        if (
+            err.message === 'Connection is disposed' ||
+            err.message === 'Connection is disposed.' ||
+            err.message === 'Cannot call write after a stream was destroyed' ||
+            err.message === 'write EPIPE' ||
+            err.message === 'This socket has been ended by the other party'
+        ) {
+            return true
+        }
         if (
             err.message === 'Language client is not ready yet' ||
             err.message === 'Client is not running' ||
@@ -179,6 +203,49 @@ export class RestartTrackingErrorHandler implements ErrorHandler {
         this.restartPending = false
         return pending
     }
+}
+
+class JuliaLanguageClient extends LanguageClient {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public override async sendRequest(type: any, ...params: any[]): Promise<any> {
+        try {
+            return await super.sendRequest(type, ...params)
+        } catch (err) {
+            if (isLanguageServerError(err)) {
+                return undefined
+            }
+            throw err
+        }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public override async sendNotification(type: any, params?: any): Promise<void> {
+        try {
+            await super.sendNotification(type, params)
+        } catch (err) {
+            if (!isLanguageServerError(err)) {
+                throw err
+            }
+        }
+    }
+}
+
+const languageServerCancellationStrategy: CancellationStrategy = {
+    receiver: CancellationStrategy.Message.receiver,
+    sender: {
+        async sendCancellation(conn, id) {
+            try {
+                await CancellationSenderStrategy.Message.sendCancellation(conn, id)
+            } catch (err) {
+                if (!isLanguageServerError(err)) {
+                    throw err
+                }
+            }
+        },
+        cleanup(id) {
+            CancellationSenderStrategy.Message.cleanup(id)
+        },
+    },
 }
 
 export class LanguageClientFeature {
@@ -487,10 +554,11 @@ export class LanguageClientFeature {
                         Promise.resolve(next(document, range, options, token))
                     ),
             },
+            connectionOptions: { cancellationStrategy: languageServerCancellationStrategy },
         }
 
         // Create the language client and start the client.
-        const languageClient = new LanguageClient('julia', 'Julia Language Server', serverOptions, clientOptions)
+        const languageClient = new JuliaLanguageClient('julia', 'Julia Language Server', serverOptions, clientOptions)
         languageClient.registerProposedFeatures()
 
         languageClient.onDidChangeState((event: StateChangeEvent) => {

--- a/src/languageClient.ts
+++ b/src/languageClient.ts
@@ -1,3 +1,4 @@
+import { ChildProcess } from 'child_process'
 import * as net from 'net'
 import * as os from 'os'
 import * as path from 'path'
@@ -10,6 +11,7 @@ import {
     LanguageClient,
     LanguageClientOptions,
     Message,
+    MessageTransports,
     RevealOutputChannelOn,
     ServerOptions,
     State,
@@ -153,6 +155,101 @@ export class RestartTrackingErrorHandler implements ErrorHandler {
     }
 }
 
+/**
+ * Decides whether a language server process exit is worth a crash report.
+ * Returns `null` for an expected exit, otherwise a one-line description.
+ *
+ * Code 1 is skipped on purpose: the Julia side's `global_err_handler`
+ * (`scripts/error_handler.jl`) writes its own crash report to the pipe and
+ * then calls `exit(1)`, so reporting that exit here would file every Julia
+ * crash twice. The same convention is used for the test item controller in
+ * `testFeature.ts`. What that path cannot cover is a death that never ran
+ * Julia code, or ran it outside the guarded block: a signal, a native crash,
+ * an out-of-memory kill, or the runtime's own exit codes. Those leave no
+ * trace anywhere else.
+ */
+export function unexpectedServerExit(
+    code: number | null,
+    signal: NodeJS.Signals | null,
+    intentionalStop: boolean
+): string | null {
+    if (intentionalStop) {
+        return null
+    }
+    if (signal === null && (code === 0 || code === 1)) {
+        return null
+    }
+    return `Julia language server process exited with code ${code ?? 'none'}, signal ${signal ?? 'none'}`
+}
+
+/**
+ * Keeps the last `limit` characters written to a stream, so that the tail
+ * of the language server's stderr can accompany an exit report.
+ */
+export class StderrTail {
+    private buffer = ''
+
+    constructor(private limit: number = 4096) {}
+
+    append(chunk: Buffer | string): void {
+        this.buffer += chunk.toString()
+        if (this.buffer.length > this.limit) {
+            this.buffer = this.buffer.slice(this.buffer.length - this.limit)
+        }
+    }
+
+    text(): string {
+        return this.buffer
+    }
+}
+
+/**
+ * Replaces the user's home directory with `~`, in the spirit of the path
+ * sanitising `error_handler.jl` applies to Julia stack traces.
+ */
+export function sanitizeHomeDir(text: string, homeDir: string = os.homedir()): string {
+    if (!homeDir) {
+        return text
+    }
+    const variants = new Set([homeDir, homeDir.replace(/\\/g, '/'), homeDir.replace(/\//g, '\\')])
+    let result = text
+    for (const variant of variants) {
+        const escaped = variant.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+        result = result.replace(new RegExp(escaped, process.platform === 'win32' ? 'gi' : 'g'), '~')
+    }
+    return result
+}
+
+/**
+ * A `LanguageClient` that hands the freshly spawned server process to a
+ * callback. `serverProcess` is set inside `createMessageTransports`, before
+ * the `initialize` request goes out, and is cleared again the moment the
+ * connection closes, so this is the one place to attach `exit` and stderr
+ * listeners that also see a death during startup. Everything else (the
+ * spawn itself, debug-mode selection, killing the process on stop) stays
+ * with the client.
+ */
+class ObservedLanguageClient extends LanguageClient {
+    constructor(
+        id: string,
+        name: string,
+        serverOptions: ServerOptions,
+        clientOptions: LanguageClientOptions,
+        private onServerProcess: (serverProcess: ChildProcess) => void
+    ) {
+        super(id, name, serverOptions, clientOptions)
+    }
+
+    protected override async createMessageTransports(encoding: string): Promise<MessageTransports> {
+        const transports = await super.createMessageTransports(encoding)
+        const serverProcess = this.serverProcess
+        if (serverProcess) {
+            this.onServerProcess(serverProcess)
+        }
+        return transports
+    }
+}
+
 export class LanguageClientFeature {
     private onDidSetLanguageClientEmitter = new vscode.EventEmitter<LanguageClient | null>()
     public onDidSetLanguageClient = this.onDidSetLanguageClientEmitter.event
@@ -287,6 +384,30 @@ export class LanguageClientFeature {
         } catch (err) {
             this.outputChannel.appendLine(`Could not notify the language server of the environment change: ${err}`)
         }
+    }
+
+    /**
+     * Reports a language server process that died without the Julia side
+     * having reported it, see `unexpectedServerExit`.
+     */
+    private observeServerProcess(serverProcess: ChildProcess, juliaExecutable: JuliaExecutable) {
+        const stderrTail = new StderrTail()
+        serverProcess.stderr?.on('data', (chunk) => stderrTail.append(chunk))
+        serverProcess.on('exit', (code, signal) => {
+            const reason = unexpectedServerExit(code, signal, this._intentionalStop)
+            if (reason === null) {
+                return
+            }
+            telemetry.traceEvent('lsprocessexit')
+            const message = [
+                reason,
+                `Julia: ${juliaExecutable.command} (${juliaExecutable.version})`,
+                '',
+                'Last stderr output:',
+                stderrTail.text(),
+            ].join('\n')
+            telemetry.handleNewCrashReport('LanguageServerProcessExit', sanitizeHomeDir(message), '', 'Language Server')
+        })
     }
 
     public async startServer(envPath?: string, autoInstall?: boolean) {
@@ -462,7 +583,13 @@ export class LanguageClientFeature {
         }
 
         // Create the language client and start the client.
-        const languageClient = new LanguageClient('julia', 'Julia Language Server', serverOptions, clientOptions)
+        const languageClient = new ObservedLanguageClient(
+            'julia',
+            'Julia Language Server',
+            serverOptions,
+            clientOptions,
+            (serverProcess) => this.observeServerProcess(serverProcess, juliaExecutable)
+        )
         languageClient.registerProposedFeatures()
 
         languageClient.onDidChangeState((event: StateChangeEvent) => {
@@ -486,6 +613,7 @@ export class LanguageClientFeature {
                     } else {
                         // The client has given up: the server entered a crash
                         // loop or shut down after repeated connection errors.
+                        telemetry.traceEvent('lscrashloop')
                         this.setState('crashed')
                         this.setLanguageClient()
                     }
@@ -540,6 +668,7 @@ export class LanguageClientFeature {
             this.statusBarItem.command = 'language-julia.showLanguageServerOutput'
             await languageClient.start()
         } catch (err) {
+            telemetry.traceEvent('lsstartfailed')
             this.outputChannel.appendLine('Could not start the Julia language server.')
             this.outputChannel.appendLine(formatErrorForOutput(err))
             if (startupCleanupError && !isLanguageServerError(startupCleanupError)) {

--- a/src/languageServerErrors.ts
+++ b/src/languageServerErrors.ts
@@ -1,0 +1,90 @@
+import {
+    ConnectionError,
+    ConnectionErrors,
+    ErrorCodes,
+    LSPErrorCodes,
+    ResponseError,
+} from 'vscode-languageserver-protocol'
+
+/**
+ * Node error codes raised when the language server's stdin pipe or socket
+ * goes away underneath a pending write.
+ */
+const teardownStreamCodes = new Set(['EPIPE', 'ECONNRESET', 'ERR_STREAM_DESTROYED', 'ERR_STREAM_WRITE_AFTER_END'])
+
+/**
+ * The exact messages of the errors this module classifies, for the cases
+ * where only the message survives.
+ *
+ * Errors that VS Code attributes to this extension (a rejected language
+ * feature provider, an unhandled rejection inside the bundled
+ * `vscode-jsonrpc`) reach `sendErrorData` as a freshly constructed plain
+ * `Error` carrying only `name`, `message` and `stack`: the prototype and the
+ * `code` property are stripped. Matching on the whole message, never a
+ * substring, keeps this from masking genuine server errors that merely
+ * mention a connection.
+ */
+const teardownMessages = new Set([
+    // vscode-jsonrpc `connection.dispose()` rejecting every pending request
+    'Pending response rejected since connection got disposed',
+    // vscode-jsonrpc `throwIfClosedOrDisposed()` on a send after close
+    'Connection is disposed.',
+    'Connection is closed.',
+    // vscode-languageclient `sendRequest`/`sendNotification` guard
+    'Client is not running',
+    // Node stream and socket failures, also wrapped as `MessageWriteError`
+    'Cannot call write after a stream was destroyed',
+    'write EPIPE',
+    'This socket has been ended by the other party',
+])
+
+/**
+ * Returns true if the error is a result of the language server connection
+ * being unavailable: the server crashed, stopped or restarted while a
+ * request, notification or cancellation was in flight, or the client was not
+ * running when a call was made.
+ *
+ * Such errors are expected teardown noise. The server crash itself is
+ * reported separately through the crash reporting pipe, so these must not
+ * become extension crash reports; `telemetry.handleNewCrashReportFromException`
+ * drops them, and `withLanguageClient` turns them into a graceful fallback.
+ *
+ * `vscode-languageclient`'s own `handleFailedRequest` already swallows the
+ * `ResponseError` codes below for its built-in providers, but it logs and
+ * rethrows everything else, notably a `ConnectionError` thrown between the
+ * connection being disposed and the client state changing, and a
+ * `MessageWriteError` wrapping a failed pipe write.
+ */
+export function isLanguageServerError(err: unknown): boolean {
+    if (err instanceof ResponseError) {
+        switch (err.code) {
+            case ErrorCodes.PendingResponseRejected:
+            case ErrorCodes.ConnectionInactive:
+            case ErrorCodes.MessageWriteError:
+            case LSPErrorCodes.RequestCancelled:
+            case LSPErrorCodes.ServerCancelled:
+            case LSPErrorCodes.ContentModified:
+                return true
+            default:
+                return false
+        }
+    }
+    if (err instanceof ConnectionError) {
+        return err.code === ConnectionErrors.Disposed || err.code === ConnectionErrors.Closed
+    }
+    if (err instanceof Error) {
+        const code = (err as Error & { code?: unknown }).code
+        if (typeof code === 'string' && teardownStreamCodes.has(code)) {
+            return true
+        }
+        if (teardownMessages.has(err.message)) {
+            return true
+        }
+        // vscode-languageclient `shutdown()` called in a state other than
+        // `Running`; the message ends with the current state.
+        if (err.message.startsWith("Client is not running and can't be stopped")) {
+            return true
+        }
+    }
+    return false
+}

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -4,6 +4,7 @@ import { parse } from 'semver'
 import { v4 as uuidv4 } from 'uuid'
 import * as vscode from 'vscode'
 import { generatePipeName, onEvent } from './utils'
+import { isLanguageServerError } from './languageServerErrors'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http'
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base'
@@ -201,6 +202,14 @@ export function handleNewCrashReport(name: string, message: string, stacktrace: 
 }
 
 export function handleNewCrashReportFromException(error: Error, cloudRole: string) {
+    // Every extension crash report passes through here: the command, event and
+    // callback wrappers in `utils.ts`, the hand-written catches, and the errors
+    // VS Code itself attributes to this extension via `sendErrorData` above.
+    // A language server going away mid-request is not an extension fault, and
+    // the crash, if any, arrives separately through the crash reporting pipe.
+    if (isLanguageServerError(error)) {
+        return
+    }
     crashReporterQueue.push({
         exception: error,
         tagOverrides: {

--- a/src/test/suite/languageClient.test.ts
+++ b/src/test/suite/languageClient.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert'
 import { CloseAction, ErrorAction, ErrorHandler } from 'vscode-languageclient/node'
-import { RestartTrackingErrorHandler, isLanguageServerError } from '../../languageClient'
+import { RestartTrackingErrorHandler } from '../../languageClient'
 
 function makeDelegate(closeActions: CloseAction[]): ErrorHandler {
     let i = 0
@@ -60,22 +60,5 @@ suite('RestartTrackingErrorHandler', () => {
         const result = await handler.error(new Error('boom'), undefined, 1)
         assert.strictEqual(result.action, ErrorAction.Continue)
         assert.strictEqual(handler.consumeRestartPending(), false)
-    })
-})
-
-suite('isLanguageServerError', () => {
-    test('handles languageclient cleanup errors with state suffixes', () => {
-        assert.strictEqual(
-            isLanguageServerError(
-                new Error("Client is not running and can't be stopped. It's current state is: startFailed")
-            ),
-            true
-        )
-        assert.strictEqual(
-            isLanguageServerError(
-                new Error("Client is not running and can't be stopped. It's current state is: starting")
-            ),
-            true
-        )
     })
 })

--- a/src/test/suite/languageClient.test.ts
+++ b/src/test/suite/languageClient.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert'
 import { CloseAction, ErrorAction, ErrorHandler } from 'vscode-languageclient/node'
-import { RestartTrackingErrorHandler } from '../../languageClient'
+import { RestartTrackingErrorHandler, StderrTail, sanitizeHomeDir, unexpectedServerExit } from '../../languageClient'
 
 function makeDelegate(closeActions: CloseAction[]): ErrorHandler {
     let i = 0
@@ -60,5 +60,58 @@ suite('RestartTrackingErrorHandler', () => {
         const result = await handler.error(new Error('boom'), undefined, 1)
         assert.strictEqual(result.action, ErrorAction.Continue)
         assert.strictEqual(handler.consumeRestartPending(), false)
+    })
+})
+
+suite('unexpectedServerExit', () => {
+    test('a clean exit is expected', () => {
+        assert.strictEqual(unexpectedServerExit(0, null, false), null)
+    })
+
+    test('exit code 1 is the Julia error handler, which reports on its own', () => {
+        assert.strictEqual(unexpectedServerExit(1, null, false), null)
+    })
+
+    test('nothing is reported for an intentional stop, however it ended', () => {
+        assert.strictEqual(unexpectedServerExit(null, 'SIGKILL', true), null)
+        assert.strictEqual(unexpectedServerExit(139, null, true), null)
+    })
+
+    test('a signal is reported', () => {
+        assert.match(unexpectedServerExit(null, 'SIGSEGV', false), /signal SIGSEGV/)
+    })
+
+    test('a runtime exit code is reported', () => {
+        assert.match(unexpectedServerExit(139, null, false), /code 139/)
+        assert.match(unexpectedServerExit(3221225477, null, false), /code 3221225477/)
+    })
+})
+
+suite('StderrTail', () => {
+    test('is empty by default', () => {
+        assert.strictEqual(new StderrTail().text(), '')
+    })
+
+    test('keeps only the last characters across appends', () => {
+        const tail = new StderrTail(8)
+        tail.append('abc')
+        tail.append(Buffer.from('defgh'))
+        assert.strictEqual(tail.text(), 'abcdefgh')
+        tail.append('ij')
+        assert.strictEqual(tail.text(), 'cdefghij')
+    })
+})
+
+suite('sanitizeHomeDir', () => {
+    test('replaces the home directory in either slash style', () => {
+        assert.strictEqual(
+            sanitizeHomeDir('at C:\\Users\\me\\x.jl and C:/Users/me/y.jl', 'C:\\Users\\me'),
+            'at ~\\x.jl and ~/y.jl'
+        )
+        assert.strictEqual(sanitizeHomeDir('at /home/me/x.jl', '/home/me'), 'at ~/x.jl')
+    })
+
+    test('leaves text alone without a home directory', () => {
+        assert.strictEqual(sanitizeHomeDir('at /home/me/x.jl', ''), 'at /home/me/x.jl')
     })
 })

--- a/src/test/suite/languageServerErrors.test.ts
+++ b/src/test/suite/languageServerErrors.test.ts
@@ -1,0 +1,93 @@
+import * as assert from 'assert'
+import {
+    ConnectionError,
+    ConnectionErrors,
+    ErrorCodes,
+    LSPErrorCodes,
+    ResponseError,
+} from 'vscode-languageserver-protocol'
+import { isLanguageServerError } from '../../languageServerErrors'
+
+function nodeError(message: string, code: string): Error {
+    return Object.assign(new Error(message), { code })
+}
+
+suite('isLanguageServerError', () => {
+    test('recognises the jsonrpc and LSP response codes for a lost or cancelled request', () => {
+        for (const code of [
+            ErrorCodes.PendingResponseRejected,
+            ErrorCodes.ConnectionInactive,
+            ErrorCodes.MessageWriteError,
+            LSPErrorCodes.RequestCancelled,
+            LSPErrorCodes.ServerCancelled,
+            LSPErrorCodes.ContentModified,
+        ]) {
+            assert.strictEqual(isLanguageServerError(new ResponseError(code, 'x')), true, `code ${code}`)
+        }
+    })
+
+    test('does not match other response codes', () => {
+        assert.strictEqual(isLanguageServerError(new ResponseError(ErrorCodes.InternalError, 'boom')), false)
+        assert.strictEqual(isLanguageServerError(new ResponseError(-33101, 'no module')), false)
+        // A response error is classified by its code alone; the message
+        // fallback below is only for errors that lost their code.
+        assert.strictEqual(
+            isLanguageServerError(new ResponseError(ErrorCodes.InternalError, 'Connection is disposed.')),
+            false
+        )
+    })
+
+    test('recognises a disposed or closed jsonrpc connection', () => {
+        assert.strictEqual(
+            isLanguageServerError(new ConnectionError(ConnectionErrors.Disposed, 'Connection is disposed.')),
+            true
+        )
+        assert.strictEqual(
+            isLanguageServerError(new ConnectionError(ConnectionErrors.Closed, 'Connection is closed.')),
+            true
+        )
+        assert.strictEqual(isLanguageServerError(new ConnectionError(ConnectionErrors.AlreadyListening, 'x')), false)
+    })
+
+    test('recognises Node stream and socket teardown errors by code', () => {
+        assert.strictEqual(isLanguageServerError(nodeError('write EPIPE', 'EPIPE')), true)
+        assert.strictEqual(
+            isLanguageServerError(nodeError('Cannot call write after a stream was destroyed', 'ERR_STREAM_DESTROYED')),
+            true
+        )
+        assert.strictEqual(isLanguageServerError(nodeError('read ECONNRESET', 'ECONNRESET')), true)
+        assert.strictEqual(isLanguageServerError(nodeError('no such file', 'ENOENT')), false)
+    })
+
+    test('recognises errors rebuilt by VS Code, which keep only the message', () => {
+        for (const message of [
+            'Pending response rejected since connection got disposed',
+            'Connection is disposed.',
+            'Connection is closed.',
+            'Client is not running',
+            "Client is not running and can't be stopped. It's current state is: starting",
+            "Client is not running and can't be stopped. It's current state is: startFailed",
+            'Cannot call write after a stream was destroyed',
+            'write EPIPE',
+            'This socket has been ended by the other party',
+        ]) {
+            assert.strictEqual(isLanguageServerError(new Error(message)), true, message)
+        }
+    })
+
+    test('matches messages exactly, never as a substring', () => {
+        assert.strictEqual(
+            isLanguageServerError(new Error('Pending response rejected since connection got disposed: more')),
+            false
+        )
+        assert.strictEqual(isLanguageServerError(new Error('Error: Connection is disposed.')), false)
+    })
+
+    test('does not match unrelated values', () => {
+        assert.strictEqual(isLanguageServerError(new Error('boom')), false)
+        assert.strictEqual(isLanguageServerError(new TypeError('x is not a function')), false)
+        assert.strictEqual(isLanguageServerError('Connection is disposed.'), false)
+        assert.strictEqual(isLanguageServerError(undefined), false)
+        assert.strictEqual(isLanguageServerError(null), false)
+    })
+})

--- a/src/testing/testFeature.ts
+++ b/src/testing/testFeature.ts
@@ -961,7 +961,7 @@ export class TestFeature implements TestControllerHost {
         private executableFeature: ExecutableFeature,
         private workspaceFeature: WorkspaceFeature,
         private compiledProvider: DebugConfigTreeProvider,
-        languageClientFeature: LanguageClientFeature
+        private languageClientFeature: LanguageClientFeature
     ) {
         // this.outputChannel = vscode.window.createOutputChannel('Julia Testserver')
         this.juliaTestitemControllerOutputChannel = vscode.window.createOutputChannel('Julia Test Item Controller')
@@ -1426,9 +1426,11 @@ export class TestFeature implements TestControllerHost {
         const testEnvPerFile = new Map<string, tlsp.GetTestEnvRequestParamsReturn>()
 
         for (const uri of uniqueFiles) {
-            const testEnv = await this.languageClient?.sendRequest(tlsp.requestTypJuliaGetTestEnv, {
-                uri: uri,
-            })
+            // `withLanguageClient` yields `undefined` when the server is not
+            // running, and when it goes away while the request is in flight.
+            const testEnv = await this.languageClientFeature.withLanguageClient((client) =>
+                client.sendRequest(tlsp.requestTypJuliaGetTestEnv, { uri: uri })
+            )
             testEnvPerFile.set(uri, testEnv)
         }
 
@@ -1436,9 +1438,9 @@ export class TestFeature implements TestControllerHost {
             return {
                 testItem: i,
                 details: this.testitems.get(i),
-                // `??  {}` because the lookup really can miss: `getTestEnv` is sent through
-                // `this.languageClient?`, which yields `undefined` whenever the client is null
-                // — the language server still starting, or restarting after a crash. Every
+                // `?? {}` because the lookup really can miss: `getTestEnv` is sent through
+                // `withLanguageClient`, which yields `undefined` whenever the language server
+                // is still starting, restarting after a crash, or lost mid-request. Every
                 // consumer already treats each field as optional.
                 testEnv: testEnvPerFile.get(i.uri.toString()) ?? {},
             }


### PR DESCRIPTION
## Crash signature

Insider telemetry showed in-flight Julia language-client traffic failing during teardown: `Pending response rejected since connection got disposed`, `Connection is disposed.`, `Cannot call write after a stream was destroyed`, `write EPIPE`, and `This socket has been ended by the other party`.

## Root cause

When the language server stops, crashes, or restarts, pending LSP requests, notifications, and queued jsonrpc writes race with the disposed connection. Those follow-on failures are expected cleanup noise and do not identify the underlying language-server crash, which is still reported separately through the crash reporting pipe.

Most of this noise does not come from calls the extension makes. VS Code's extension host attributes every rejected language-feature provider call and every unhandled rejection to the extension by stack-trace path and forwards it to the `sendErrorData` callback of our telemetry logger. That path carries:

- `ConnectionError('Connection is disposed.')`, which `vscode-languageclient`'s `handleFailedRequest` logs and rethrows because it is not a `ResponseError`;
- `ResponseError(MessageWriteError, <OS message>)` for a failed pipe write, which `handleFailedRequest` also rethrows;
- an **unhandled rejection with the raw Node `EPIPE`/`ERR_STREAM_DESTROYED` error** produced by `vscode-jsonrpc` itself on every failed request write (`connection.sendRequest` rethrows inside an `async` promise executor whose promise nobody holds). No `sendRequest` override in the extension can catch that one.

VS Code rebuilds these errors as plain `Error` objects before handing them to `sendErrorData`, keeping only `name`, `message` and `stack`, so `instanceof` and `code` checks do not work on that path.

## Fix

Classify once, at the crash-report sink, following the pattern VS Code core uses for its own unexpected-error handler (`isCancellationError`, `ErrorNoTelemetry`):

- `isLanguageServerError` moves to its own module, `src/languageServerErrors.ts`, so that `telemetry.ts` can import it without a cycle. It now also recognises `ConnectionError` Disposed/Closed, `ResponseError` `MessageWriteError`, Node stream and socket codes (`EPIPE`, `ECONNRESET`, `ERR_STREAM_DESTROYED`, `ERR_STREAM_WRITE_AFTER_END`), and, for the errors VS Code has stripped, the exact messages of the errors above. Response and connection errors are classified by code only; message matching is exact, never substring.
- `handleNewCrashReportFromException` drops errors that match. Every extension crash report passes through it: the command, event and callback wrappers in `utils.ts`, the hand-written catches, and the VS Code-forwarded errors.
- `withLanguageClient` is unchanged and still gives call sites a graceful fallback value.
- The one language-client request outside `withLanguageClient`, `getTestEnv` in the test runner, now goes through it, so a server restart mid test run degrades to "no test env" instead of rejecting the run.

The earlier revision of this PR subclassed `LanguageClient` and installed a custom `CancellationStrategy`. Both are dropped: the subclass cannot see the jsonrpc-internal unhandled rejection that dominates the signature, and `vscode-jsonrpc` already `.catch`es cancellation sends (`Sending cancellation messages for id … failed` is logged, never thrown). None of Microsoft's own language-client extensions (ESLint, C/C++, C#, Python) wrap the client this way; they log at fire-and-forget call sites and rely on `handleFailedRequest` and VS Code's error handling.

Genuine language-server crashes are not filtered: the language-client error handler, restart and crash-loop state handling, and the language-server crash-reporting pipe still run.

## Learning about deaths the Julia side cannot report

Dropping the teardown noise raised the question whether a language server that dies *without* running the Julia-side `global_err_handler` (a segfault, an out-of-memory kill, a failure before the `try` in `main.jl`) would still be noticed. It would not have been, with or without this PR: every "Language Server" crash report so far originated in Julia, the extension emitted nothing on an unexpected connection close, on a crash loop, or on a start failure, and the exit code only ever reached the output channel. The teardown errors were a poor proxy anyway: they fire only when a request happens to be in flight, they look the same for a crash and for a deliberate restart, and they carry no exit code or stderr.

So this PR adds a deliberate signal instead:

- A small `LanguageClient` subclass overrides `createMessageTransports` to hand the freshly spawned server process to the feature. That is the one point where the client has set `serverProcess` and the `initialize` request has not gone out yet, so deaths during startup are seen too. Spawning, debug-mode selection and killing the process on stop stay with the client. (Using the function form of `serverOptions` was considered and rejected: on that path the client never records `_serverProcess`, so it would stop killing the server on shutdown.)
- On `exit`, `unexpectedServerExit` decides whether to report. It skips intentional stops, exit code 0, and exit code 1. Code 1 is what `global_err_handler` exits with after writing its own report to the pipe, the same convention `testFeature.ts` already uses for the test item controller, so a Julia-reported crash is filed once. Everything else, a signal, a native crash code, an OOM kill, becomes a `LanguageServerProcessExit` crash report with cloud role "Language Server", carrying the exit code, signal, Julia command and version, and the last 4 KB of stderr with the home directory replaced by `~`.
- Two cheap counters: `lscrashloop` when the client gives up after repeated crashes, and `lsstartfailed` when `start()` rejects.

## Testing

- `npm run check-types`, ESLint and Prettier on the changed files
- `npm test`: new `src/test/suite/languageServerErrors.test.ts` covers every recognised code and message, exact-match behaviour, and negative cases; the two state-suffix cases previously in `languageClient.test.ts` moved there
- `npm test`: `languageClient.test.ts` gains suites for `unexpectedServerExit`, `StderrTail` and `sanitizeHomeDir`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
