### PR TITLE
Guard profiler trace navigation crashes

### DIFF
--- a/src/interactive/profiler.ts
+++ b/src/interactive/profiler.ts
@@ -98,12 +98,21 @@ export class ProfilerFeature {
     setInlineTrace(profile: Record<string, ProfilerFrame>) {
         this.clearInlineTrace()
 
+        let root = profile[this.selection]
+        if (!root) {
+            const fallbackSelection = Object.keys(profile)[0]
+            if (fallbackSelection === undefined) {
+                return
+            }
+            this.selection = fallbackSelection
+            root = profile[fallbackSelection]
+        }
+
         this.decoration = vscode.window.createTextEditorDecorationType({
             rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
             isWholeLine: true,
         })
 
-        const root = profile[this.selection]
         this.buildInlineTraceElements(root, root.count)
 
         this.refreshInlineTrace(vscode.window.visibleTextEditors)

--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -429,7 +429,7 @@ export async function openFile(
     column: vscode.ViewColumn | undefined = undefined,
     preserveFocus: boolean | undefined = undefined
 ) {
-    const newLine = line || 1
+    const newLine = Math.max(1, line || 1)
     const start = new vscode.Position(newLine - 1, 0)
     const end = new vscode.Position(newLine - 1, 0)
     const range = new vscode.Range(start, end)


### PR DESCRIPTION
## Crash signature

- `TypeError: Cannot read properties of undefined (reading 'count')` in `ProfilerFeature.setInlineTrace` when `profile[this.selection]` is missing.
- `Error: Illegal argument: line must be non-negative` in `openFile` when profiler data supplies a negative frame line.

## Root cause

- The profiler inline trace reused `this.selection` without verifying that the current profile contains that key. A stale selection or a profile with different thread/task keys made the selected root undefined.
- `openFile` treated `0` and `undefined` as line 1, but negative profiler line values for unknown or synthetic locations passed through and produced a negative VS Code `Position`.

## Fix

- Resolve the inline trace root before creating decorations. If the stored selection is absent, fall back to the first available profile key, update `this.selection`, and skip decoration only for an empty profile.
- Clamp the 1-based line value in `openFile` to at least 1 so all callers pass a valid non-negative VS Code position.

## Testing

- `npm run check-types`