### PR TITLE
Fix documentation webview cold-start crash

### DIFF
--- a/src/docbrowser/documentation.ts
+++ b/src/docbrowser/documentation.ts
@@ -78,6 +78,8 @@ export function activate(context: vscode.ExtensionContext, languageClientFeature
 
 class DocumentationViewProvider implements vscode.WebviewViewProvider {
     private view?: vscode.WebviewView
+    private resolvedViewPromise?: Promise<vscode.WebviewView>
+    private resolvedViewPromiseResolve?: (view: vscode.WebviewView) => void
 
     private backStack = Array<string>() // also keep current page
     private forwardStack = Array<string>()
@@ -89,13 +91,17 @@ class DocumentationViewProvider implements vscode.WebviewViewProvider {
 
     resolveWebviewView(view: vscode.WebviewView) {
         this.view = view
+        this.resolvedViewPromiseResolve?.(view)
+        this.resolvedViewPromise = undefined
+        this.resolvedViewPromiseResolve = undefined
 
         view.webview.options = {
             enableScripts: true,
             enableCommandUris: true,
         }
         view.webview.html = this.createWebviewHTML(
-            'Use the `language-julia.show-documentation` command in an editor or search for documentation above.'
+            'Use the `language-julia.show-documentation` command in an editor or search for documentation above.',
+            view.webview
         )
 
         onEvent(view.webview.onDidReceiveMessage, (msg) => {
@@ -111,12 +117,32 @@ class DocumentationViewProvider implements vscode.WebviewViewProvider {
         this.showDocumentationFromWord(params.searchTerm)
     }
 
-    async showDocumentationPane() {
+    async showDocumentationPane(): Promise<vscode.WebviewView> {
+        const resolvedViewPromise = this.getResolvedView()
+
         if (this.view?.show === undefined) {
             // this forces the webview to be resolved, but changes focus:
             await vscode.commands.executeCommand('julia-documentation.focus')
         }
-        this.view?.show(true)
+
+        const view = await resolvedViewPromise
+        view.show?.(true)
+
+        return view
+    }
+
+    private getResolvedView() {
+        if (this.view) {
+            return Promise.resolve(this.view)
+        }
+
+        if (!this.resolvedViewPromise) {
+            this.resolvedViewPromise = new Promise((resolve) => {
+                this.resolvedViewPromiseResolve = resolve
+            })
+        }
+
+        return this.resolvedViewPromise
     }
 
     async showDocumentationFromWord(word: string) {
@@ -125,8 +151,8 @@ class DocumentationViewProvider implements vscode.WebviewViewProvider {
             return
         }
 
-        await this.showDocumentationPane()
-        const html = this.createWebviewHTML(docAsMD)
+        const view = await this.showDocumentationPane()
+        const html = this.createWebviewHTML(docAsMD, view.webview)
         this.setHTML(html)
     }
 
@@ -155,8 +181,8 @@ class DocumentationViewProvider implements vscode.WebviewViewProvider {
         }
 
         this.forwardStack = [] // initialize forward page stack for manual search
-        await this.showDocumentationPane()
-        const html = this.createWebviewHTML(docAsMD)
+        const view = await this.showDocumentationPane()
+        const html = this.createWebviewHTML(docAsMD, view.webview)
         this.setHTML(html)
     }
 
@@ -175,31 +201,31 @@ class DocumentationViewProvider implements vscode.WebviewViewProvider {
         )
     }
 
-    createWebviewHTML(docAsMD: string) {
+    createWebviewHTML(docAsMD: string, webview: vscode.Webview) {
         const docAsHTML = md.render(docAsMD)
 
         const extensionPath = this.context.extensionPath
 
-        const googleFontscss = this.view.webview.asWebviewUri(
+        const googleFontscss = webview.asWebviewUri(
             vscode.Uri.file(path.join(extensionPath, 'libs', 'google_fonts', 'css'))
         )
-        const fontawesomecss = this.view.webview.asWebviewUri(
+        const fontawesomecss = webview.asWebviewUri(
             vscode.Uri.file(path.join(extensionPath, 'libs', 'fontawesome', 'fontawesome.min.css'))
         )
-        const solidcss = this.view.webview.asWebviewUri(
+        const solidcss = webview.asWebviewUri(
             vscode.Uri.file(path.join(extensionPath, 'libs', 'fontawesome', 'solid.min.css'))
         )
-        const brandscss = this.view.webview.asWebviewUri(
+        const brandscss = webview.asWebviewUri(
             vscode.Uri.file(path.join(extensionPath, 'libs', 'fontawesome', 'brands.min.css'))
         )
-        const documenterStylesheetcss = this.view.webview.asWebviewUri(
+        const documenterStylesheetcss = webview.asWebviewUri(
             vscode.Uri.file(path.join(extensionPath, 'libs', 'documenter', 'documenter-vscode.css'))
         )
-        const katexcss = this.view.webview.asWebviewUri(
+        const katexcss = webview.asWebviewUri(
             vscode.Uri.file(path.join(extensionPath, 'libs', 'katex', 'katex.min.css'))
         )
 
-        const webfontjs = this.view.webview.asWebviewUri(
+        const webfontjs = webview.asWebviewUri(
             vscode.Uri.file(path.join(extensionPath, 'libs', 'webfont', 'webfont.js'))
         )
 


### PR DESCRIPTION
## Crash signature

`TypeError: Cannot read properties of undefined (reading 'webview')` in `DocumentationViewProvider.createWebviewHTML`, reached from `showDocumentation` after invoking the documentation command from a cold documentation pane.

## Root cause

`this.view` is the `WebviewView` supplied by VS Code, and it is assigned only when VS Code calls `resolveWebviewView`. `showDocumentationPane()` reveals the `julia-documentation` view by awaiting `vscode.commands.executeCommand('julia-documentation.focus')`, but that command can return before the provider's `resolveWebviewView` callback has run. In that window, `showDocumentation()` and `showDocumentationFromWord()` continued into `createWebviewHTML()`, which converted local asset paths with `this.view.webview.asWebviewUri(...)` and crashed because `this.view` was still undefined. The user-visible result was the first cold "Open documentation" invocation doing nothing.

## Fix

Implemented the preferred approach: `showDocumentationPane()` now waits for a deferred `WebviewView` promise that is resolved from `resolveWebviewView`. Callers receive the resolved view and pass its `webview` into `createWebviewHTML()`, so HTML asset URI generation cannot run until the view exists. The initial `resolveWebviewView` rendering also passes its own `view.webview`, and the remaining `this.view` dereference in `setHTML()` stays guarded.

## Testing

- `npm run check-types`
