### PR TITLE
Handle stale Julia file opens

### DIFF
--- a/src/docbrowser/documentation.ts
+++ b/src/docbrowser/documentation.ts
@@ -51,7 +51,10 @@ md.renderer.rules.link_open = (tokens, idx, options, _env, self) => {
         const { uri, line } = openArgs(href)
         let commandUri
         if (line === undefined) {
-            commandUri = constructCommandString('vscode.open', uri)
+            commandUri =
+                uri instanceof vscode.Uri && uri.scheme === 'file'
+                    ? constructCommandString('language-julia.openFile', { path: uri.fsPath })
+                    : constructCommandString('vscode.open', uri)
         } else {
             commandUri = constructCommandString('language-julia.openFile', { path: uri, line })
         }

--- a/src/interactive/results.ts
+++ b/src/interactive/results.ts
@@ -434,19 +434,23 @@ export async function openFile(
     const end = new vscode.Position(newLine - 1, 0)
     const range = new vscode.Range(start, end)
 
-    let uri: vscode.Uri
     if (path.indexOf('Untitled') === 0) {
-        // can't open an untitled file like this:
-        // uri = vscode.Uri.parse('untitled:' + path)
-    } else {
-        uri = vscode.Uri.file(path)
+        vscode.window.showWarningMessage(`Cannot open ${path}: the file no longer exists.`)
+        return undefined
     }
-    return vscode.window.showTextDocument(uri, {
-        preserveFocus: preserveFocus,
-        preview: true,
-        selection: range,
-        viewColumn: column,
-    })
+
+    const uri = vscode.Uri.file(path)
+    try {
+        return await vscode.window.showTextDocument(uri, {
+            preserveFocus: preserveFocus,
+            preview: true,
+            selection: range,
+            viewColumn: column,
+        })
+    } catch {
+        vscode.window.showWarningMessage(`Cannot open ${path}: the file no longer exists.`)
+        return undefined
+    }
 }
 
 function gotoFirstFrame() {


### PR DESCRIPTION
## Crash signature

Insider telemetry showed 20 events / 1 user on extension 1.231.1:

```text
CodeExpectedError: cannot open file:///... Detail: Unable to read file '...'
    (Error: Unable to resolve nonexistent file '...')
  #0 sFe.$tryOpenDocument @ vscode-file://vscode-app/.../workbench/api/node/extensionHostProcess.js:1101
```

## Root cause

The exposed paths are Julia-side navigation data rather than live VS Code resources. I found these call sites flowing through `src/interactive/results.ts`'s `openFile` helper: stack-frame navigation (`gotoFrame` and `language-julia.openFile` command), profiler webview node clicks, workspace variable locations, REPL `OpenFile` notifications, and terminal links. Documentation links with line numbers already route through the helper, while `file:` documentation links without a line used `vscode.open` directly. If any of those stale paths were deleted, moved, or absent locally, VS Code rejected the open request and the unhandled rejection could be reported as a crash.

## Fix

Catch `showTextDocument` failures in the shared `openFile` helper and show a warning naming the path instead of letting the rejection propagate. Also route no-line `file:` documentation links through `language-julia.openFile` so local documentation file links get the same handling. I left unrelated opens alone: created/untitled documents, package folder opens, and external FAQ/http links are not stale Julia-side file navigation paths.

## Testing

- `npm run check-types`