### PR TITLE
Classify LS precompile failures

### DIFF
--- a/scripts/languageserver/main.jl
+++ b/scripts/languageserver/main.jl
@@ -113,6 +113,19 @@ function Base.showerror(io::IO, ex::LSPrecompileFailure)
     print(io, ex.msg)
 end
 
+function is_language_server_precompile_failure(err)
+    if err isa ErrorException
+        return startswith(err.msg, "Failed to precompile") ||
+            occursin("failed to precompile", lowercase(err.msg))
+    elseif err isa LoadError
+        return is_language_server_precompile_failure(err.error)
+    elseif occursin("PkgPrecompileError", string(typeof(err)))
+        return true
+    else
+        return occursin("failed to precompile", lowercase(sprint(showerror, err)))
+    end
+end
+
 try
     if length(Base.ARGS) != 7
         error("Invalid number of arguments passed to julia language server.")
@@ -157,13 +170,13 @@ try
     try
         using LanguageServer
     catch err
-        if err isa ErrorException && startswith(err.msg, "Failed to precompile")
+        if is_language_server_precompile_failure(err)
             println(stderr, """\n
             The Language Server failed to precompile.
             Please make sure you have permissions to write to the LS depot path at
             \t$(ENV["JULIA_DEPOT_PATH"])
             """)
-            throw(LSPrecompileFailure(err.msg))
+            throw(LSPrecompileFailure(sprint(showerror, err)))
         else
             rethrow(err)
         end

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -180,6 +180,7 @@ export function handleNewCrashReport(name: string, message: string, stacktrace: 
                     )
                 }
             })
+        return
     }
     crashReporterQueue.push({
         exception: {


### PR DESCRIPTION
## Crash signature

Insider telemetry showed the largest Language Server crash group in the last 30 days as startup precompilation failures reported with `cloud_RoleName == "Language Server"`: raw `LoadError` from `_precompilepkgs(...)`, `Base.Precompilation.PkgPrecompileError`, and a second `PkgPrecompileError` variant. One major signature shows bundled `JuliaWorkspaces` failing to precompile on Julia 1.13.0-rc3; that compatibility issue should be followed up separately.

## Root cause

The crash pipe already has a dedicated `LSPrecompileFailure` UI path, but `scripts/languageserver/main.jl` only classified the older `ErrorException` shape whose message starts with `Failed to precompile`. Current Julia/Pkg failures can arrive while loading `LanguageServer` as `LoadError` wrapping a precompile failure or as `Base.Precompilation.PkgPrecompileError`, so they were rethrown to the outer crash handler under their raw exception type. The WDAC/Application Control case is an environment policy blocking the precompile cache DLL, not an extension fault.

## Fix

Classify precompilation failures at the `using LanguageServer` boundary, where the startup load context is known. The classifier now recognizes wrapped `LoadError`s, `PkgPrecompileError`, and explicit `failed to precompile` messages, then wraps them as `LSPrecompileFailure`. `handleNewCrashReport` now treats that narrow classification as handled after showing the existing FAQ/logs notification instead of enqueueing an Application Insights crash report.

No companion submodule change is needed for this classification fix. A separate `JuliaWorkspaces`/LanguageServer compatibility fix may be needed for Julia 1.13.0-rc3 support.

## Testing

- Parsed `scripts\languageserver\main.jl` with Julia (`Meta.parseall`)
- `npm run check-types`